### PR TITLE
Use properties instead of categories, fix rego bug

### DIFF
--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.319"
+$version="0.0.323"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/DemoPerformanceTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/DemoPerformanceTest.cs
@@ -4,7 +4,7 @@ using Sailfish.Attributes;
 
 namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
 
-[Sailfish(Disabled = true)]
+[Sailfish(Disabled = false)]
 public class DemoPerformanceTest
 {
     [SailfishMethod]

--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/PerfTestWithAltRego.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/PerfTestWithAltRego.cs
@@ -5,7 +5,7 @@ using Sailfish.Attributes;
 
 namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
 
-[Sailfish(NumIterations = 3, NumWarmupIterations = 2, Disabled = true)]
+[Sailfish(NumIterations = 3, NumWarmupIterations = 2, Disabled = false)]
 public class PerfTestWithAltRego
 {
     private readonly ExampleDependencyForAltRego dep;

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.1.132" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.323" />
         <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>
 

--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -14,12 +14,6 @@ namespace Sailfish.TestAdapter.Discovery;
 
 internal static class TestCaseItemCreator
 {
-    // categories
-    public const string TestTypeFullName = "TestTypeFullName";
-    public const string DisplayName = "DisplayName";
-    public const string FormedVariableSection = "FormedVariableSection";
-    public const string MethodName = "MethodName";
-
     private static PropertySetGenerator PropertySetGenerator => new(new ParameterCombinator(), new IterationVariableRetriever());
 
     public static IEnumerable<TestCase> AssembleTestCases(Type testType, string testCsFileContent, string testCsFilePath, string sourceDll, IMessageLogger logger)
@@ -43,7 +37,6 @@ internal static class TestCaseItemCreator
 
             if (propertySets.Length > 0)
             {
-                var i = 0;
                 foreach (var propertySet in propertySets)
                 {
                     var propertyNames = propertySet.GetPropertyNames();
@@ -56,7 +49,6 @@ internal static class TestCaseItemCreator
                         propertyNames,
                         propertyValues,
                         true); // TODO: Remove this once we have traits and properties sorted. see below
-                    i++;
                     testCase.CodeFilePath = testCsFilePath;
                     testCase.ExecutorUri = TestExecutor.ExecutorUri;
                     testCase.LineNumber = methodNameLine;
@@ -108,13 +100,10 @@ internal static class TestCaseItemCreator
         }
 
         if (!shouldAddCategories) return testCase;
-        // TODO: Send these traits over to the properties
-        // Traits is not the right way to pass this information, but the Properties property keeps getting cleared on the test case when
-        // is passed to the executor -- I'm setting that property incorrectly probably
-        testCase.Traits.Add(new Trait(TestTypeFullName, testType.FullName));
-        testCase.Traits.Add(new Trait(DisplayName, testCaseId.DisplayName));
-        testCase.Traits.Add(new Trait(FormedVariableSection, testCaseId.TestCaseVariables.FormVariableSection()));
-        testCase.Traits.Add(new Trait(MethodName, method.Name));
+        testCase.SetPropertyValue(SailfishTestTypeFullNameDefinition.SailfishTestTypeFullNameDefinitionProperty, testType.FullName);
+        testCase.SetPropertyValue(SailfishDisplayNameDefinition.SailfishDisplayNameDefinitionProperty, testCaseId.DisplayName);
+        testCase.SetPropertyValue(SailfishFormedVariableSectionDefinition.SailfishFormedVariableSectionDefinitionProperty, testCaseId.TestCaseVariables.FormVariableSection());
+        testCase.SetPropertyValue(SailfishMethodNameDefinition.SailfishMethodNameDefinitionProperty, method.Name);
 
         return testCase;
     }

--- a/source/Sailfish.TestAdapter/Execution/TestExecution.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestExecution.cs
@@ -7,7 +7,7 @@ using Autofac;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Sailfish.Execution;
-using Sailfish.TestAdapter.Discovery;
+using Sailfish.TestAdapter.TestProperties;
 
 namespace Sailfish.TestAdapter.Execution;
 
@@ -35,8 +35,11 @@ internal static class TestExecution
     {
         var assembly = Assembly.LoadFile(testCases.First().Source);
         AppDomain.CurrentDomain.Load(assembly.GetName()); // is this necessary?
-        var testTypeTrait = testCases.First().Traits.Single(trait => trait.Name == TestCaseItemCreator.TestTypeFullName);
-        var testTypeFullName = testTypeTrait.Value;
+
+        var testTypeFullName = testCases
+            .First()
+            .GetPropertyHelper(SailfishTestTypeFullNameDefinition.SailfishTestTypeFullNameDefinitionProperty);
+
         var refTestType = assembly.GetType(testTypeFullName, true, true);
         if (refTestType is null) throw new Exception("First test type was null when starting test execution");
         return refTestType;

--- a/source/Sailfish.TestAdapter/TestProperties/PropertyValueExtensionMethods.cs
+++ b/source/Sailfish.TestAdapter/TestProperties/PropertyValueExtensionMethods.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Sailfish.Exceptions;
+
+namespace Sailfish.TestAdapter.TestProperties;
+
+public static class PropertyValueExtensionMethods
+{
+    public static string GetPropertyHelper(this TestCase testCase, TestProperty testProperty)
+    {
+        var value = testCase
+            .GetPropertyValue(testProperty, $"Failed to return {testProperty.Id}");
+        if (value is null) throw new SailfishException($"Failed to return {testProperty.Id}");
+        return value;
+    }
+}

--- a/source/Sailfish.TestAdapter/TestProperties/SailfishDisplayNameDefinition.cs
+++ b/source/Sailfish.TestAdapter/TestProperties/SailfishDisplayNameDefinition.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Sailfish.TestAdapter.TestProperties;
+
+public static class SailfishDisplayNameDefinition
+{
+    public const string DisplayName = "DisplayName";
+
+    internal static readonly TestProperty SailfishDisplayNameDefinitionProperty = TestProperty.Register(
+        $"Sailfish.{DisplayName}Definition",
+        $"{DisplayName}Definition",
+        typeof(string),
+        TestPropertyAttributes.Immutable,
+        typeof(TestCase)
+    );
+}

--- a/source/Sailfish.TestAdapter/TestProperties/SailfishFormedVariableSectionDefinition.cs
+++ b/source/Sailfish.TestAdapter/TestProperties/SailfishFormedVariableSectionDefinition.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Sailfish.TestAdapter.TestProperties;
+
+public static class SailfishFormedVariableSectionDefinition
+{
+    public const string FormedVariableSection = "FormedVariableSection";
+
+    internal static readonly TestProperty SailfishFormedVariableSectionDefinitionProperty = TestProperty.Register(
+        $"Sailfish.{FormedVariableSection}Definition",
+        $"{FormedVariableSection}Definition",
+        typeof(string),
+        TestPropertyAttributes.Immutable,
+        typeof(TestCase)
+    );
+}

--- a/source/Sailfish.TestAdapter/TestProperties/SailfishMethodNameDefinition.cs
+++ b/source/Sailfish.TestAdapter/TestProperties/SailfishMethodNameDefinition.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Sailfish.TestAdapter.TestProperties;
+
+public static class SailfishMethodNameDefinition
+{
+    public const string MethodName = "MethodName";
+
+    internal static readonly TestProperty SailfishMethodNameDefinitionProperty = TestProperty.Register(
+        $"Sailfish.{MethodName}Definition",
+        $"{MethodName}Definition",
+        typeof(string),
+        TestPropertyAttributes.Immutable,
+        typeof(TestCase)
+    );
+}

--- a/source/Sailfish.TestAdapter/TestProperties/SailfishTestTypeDefinition.cs
+++ b/source/Sailfish.TestAdapter/TestProperties/SailfishTestTypeDefinition.cs
@@ -2,11 +2,13 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Sailfish.TestAdapter.TestProperties;
 
-public static class SailfishDisplayNameDefinition
+public static class SailfishTestTypeFullNameDefinition
 {
-    internal static readonly TestProperty SailfishDisplayNameDefinitionProperty = TestProperty.Register(
-        "Sailfish.DisplayNameDefinition",
-        "DisplayNameDefinition",
+    public const string TestTypeFullName = "TestTypeFullName";
+
+    internal static readonly TestProperty SailfishTestTypeFullNameDefinitionProperty = TestProperty.Register(
+        $"Sailfish.{TestTypeFullName}Definition",
+        $"{TestTypeFullName}Definition",
         typeof(string),
         TestPropertyAttributes.Immutable,
         typeof(TestCase)

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -63,12 +63,9 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
             instanceContainerEnumerator.Dispose();
             var msg = $"Error resolving test from {testProvider.Test.FullName}";
             Log.Logger.Fatal(ex, "{Message}", msg);
-            if (exceptionCallback is not null)
-            {
-                return new List<TestExecutionResult>();
-            }
-
-            throw;
+            if (exceptionCallback is null) throw;
+            var exceptionResult = new TestExecutionResult(testProvider, ex);
+            return new List<TestExecutionResult>() { exceptionResult };
         }
 
         var results = new List<TestExecutionResult>();

--- a/source/Sailfish/Execution/TestExecutionResult.cs
+++ b/source/Sailfish/Execution/TestExecutionResult.cs
@@ -29,11 +29,25 @@ internal class TestExecutionResult
         PerformanceTimerResults = container.Invocation.GetPerformanceResults(false);
     }
 
+    public TestExecutionResult(TestInstanceContainerProvider testProvider, Exception exception)
+    {
+        Exception = exception;
+        IsSuccess = false;
+        StatusCode = StatusCode.Failure;
+
+        TestInstanceContainer = null;
+        TestInstanceContainerProvider = testProvider;
+        Messages = null;
+        ExecutionSettings = null;
+        PerformanceTimerResults = null;
+    }
+
     public IExecutionSettings? ExecutionSettings { get; }
     public List<string>? Messages { get; }
     public Exception? Exception { get; }
     public StatusCode StatusCode { get; }
     public bool IsSuccess { get; }
-    public TestInstanceContainer TestInstanceContainer { get; set; }
-    public PerformanceTimer PerformanceTimerResults { get; }
+    public TestInstanceContainer? TestInstanceContainer { get; set; }
+    public TestInstanceContainerProvider? TestInstanceContainerProvider { get; set; }
+    public PerformanceTimer? PerformanceTimerResults { get; }
 }


### PR DESCRIPTION
This PR: 

 - removes the misuse of 'TestCase.Trait'
 - adds correct usage of 'TestCase.Properties'
 - fixes a bug in the SailfishTypeRegistrationUtility