### PR TITLE
Persist instances between variable iterations for a given execution method

### DIFF
--- a/source/AsAConsoleApp/DemoPerfTest.cs
+++ b/source/AsAConsoleApp/DemoPerfTest.cs
@@ -63,13 +63,14 @@ namespace AsAConsoleApp
         [ExecutePerformanceCheck]
         public async Task WaitPeriodPerfTest()
         {
+            await Task.Delay(WaitPeriod);
             await Client.GetStringAsync("/");
         }
 
         [ExecutePerformanceCheck]
         public async Task Other()
         {
-            Thread.Sleep(1);
+            Thread.Sleep(200);
             await Task.CompletedTask;
             Console.WriteLine("WOW");
         }

--- a/source/Sailfish/Execution/ISailTestExecutor.cs
+++ b/source/Sailfish/Execution/ISailTestExecutor.cs
@@ -10,7 +10,7 @@ namespace Sailfish.Execution
     {
         Task<Dictionary<Type, List<TestExecutionResult>>> Execute(Type[] testTypes, Action<TestInstanceContainer, TestExecutionResult>? callback = null);
         Task<List<TestExecutionResult>> Execute(Type test, Action<TestInstanceContainer, TestExecutionResult>? callback = null);
-        Task<List<TestExecutionResult>> Execute(List<TestInstanceContainerProvider> testInstanceContainer, Action<TestInstanceContainer, TestExecutionResult>? callback = null);
+        Task<List<TestExecutionResult>> Execute(List<TestInstanceContainerProvider> testMethods, Action<TestInstanceContainer, TestExecutionResult>? callback = null);
         Task<TestExecutionResult> Execute(TestInstanceContainer testInstanceContainer, Action<TestInstanceContainer, TestExecutionResult>? callback = null);
     }
 }

--- a/source/Sailfish/Execution/ITestInstanceContainerCreator.cs
+++ b/source/Sailfish/Execution/ITestInstanceContainerCreator.cs
@@ -5,7 +5,6 @@ namespace Sailfish.Execution
 {
     public interface ITestInstanceContainerCreator
     {
-        // List<TestInstanceContainer> CreateTestContainerInstances(Type test);
-        List<TestInstanceContainerProvider> CreateTestContainerInstanceProvider(Type test);
+        List<TestInstanceContainerProvider> CreateTestContainerInstanceProviders(Type test);
     }
 }

--- a/source/Sailfish/Execution/TestInstanceContainerCreator.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerCreator.cs
@@ -19,9 +19,9 @@ public class TestInstanceContainerCreator : ITestInstanceContainerCreator
         this.parameterGridCreator = parameterGridCreator;
     }
 
-    public List<TestInstanceContainerProvider> CreateTestContainerInstanceProvider(Type test)
+    public List<TestInstanceContainerProvider> CreateTestContainerInstanceProviders(Type test)
     {
-        var (propNames, combos) = parameterGridCreator.GenerateParameterGrid(test);
+        var (propNames, variableSets) = parameterGridCreator.GenerateParameterGrid(test);
         var methods = test
             .GetMethodsWithAttribute<ExecutePerformanceCheckAttribute>()
             .OrderBy(x => x.Name);
@@ -29,16 +29,13 @@ public class TestInstanceContainerCreator : ITestInstanceContainerCreator
         var instanceContainers = new List<TestInstanceContainerProvider>();
         foreach (var method in methods)
         {
-            foreach (var combo in combos)
-            {
-                var provider = new TestInstanceContainerProvider(
-                    typeResolver,
-                    test,
-                    combo,
-                    propNames,
-                    method);
-                instanceContainers.Add(provider);
-            }
+            var provider = new TestInstanceContainerProvider(
+                typeResolver,
+                test,
+                variableSets,
+                propNames,
+                method);
+            instanceContainers.Add(provider);
         }
 
         return instanceContainers;

--- a/source/Tests.Sailfish/ApiCommunicationTests/Base/ApiTestBase.cs
+++ b/source/Tests.Sailfish/ApiCommunicationTests/Base/ApiTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Test.API;
@@ -7,7 +8,7 @@ using Xunit;
 
 namespace Test.ApiCommunicationTests.Base
 {
-    public class ApiTestBase : IClassFixture<WebApplicationFactory<DemoApp>>
+    public class ApiTestBase : IClassFixture<WebApplicationFactory<DemoApp>>, IAsyncDisposable
     {
         public ApiTestBase(WebApplicationFactory<DemoApp> factory)
         {
@@ -18,5 +19,9 @@ namespace Test.ApiCommunicationTests.Base
 
         public WebApplicationFactory<DemoApp> WebHostFactory { get; set; }
         public HttpClient Client { get; }
+        public async ValueTask DisposeAsync()
+        {
+            await WebHostFactory.DisposeAsync();
+        }
     }
 }


### PR DESCRIPTION
Currently, we destory test instances each time we iterate over variables for a method. This is a dangerous implementation for users that perform method level setup since we call the method teardown methods on the instance before the next method variable set iteration. 

Technically, this is more of a bug.

This PR refactors the executor to use a test instance provider, which will persist the instance and simply reassign the variable properties to the same instance.