### PR TITLE
Refactor the test adapter executor

### DIFF
--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.290"
+$version="0.0.293"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,7 +1,14 @@
-# manually increment this until you figure out how to autoincrement :D 
-$version="0.0.280"  
+# manually increment this until you figure out how to autoincrement :D
+$version="0.0.290"
+$path = "../SailfishLocalPackages"
+If(!(test-path -PathType container $path))
+{
+    New-Item -ItemType Directory -Path $path
+}
 
-dotnet publish -c Release /p:Version=$version ./source/Sailfish.TestAdapter 
 
-Move-Item -Force ./source/Sailfish.TestAdapter/bin/Release/Sailfish.TestAdapter.$version.nupkg ../SailfishLocalPackages
+dotnet build -c Release /p:Version=$version ./source/Sailfish.TestAdapter
+
+
+Move-Item -Force ./source/Sailfish.TestAdapter/bin/Release/Sailfish.TestAdapter.$version.nupkg ../SailfishLocalPackages/Sailfish.TestAdapter.$version.nupkg
 

--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.293"
+$version="0.0.299"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/PerformanceTests/ExamplePerformanceTests/ExamplePerformanceTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ExamplePerformanceTest.cs
@@ -26,12 +26,14 @@ public class ExamplePerformanceTest : TestBase
     [SailfishGlobalSetup]
     public void GlobalSetup(CancellationToken cancellationToken)
     {
+        ;
         // logger.Information("This is the Global Setup");
     }
 
     [SailfishMethodSetup]
     public void ExecutionMethodSetup(CancellationToken cancellationToken)
     {
+        ;
         // logger.Information("This is the Execution Method Setup");
     }
 
@@ -58,12 +60,14 @@ public class ExamplePerformanceTest : TestBase
     [SailfishIterationTeardown]
     public void IterationTeardown(CancellationToken cancellationToken)
     {
+        
         // logger.Warning("This is the Iteration Teardown - use sparingly");
     }
 
     [SailfishMethodTeardown]
     public void ExecutionMethodTeardown(CancellationToken cancellationToken)
     {
+        ;
         // logger.Verbose("This is the Execution Method Teardown");
     }
 

--- a/source/PerformanceTests/ExamplePerformanceTests/ExamplePerformanceTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ExamplePerformanceTest.cs
@@ -10,7 +10,7 @@ namespace PerformanceTests.ExamplePerformanceTests;
 
 [WriteToMarkdown]
 [WriteToCsv]
-[Sailfish(5, 2, Disabled = true)]
+[Sailfish(1, 0, Disabled = true)]
 public class ExamplePerformanceTest : TestBase
 {
     private readonly ILogger logger;
@@ -40,6 +40,7 @@ public class ExamplePerformanceTest : TestBase
     [SailfishIterationSetup]
     public void IterationSetup(CancellationToken cancellationToken)
     {
+        ;
         // logger.Warning("This is the Iteration Setup - use sparingly");
     }
 
@@ -60,7 +61,7 @@ public class ExamplePerformanceTest : TestBase
     [SailfishIterationTeardown]
     public void IterationTeardown(CancellationToken cancellationToken)
     {
-        
+        ;
         // logger.Warning("This is the Iteration Teardown - use sparingly");
     }
 

--- a/source/PerformanceTests/ExamplePerformanceTests/SimplePerfTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/SimplePerfTest.cs
@@ -14,16 +14,22 @@ public class SimplePerfTest
     {
         await Task.CompletedTask;
     }
-    
+ 
     [SailfishMethod]
     public async Task TestA(CancellationToken cancellationToken)
     {
-        await Task.Delay(1_000, cancellationToken);
+        await Task.Delay(500, cancellationToken);
     }
 
     [SailfishMethod]
     public async Task TestB(CancellationToken cancellationToken)
     {
-        await Task.Delay(1_000, cancellationToken);
+        await Task.Delay(300, cancellationToken);
+    }
+
+    [SailfishGlobalTeardown]
+    public async Task GlobalTearDown(CancellationToken cancellationToken)
+    {
+        await Task.CompletedTask;
     }
 }

