### PR TITLE
Fix various issues (TargetFramework, test grouping, logging)

### DIFF
--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D 
-$version="0.0.272"  
+$version="0.0.275"  
 
 dotnet publish -c Release /p:Version=$version ./source/Sailfish.TestAdapter 
 

--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D 
-$version="0.0.275"  
+$version="0.0.276"  
 
 dotnet publish -c Release /p:Version=$version ./source/Sailfish.TestAdapter 
 

--- a/source/Demo.API/Controllers/Base/BaseController.cs
+++ b/source/Demo.API/Controllers/Base/BaseController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 
-namespace Test.API.Controllers.Base;
+namespace Demo.API.Controllers.Base;
 
 [Route("/")]
 [ApiController]

--- a/source/Demo.API/Controllers/CountToTenMillionController.cs
+++ b/source/Demo.API/Controllers/CountToTenMillionController.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Test.API.Controllers.Base;
+﻿using Demo.API.Controllers.Base;
+using Microsoft.AspNetCore.Mvc;
 
-namespace Test.API.Controllers;
+namespace Demo.API.Controllers;
 
 public class CountToTenMillionController : BaseController
 {

--- a/source/Demo.API/Controllers/TestController.cs
+++ b/source/Demo.API/Controllers/TestController.cs
@@ -1,7 +1,7 @@
+using Demo.API.Controllers.Base;
 using Microsoft.AspNetCore.Mvc;
-using Test.API.Controllers.Base;
 
-namespace Test.API.Controllers;
+namespace Demo.API.Controllers;
 
 public class TestController : BaseController
 {

--- a/source/Demo.API/Demo.API.csproj
+++ b/source/Demo.API/Demo.API.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <RootNamespace>Test.API</RootNamespace>
-
+        <RootNamespace>Demo.API</RootNamespace>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <InternalsVisibleTo Include="Test" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Demo.API/DemoApp.cs
+++ b/source/Demo.API/DemoApp.cs
@@ -1,4 +1,4 @@
-﻿namespace Test.API;
+﻿namespace Demo.API;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 public class DemoApp

--- a/source/PerformanceTestingConsoleApp/PerformanceTestingConsoleApp.csproj
+++ b/source/PerformanceTestingConsoleApp/PerformanceTestingConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/source/PerformanceTests/DemoUtils/SailfishDependencies.cs
+++ b/source/PerformanceTests/DemoUtils/SailfishDependencies.cs
@@ -1,8 +1,8 @@
 using System;
 using Autofac;
+using Demo.API;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Sailfish.AdapterUtils;
-using Test.API;
 
 namespace PerformanceTests.DemoUtils;
 

--- a/source/PerformanceTests/ExamplePerformanceTests/ExamplePerformanceTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ExamplePerformanceTest.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Demo.API;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Sailfish.Attributes;
-using Test.API;
 
 // Tests here are automatically discovered and executed
 namespace PerformanceTests.ExamplePerformanceTests;

--- a/source/PerformanceTests/ExamplePerformanceTests/TestBase.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/TestBase.cs
@@ -1,11 +1,11 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Demo.API;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using PerformanceTests.DemoUtils;
 using Sailfish.AdapterUtils;
-using Test.API;
 
 namespace PerformanceTests.ExamplePerformanceTests;
 

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.4.1" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.1.122" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.275" />
         <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,6 +13,7 @@
         <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.4.1" />
         <PackageReference Include="Sailfish.TestAdapter" Version="0.0.275" />
         <PackageReference Include="Serilog" Version="2.12.0" />
+
     </ItemGroup>
 
     <ItemGroup>

--- a/source/PerformanceTests/RegistrationProvider.cs
+++ b/source/PerformanceTests/RegistrationProvider.cs
@@ -1,11 +1,8 @@
-using System;
 using Autofac;
-using MediatR;
+using Demo.API;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Sailfish.Contracts.Public.Commands;
 using Sailfish.Registration;
 using Serilog;
-using Test.API;
 
 namespace PerformanceTests;
 
@@ -13,10 +10,6 @@ public class RegistrationProvider : IProvideARegistrationCallback
 {
     public void Register(ContainerBuilder builder)
     {
-        // These registrations will be used by Sailfish's internal DI container which
-        // is necessary to resolve dependencies used by test classes.
-        // Additionally, there are various MediatR handlers that can be overriden
-        // using these additional registrations.
         builder.RegisterType<WebApplicationFactory<DemoApp>>();
         builder.RegisterInstance(Log.Logger).As<ILogger>();
     }

--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -108,6 +108,7 @@ internal static class TestCaseItemCreator
         }
 
         if (!shouldAddCategories) return testCase;
+        // TODO: Send these traits over to the properties
         // Traits is not the right way to pass this information, but the Properties property keeps getting cleared on the test case when
         // is passed to the executor -- I'm setting that property incorrectly probably
         testCase.Traits.Add(new Trait(TestTypeFullName, testType.FullName));

--- a/source/Sailfish.TestAdapter/Execution/TestExecution.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestExecution.cs
@@ -16,8 +16,7 @@ namespace Sailfish.TestAdapter.Execution;
 
 internal static class TestExecution
 {
-    private static readonly ExecutionSummaryCompiler SummaryCompiler = new(
-        new StatisticsCompiler());
+    private static readonly ExecutionSummaryCompiler SummaryCompiler = new(new StatisticsCompiler());
 
     private static readonly Func<ITestExecutionRecorder?, ConsoleWriter> ConsoleWriter = handle =>
         new(

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -9,9 +9,10 @@
             tests that assess the speed of your code, without weighing you down with all the extra ceremony.
         </Description>
         <RootNamespace>Sailfish.TestAdapter</RootNamespace>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.4.1" />

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -25,7 +25,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
     {
         var currentVariableSetIndex = 0;
         var totalNumVariableSets = testProvider.GetNumberOfPropertySetsInTheQueue() - 1;
- 
+
         var instanceContainerEnumerator = testProvider.ProvideNextTestInstanceContainer().GetEnumerator();
 
         try
@@ -55,12 +55,9 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
 
             var executionResult = await IterateOverVariableCombos(testMethodContainer, cancellationToken);
 
-            callback?.Invoke(executionResult);
-            results.Add(executionResult);
-
             await testMethodContainer.Invocation.MethodTearDown(cancellationToken);
 
-            if (ShouldCallGlobalTeardown(testProviderIndex, totalTestProviderCount, currentVariableSetIndex, totalNumVariableSets))
+            if (ShouldCallGlobalTeardown(testProviderIndex, totalTestProviderCount - 1, currentVariableSetIndex, totalNumVariableSets))
             {
                 await testMethodContainer.Invocation.GlobalTeardown(cancellationToken);
             }
@@ -81,6 +78,9 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
                 await DisposeOfTestInstance(instanceContainerEnumerator.Current);
                 throw;
             }
+
+            callback?.Invoke(executionResult);
+            results.Add(executionResult);
         } while (continueIterating);
 
         instanceContainerEnumerator.Dispose();

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 

--- a/source/Sailfish/Program/SailfishProgramBase.cs
+++ b/source/Sailfish/Program/SailfishProgramBase.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Accord.Collections;

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -8,7 +8,7 @@
             against your component or API. The general intention is to provide a simple tool that teams can use to write straight forward
             tests that assess the speed of your code, without weighing you down with all the extra ceremony.
         </Description>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net5;net6.0;net7.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
@@ -22,16 +22,16 @@
         <RepositoryUrl>https://github.com/paulegradie/Sailfish</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Accord.Statistics" Version="3.8.0" />
-        <PackageReference Include="Autofac" Version="6.5.0" />
-        <PackageReference Include="CsvHelper" Version="30.0.1" />
-        <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="All" />
-        <PackageReference Include="MediatR" Version="11.1.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Serilog" Version="2.12.0" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-        <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
+        <PackageReference Include="Accord.Statistics" Version="3.8.0"/>
+        <PackageReference Include="Autofac" Version="6.5.0"/>
+        <PackageReference Include="CsvHelper" Version="30.0.1"/>
+        <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="All"/>
+        <PackageReference Include="MediatR" Version="11.1.0"/>
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Serilog" Version="2.12.0"/>
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2"/>
+        <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageReference Include="System.Runtime.Caching" Version="5.0.0"/>
     </ItemGroup>
 </Project>

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -8,7 +8,7 @@
             against your component or API. The general intention is to provide a simple tool that teams can use to write straight forward
             tests that assess the speed of your code, without weighing you down with all the extra ceremony.
         </Description>
-        <TargetFrameworks>net5;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
@@ -22,16 +22,16 @@
         <RepositoryUrl>https://github.com/paulegradie/Sailfish</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Accord.Statistics" Version="3.8.0"/>
-        <PackageReference Include="Autofac" Version="6.5.0"/>
-        <PackageReference Include="CsvHelper" Version="30.0.1"/>
-        <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="All"/>
-        <PackageReference Include="MediatR" Version="11.1.0"/>
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Serilog" Version="2.12.0"/>
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2"/>
-        <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
-        <PackageReference Include="System.Runtime.Caching" Version="5.0.0"/>
+        <PackageReference Include="Accord.Statistics" Version="3.8.0" />
+        <PackageReference Include="Autofac" Version="6.5.0" />
+        <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="All" />
+        <PackageReference Include="MediatR" Version="11.1.0" />
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Serilog" Version="2.12.0" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+        <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
     </ItemGroup>
 </Project>

--- a/source/Sailfish/SailfishRunner.cs
+++ b/source/Sailfish/SailfishRunner.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Sailfish.Execution;
-using Sailfish.Registration;
 
 namespace Sailfish;
 

--- a/source/Tests.Sailfish.TestAdapter/WhenDiscoveringTests.cs
+++ b/source/Tests.Sailfish.TestAdapter/WhenDiscoveringTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Sailfish.TestAdapter;
 using Sailfish.TestAdapter.Discovery;
 using Shouldly;
 using Tests.Sailfish.TestAdapter.Utils;

--- a/source/Tests.Sailfish/ApiCommunicationTests/Base/ApiTestBase.cs
+++ b/source/Tests.Sailfish/ApiCommunicationTests/Base/ApiTestBase.cs
@@ -2,9 +2,9 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Demo.API;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Test.API;
 using Xunit;
 
 namespace Test.ApiCommunicationTests.Base;

--- a/source/Tests.Sailfish/ApiCommunicationTests/WhenTalkingToTheApi.cs
+++ b/source/Tests.Sailfish/ApiCommunicationTests/WhenTalkingToTheApi.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
+using Demo.API;
+using Demo.API.Controllers;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Shouldly;
-using Test.API;
-using Test.API.Controllers;
 using Test.ApiCommunicationTests.Base;
 using Xunit;
 

--- a/source/Tests.Sailfish/Tests.Sailfish.csproj
+++ b/source/Tests.Sailfish/Tests.Sailfish.csproj
@@ -1,23 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <RootNamespace>Test</RootNamespace>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />
-        <PackageReference Include="Shouldly" Version="4.0.3" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
This fixes:

 - a testcase grouping bug where different classes that had the same sailfish method name would cause an error
 - Sailfnow targts .net6 and .net7
 - general cleanup