### PR TITLE
Do not time warmup method iterations!

### DIFF
--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -33,7 +33,7 @@ internal class TestCaseIterator : ITestCaseIterator
             cancellationToken.ThrowIfCancellationRequested();
             await testInstanceContainer.Invocation.IterationSetup(cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
-            await testInstanceContainer.Invocation.ExecutionMethod(cancellationToken).ConfigureAwait(false);
+            await testInstanceContainer.Invocation.ExecutionMethod(cancellationToken, timed: false).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             await testInstanceContainer.Invocation.IterationTearDown(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Description

We are current adding warmup iterations to the final array of timed values. There is an option to not time the function, but its not being used.