--- a/source/PerformanceTests/ExamplePerformanceTests/SimplePerfTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/SimplePerfTest.cs
@@ -9,6 +9,12 @@ public class SimplePerfTest
 {
     [SailfishVariable(1, 2, 3)] public int VariableA { get; set; }
 
+    [SailfishGlobalSetup]
+    public async Task GlobalSetup(CancellationToken cancellationToken)
+    {
+        await Task.CompletedTask;
+    }
+    
     [SailfishMethod]
     public async Task TestA(CancellationToken cancellationToken)
     {

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.293" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.298" />
         <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -7,10 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.279" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.290" />
         <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.290" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.293" />
         <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 

--- a/source/Sailfish.TestAdapter/Execution/TestExecution.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestExecution.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -46,7 +45,6 @@ internal static class TestExecution
                 testCase =>
                     testCase.Traits.Single(x => x.Name == TestCaseItemCreator.TestTypeFullName).Value);
 
-        Type? testType = null;
         foreach (var testCaseGroup in testCaseGroups)
         {
             var groupResults = new List<TestExecutionResult>();
@@ -55,19 +53,12 @@ internal static class TestExecution
             var testTypeTrait = firstTestCase.Traits.Single(trait => trait.Name == TestCaseItemCreator.TestTypeFullName);
             var testTypeFullName = testTypeTrait.Value;
             var assembly = LoadAssemblyFromDll(firstTestCase.Source);
-            var nextTestType = assembly.GetType(testTypeFullName, true, true);
-            if (nextTestType is null)
+            var testType = assembly.GetType(testTypeFullName, true, true);
+            if (testType is null)
             {
                 frameworkHandle?.SendMessage(TestMessageLevel.Error, $"Unable to find the following testType: {testTypeFullName}");
                 continue;
             }
-
-            if (testType is not null && testType.FullName != nextTestType.FullName)
-            {
-                throw new Exception($"The test types in the group should be matching: current: {testType.FullName} - next: {nextTestType.FullName}");
-            }
-
-            testType = nextTestType; // what the hell TODO: Fix this since the refactor
 
             var availableVariableSections = testCases.Select(x => x.Traits.Single(y => y.Name == TestCaseItemCreator.FormedVariableSection).Value).Distinct();
 

--- a/source/Sailfish.TestAdapter/Execution/TestExecution.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestExecution.cs
@@ -46,10 +46,10 @@ internal static class TestExecution
                 testCase =>
                     testCase.Traits.Single(x => x.Name == TestCaseItemCreator.TestTypeFullName).Value);
 
+        Type? testType = null;
         foreach (var testCaseGroup in testCaseGroups)
         {
             var groupResults = new List<TestExecutionResult>();
-            Type? testType = null;
 
             var firstTestCase = testCaseGroup.First();
             var testTypeTrait = firstTestCase.Traits.Single(trait => trait.Name == TestCaseItemCreator.TestTypeFullName);
@@ -67,17 +67,34 @@ internal static class TestExecution
                 throw new Exception($"The test types in the group should be matching: current: {testType.FullName} - next: {nextTestType.FullName}");
             }
 
-            testType = nextTestType;
+            testType = nextTestType; // what the hell TODO: Fix this since the refactor
+
+            var availableVariableSections = testCases.Select(x => x.Traits.Single(y => y.Name == TestCaseItemCreator.FormedVariableSection).Value).Distinct();
+
+            bool PropertyFilter(PropertySet currentPropertySet)
+            {
+                var currentVariableSection = currentPropertySet.FormTestCaseVariableSection();
+                return availableVariableSections.Contains(currentVariableSection);
+            }
+
+            var availableMethods = testCases.Select(x => x.Traits.Single(y => y.Name == TestCaseItemCreator.MethodName).Value).Distinct();
+
+            bool MethodFilter(MethodInfo currentMethodInfo)
+            {
+                var currentMethod = currentMethodInfo.Name;
+                return availableMethods.Contains(currentMethod);
+            }
 
             // list of methods with their many variable combos. Each element is a container, which represents a SailfishMethod
-            var providerForCurrentTestCases = TestInstanceContainerCreator.CreateTestContainerInstanceProviders(testType); //, PropertyFilter, MethodFilter);
+            var providerForCurrentTestCases = TestInstanceContainerCreator.CreateTestContainerInstanceProviders(testType, PropertyFilter, MethodFilter);
 
+            var totalTestProviderCount = providerForCurrentTestCases.Count - 1;
             for (var i = 0; i < providerForCurrentTestCases.Count; i++)
             {
                 var provider = providerForCurrentTestCases[i];
                 var results = engine.ActivateContainer(
                         i,
-                        providerForCurrentTestCases.Count,
+                        totalTestProviderCount,
                         provider,
                         PreTestResultCallback(frameworkHandle, testCaseGroup),
                         PostTestResultCallback(testCaseGroup, frameworkHandle, cancellationToken),
@@ -109,21 +126,27 @@ internal static class TestExecution
         }
     }
 
-    private static Action<TestInstanceContainerProvider> PreTestResultCallback(ITestExecutionRecorder? logger, IGrouping<string, TestCase> testCaseGroup)
+    private static Action<TestInstanceContainer> PreTestResultCallback(ITestExecutionRecorder? logger, IGrouping<string, TestCase> testCaseGroup)
     {
-        return provider =>
+        return container =>
         {
-            var currentTestCase = testCaseGroup.Single(x => x.DisplayName == provider.Test.FullName);
+            var currentTestCase = GetTestCaseFromTestCaseGroupMatchingCurrentContainer(container, testCaseGroup);
             logger?.RecordStart(currentTestCase);
         };
     }
 
-    private static Action<TestExecutionResult> PostTestResultCallback(IGrouping<string, TestCase> testCaseGroups, ITestExecutionRecorder? logger, CancellationToken cancellationToken)
+    private static TestCase GetTestCaseFromTestCaseGroupMatchingCurrentContainer(TestInstanceContainer container, IGrouping<string, TestCase> testCaseGroup)
     {
-        return result =>
+        return testCaseGroup.Single(x => string.Equals(x.DisplayName, container.TestCaseId.DisplayName, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private static Action<TestExecutionResult, TestInstanceContainer> PostTestResultCallback(IGrouping<string, TestCase> testCaseGroups, ITestExecutionRecorder? logger,
+        CancellationToken cancellationToken)
+    {
+        return (result, container) =>
         {
-            var testCase = testCaseGroups.Single(x => x.FullyQualifiedName == result.TestInstanceContainer.Type.FullName);
-            
+            var currentTestCase = GetTestCaseFromTestCaseGroupMatchingCurrentContainer(container, testCaseGroups);
+
             var rawResult = result.Exception is null
                 ? new RawExecutionResult(result.TestInstanceContainer.Type, new List<TestExecutionResult>() { result })
                 : new RawExecutionResult(result.TestInstanceContainer.Type, result.Exception);
@@ -132,7 +155,7 @@ internal static class TestExecution
             var medianTestRuntime = compiledResult.Single().CompiledResults.Single().DescriptiveStatisticsResult?.Median ??
                                     throw new SailfishException("Error computing compiled results");
 
-            var testResult = new TestResult(testCase);
+            var testResult = new TestResult(currentTestCase);
 
             if (result.Exception is not null)
             {
@@ -141,7 +164,7 @@ internal static class TestExecution
             }
 
             testResult.Outcome = result.StatusCode == 0 ? TestOutcome.Passed : TestOutcome.Failed;
-            testResult.DisplayName = testCase.DisplayName;
+            testResult.DisplayName = currentTestCase.DisplayName;
 
             testResult.StartTime = result.PerformanceTimerResults.GlobalStart;
             testResult.EndTime = result.PerformanceTimerResults.GlobalStop;
@@ -155,7 +178,7 @@ internal static class TestExecution
             LogTestResults(result, logger);
 
             logger?.RecordResult(testResult);
-            logger?.RecordEnd(testCase, testResult.Outcome);
+            logger?.RecordEnd(currentTestCase, testResult.Outcome);
         };
     }
 }

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -27,7 +27,6 @@
         <Optimize>true</Optimize>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.4.1"/>
         <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.4.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -36,7 +35,8 @@
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2"/>
         <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1"/>
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0"/>
+        <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.11.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj"/>

--- a/source/Sailfish/Execution/ISailFishTestExecutor.cs
+++ b/source/Sailfish/Execution/ISailFishTestExecutor.cs
@@ -9,6 +9,6 @@ internal interface ISailFishTestExecutor
 {
     Task<List<RawExecutionResult>> Execute(
         IEnumerable<Type> testTypes,
-        Action<TestExecutionResult>? callback = null,
+        Action<TestExecutionResult, TestInstanceContainer>? callback = null,
         CancellationToken cancellationToken = default);
 }

--- a/source/Sailfish/Execution/ISailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/ISailfishExecutionEngine.cs
@@ -11,6 +11,7 @@ internal interface ISailfishExecutionEngine
         int testProviderIndex,
         int totalTestProviderCount,
         TestInstanceContainerProvider testProvider,
+        Action<TestInstanceContainerProvider>? preCallback = null,
         Action<TestExecutionResult>? callback = null,
         CancellationToken cancellationToken = default);
 }

--- a/source/Sailfish/Execution/ISailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/ISailfishExecutionEngine.cs
@@ -11,7 +11,7 @@ internal interface ISailfishExecutionEngine
         int testProviderIndex,
         int totalTestProviderCount,
         TestInstanceContainerProvider testProvider,
-        Action<TestInstanceContainerProvider>? preCallback = null,
-        Action<TestExecutionResult>? callback = null,
+        Action<TestInstanceContainer>? preCallback = null,
+        Action<TestExecutionResult, TestInstanceContainer>? callback = null,
         CancellationToken cancellationToken = default);
 }

--- a/source/Sailfish/Execution/SailFishTestExecutor.cs
+++ b/source/Sailfish/Execution/SailFishTestExecutor.cs
@@ -27,7 +27,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
 
     public async Task<List<RawExecutionResult>> Execute(
         IEnumerable<Type> testTypes,
-        Action<TestExecutionResult>? callback = null,
+        Action<TestExecutionResult, TestInstanceContainer>? callback = null,
         CancellationToken cancellationToken = default)
     {
         var rawResults = new List<RawExecutionResult>();
@@ -61,7 +61,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
 
     private async Task<List<TestExecutionResult>> Execute(
         Type test,
-        Action<TestExecutionResult>? callback = null,
+        Action<TestExecutionResult, TestInstanceContainer>? callback = null,
         CancellationToken cancellationToken = default)
     {
         var testInstanceContainerProviders = testInstanceContainerCreator.CreateTestContainerInstanceProviders(test);
@@ -71,7 +71,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
 
     private async Task<List<TestExecutionResult>> Execute(
         IReadOnlyCollection<TestInstanceContainerProvider> testInstanceContainerProviders,
-        Action<TestExecutionResult>? callback = null,
+        Action<TestExecutionResult, TestInstanceContainer>? callback = null,
         CancellationToken cancellationToken = default)
     {
         var results = new List<TestExecutionResult>();

--- a/source/Sailfish/Execution/SailFishTestExecutor.cs
+++ b/source/Sailfish/Execution/SailFishTestExecutor.cs
@@ -81,7 +81,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
         foreach (var testInstanceContainerProvider in testInstanceContainerProviders.OrderBy(x => x.Method.Name))
         {
             TestCaseCountPrinter.PrintMethodUpdate(testInstanceContainerProvider.Method);
-            var executionResults = await engine.ActivateContainer(currentTestInstanceContainer, totalMethodCount, testInstanceContainerProvider, callback, cancellationToken);
+            var executionResults = await engine.ActivateContainer(currentTestInstanceContainer, totalMethodCount, testInstanceContainerProvider, null, callback, cancellationToken);
             results.AddRange(executionResults);
             currentTestInstanceContainer += 1;
         }

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -29,6 +29,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
     /// <param name="testProviderIndex"></param>
     /// <param name="totalTestProviderCount"></param>
     /// <param name="testProvider"></param>
+    /// <param name="preCallback"></param>
     /// <param name="callback"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
@@ -36,8 +37,8 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         [Range(1, int.MaxValue)] int testProviderIndex,
         [Range(1, int.MaxValue)] int totalTestProviderCount,
         TestInstanceContainerProvider testProvider,
-        Action<TestInstanceContainerProvider>? preCallback = null,
-        Action<TestExecutionResult>? callback = null,
+        Action<TestInstanceContainer>? preCallback = null,
+        Action<TestExecutionResult, TestInstanceContainer>? callback = null,
         CancellationToken cancellationToken = default)
     {
         if (testProviderIndex > totalTestProviderCount)
@@ -46,7 +47,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         }
 
         var currentPropertyTensorIndex = 0;
-        var totalPropertyTensorElements = testProvider.GetNumberOfPropertySetsInTheQueue();
+        var totalPropertyTensorElements = testProvider.GetNumberOfPropertySetsInTheQueue() - 1;
 
         var instanceContainerEnumerator = testProvider.ProvideNextTestInstanceContainer(runSettings.TestLocationAnchors, runSettings.RegistrationProviderAnchors)
             .GetAsyncEnumerator(cancellationToken);
@@ -65,10 +66,10 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
 
         var results = new List<TestExecutionResult>();
         bool continueIterating;
-        preCallback?.Invoke(testProvider);
         do
         {
             var testMethodContainer = instanceContainerEnumerator.Current;
+            preCallback?.Invoke(testMethodContainer);
             TestCaseCountPrinter.PrintCaseUpdate(testMethodContainer.TestCaseId.DisplayName);
 
             if (ShouldCallGlobalSetup(testProviderIndex, currentPropertyTensorIndex))
@@ -87,6 +88,9 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
                 await testMethodContainer.Invocation.GlobalTeardown(cancellationToken);
             }
 
+            callback?.Invoke(executionResult, testMethodContainer);
+            results.Add(executionResult);
+
             if (ShouldDisposeOfInstance(currentPropertyTensorIndex, totalPropertyTensorElements))
             {
                 await DisposeOfTestInstance(testMethodContainer);
@@ -103,9 +107,6 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
                 await DisposeOfTestInstance(instanceContainerEnumerator.Current);
                 throw;
             }
-
-            callback?.Invoke(executionResult);
-            results.Add(executionResult);
         } while (continueIterating);
 
         await instanceContainerEnumerator.DisposeAsync();

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -44,7 +44,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
             throw new SailfishException($"test provider index {testProviderIndex} cannot be greater than total test provider count {totalTestProviderCount}");
         }
 
-        var currentPropertyTensorIndex = 1;
+        var currentPropertyTensorIndex = 0;
         var totalPropertyTensorElements = testProvider.GetNumberOfPropertySetsInTheQueue();
 
         var instanceContainerEnumerator = testProvider.ProvideNextTestInstanceContainer(runSettings.TestLocationAnchors, runSettings.RegistrationProviderAnchors).GetAsyncEnumerator(cancellationToken);

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -36,6 +36,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         [Range(1, int.MaxValue)] int testProviderIndex,
         [Range(1, int.MaxValue)] int totalTestProviderCount,
         TestInstanceContainerProvider testProvider,
+        Action<TestInstanceContainerProvider>? preCallback = null,
         Action<TestExecutionResult>? callback = null,
         CancellationToken cancellationToken = default)
     {
@@ -47,7 +48,8 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         var currentPropertyTensorIndex = 0;
         var totalPropertyTensorElements = testProvider.GetNumberOfPropertySetsInTheQueue();
 
-        var instanceContainerEnumerator = testProvider.ProvideNextTestInstanceContainer(runSettings.TestLocationAnchors, runSettings.RegistrationProviderAnchors).GetAsyncEnumerator(cancellationToken);
+        var instanceContainerEnumerator = testProvider.ProvideNextTestInstanceContainer(runSettings.TestLocationAnchors, runSettings.RegistrationProviderAnchors)
+            .GetAsyncEnumerator(cancellationToken);
 
         try
         {
@@ -63,6 +65,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
 
         var results = new List<TestExecutionResult>();
         bool continueIterating;
+        preCallback?.Invoke(testProvider);
         do
         {
             var testMethodContainer = instanceContainerEnumerator.Current;

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -9,8 +9,8 @@ namespace Sailfish.Execution;
 internal class TestInstanceContainerProvider
 {
     public readonly MethodInfo Method;
+    public readonly Type Test;
     private readonly ITypeResolutionUtility typeResolutionUtility;
-    private readonly Type test;
     private readonly IEnumerable<PropertySet> propertySets;
 
     public TestInstanceContainerProvider(
@@ -20,9 +20,9 @@ internal class TestInstanceContainerProvider
         MethodInfo method)
     {
         Method = method;
+        Test = test;
 
         this.typeResolutionUtility = typeResolutionUtility;
-        this.test = test;
         this.propertySets = propertySets;
     }
 
@@ -35,14 +35,14 @@ internal class TestInstanceContainerProvider
     {
         if (GetNumberOfPropertySetsInTheQueue() is 0)
         {
-            var instance = await typeResolutionUtility.CreateDehydratedTestInstance(test, testDiscoveryAnchorTypes, registrationProviderAnchorTypes);
+            var instance = await typeResolutionUtility.CreateDehydratedTestInstance(Test, testDiscoveryAnchorTypes, registrationProviderAnchorTypes);
             yield return TestInstanceContainer.CreateTestInstance(instance, Method, Array.Empty<string>(), Array.Empty<int>());
         }
         else
         {
             foreach (var nextPropertySet in propertySets)
             {
-                var instance = await typeResolutionUtility.CreateDehydratedTestInstance(test, testDiscoveryAnchorTypes, registrationProviderAnchorTypes);
+                var instance = await typeResolutionUtility.CreateDehydratedTestInstance(Test, testDiscoveryAnchorTypes, registrationProviderAnchorTypes);
 
                 HydrateInstance(instance, nextPropertySet);
 

--- a/source/Tests.Sailfish.TestAdapter/TestAdapterExecutionE2EFixture.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestAdapterExecutionE2EFixture.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests.Sailfish.TestAdapter;
+
+
+public class TestAdapterExecutionE2EFixture
+{
+    // [Fact]
+    // public async Task AllLifeCycleMethodsAreInvoked()
+    // {
+    //     
+    // }
+}

--- a/source/Tests.Sailfish.TestAdapter/TestResources/TestClassWithRegistrationProviderDependency.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestResources/TestClassWithRegistrationProviderDependency.cs
@@ -2,7 +2,7 @@ using Sailfish.Attributes;
 
 namespace Tests.Sailfish.TestAdapter.TestResources;
 
-[Sailfish]
+[Sailfish(Disabled = true)]
 public class TestClassWithRegistrationProviderDependency
 {
     private readonly GenericDependency<AnyType> genericDependency;

--- a/source/Tests.Sailfish.TestAdapter/TestResources/TestResourceDoNotRename.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestResources/TestResourceDoNotRename.cs
@@ -4,7 +4,7 @@ using Sailfish.Attributes;
 
 namespace Tests.Sailfish.TestAdapter.TestResources;
 
-[Sailfish]
+[Sailfish( Disabled = true)]
 public class SimplePerfTest
 {
     [SailfishVariable(1, 2, 3)] public int VariableA { get; set; }

--- a/source/Tests.Sailfish.TestAdapter/Tests.Sailfish.TestAdapter.csproj
+++ b/source/Tests.Sailfish.TestAdapter/Tests.Sailfish.TestAdapter.csproj
@@ -8,19 +8,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NSubstitute" Version="4.4.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+        <PackageReference Include="NSubstitute" Version="4.4.0"/>
+        <PackageReference Include="Shouldly" Version="4.1.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="coverlet.collector" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Sailfish.TestAdapter\Sailfish.TestAdapter.csproj" />
+        <ProjectReference Include="..\Sailfish.TestAdapter\Sailfish.TestAdapter.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/source/Tests.Sailfish.TestAdapter/WhenAssemblingTestCases.cs
+++ b/source/Tests.Sailfish.TestAdapter/WhenAssemblingTestCases.cs
@@ -1,18 +1,17 @@
 ﻿using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Sailfish.TestAdapter.Discovery;
 using Shouldly;
 using Tests.Sailfish.TestAdapter.TestResources;
+using Xunit;
 
 namespace Tests.Sailfish.TestAdapter;
 
-[TestClass]
 public class WhenAssemblingTestCases
 {
-    public string FindSpecificUniqueFile(string fileName)
+    public static string FindSpecificUniqueFile(string fileName)
     {
         var refFile = Directory.GetFiles(".").First();
 
@@ -21,7 +20,7 @@ public class WhenAssemblingTestCases
         return file;
     }
 
-    [TestMethod]
+    [Fact]
     public void AllTestCasesAreMade()
     {
         var testResourceRelativePath = FindSpecificUniqueFile("TestResourceDoNotRename.cs");

--- a/source/Tests.Sailfish.TestAdapter/WhenDiscoveringTests.cs
+++ b/source/Tests.Sailfish.TestAdapter/WhenDiscoveringTests.cs
@@ -1,15 +1,15 @@
 ﻿using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Sailfish.TestAdapter.Discovery;
 using Shouldly;
 using Tests.Sailfish.TestAdapter.Utils;
+using Xunit;
 
 namespace Tests.Sailfish.TestAdapter;
 
-[TestClass]
+
 public class WhenDiscoveringTests
 {
-    [TestMethod]
+    [Fact]
     public void AllTestsAreDiscovered()
     {
         // sources is a list of dlls that we've discovered in this project
@@ -21,7 +21,7 @@ public class WhenDiscoveringTests
         testCases.Count.ShouldBe(7);
     }
 
-    [TestMethod]
+    [Fact]
     public void TestCasesAreAssembledCorrect()
     {
         var sources = DllFinder.FindAllDllsRecursively();

--- a/source/Tests.Sailfish.TestAdapter/WhenExecutingTests.cs
+++ b/source/Tests.Sailfish.TestAdapter/WhenExecutingTests.cs
@@ -2,19 +2,18 @@
 using System.Threading;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Sailfish.TestAdapter.Discovery;
 using Sailfish.TestAdapter.Execution;
 using Shouldly;
 using Tests.Sailfish.TestAdapter.Utils;
+using Xunit;
 
 namespace Tests.Sailfish.TestAdapter;
 
-[TestClass]
 public class WhenExecutingTests
 {
-    [TestMethod]
+    [Fact]
     public void FilteredTestsAreSuccessfullyDiscovered()
     {
         var frameworkHandle = Substitute.For<IFrameworkHandle>();
@@ -25,7 +24,7 @@ public class WhenExecutingTests
         Should.NotThrow(() => TestExecution.ExecuteTests(testCases.Take(1).ToList(), frameworkHandle, CancellationToken.None));
     }
 
-    [TestMethod]
+    [Fact]
     public void TestCasesAreExecutedCorrectly()
     {
         var frameworkHandle = Substitute.For<IFrameworkHandle>();


### PR DESCRIPTION
This refactor:

 - fixed a bug with the numbers printing via the test adapter ConsoleWriter
 - fixed a bug where lifecycle methods weren't being called correctly from the test adapter
 - improved the way tests are iterated in the test adapter - this enables a shared global setup for a class when running via the ide (technically a bug)
 - 