### PR TITLE
Exceptions an scopes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Description
+
+<!-- A clear description to provide context -->
+
+
+## Results
+
+<!-- The changes you ended up making -->

--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.340"
+$version="0.0.344"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/WillThrow.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/WillThrow.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Sailfish.Attributes;
+
+namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
+
+[Sailfish]
+public class WillThrow
+{
+    [SailfishMethod]
+    public void ThisThrows()
+    {
+        throw new Exception("This was my exception!");
+    }
+}

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.340" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.344" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
     </ItemGroup>

--- a/source/Sailfish.TestAdapter/Execution/ConsoleWriter.cs
+++ b/source/Sailfish.TestAdapter/Execution/ConsoleWriter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Accord.Collections;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Sailfish.Execution;
@@ -13,7 +14,10 @@ internal class ConsoleWriter : IConsoleWriter
 {
     private readonly IMarkdownTableConverter markdownTableConverter;
     private readonly IMessageLogger? messageLogger;
-    private readonly Logger consoleLogger;
+
+    private readonly Logger consoleLogger = new LoggerConfiguration()
+        .WriteTo.Console()
+        .CreateLogger();
 
     public ConsoleWriter(
         IMarkdownTableConverter markdownTableConverter,
@@ -21,14 +25,32 @@ internal class ConsoleWriter : IConsoleWriter
     {
         this.markdownTableConverter = markdownTableConverter;
         this.messageLogger = messageLogger;
-        consoleLogger = new LoggerConfiguration()
-            .WriteTo.Console()
-            .CreateLogger();
     }
 
     public string Present(IEnumerable<IExecutionSummary> results, OrderedDictionary<string, string>? tags = null)
     {
-        var markdownStringTable = markdownTableConverter.ConvertToMarkdownTableString(results);
+        var summaryResults = results.ToList();
+        foreach (var result in summaryResults)
+        {
+            foreach (var compiledResult in result.CompiledResults)
+            {
+                if (compiledResult.Exception is null) continue;
+                messageLogger?.SendMessage(TestMessageLevel.Error, compiledResult.Exception.Message);
+                consoleLogger.Error("{Error}", compiledResult.Exception.Message);
+
+                messageLogger?.SendMessage(TestMessageLevel.Error, compiledResult.Exception.StackTrace);
+                consoleLogger.Error("{StackTrace}", compiledResult.Exception.Message);
+
+                if (compiledResult.Exception.InnerException is null) continue;
+                messageLogger?.SendMessage(TestMessageLevel.Error, compiledResult.Exception.InnerException.Message);
+                consoleLogger.Error("{InnerError}", compiledResult.Exception.InnerException.Message);
+
+                messageLogger?.SendMessage(TestMessageLevel.Error, compiledResult.Exception.InnerException.StackTrace);
+                consoleLogger.Error("{InnerStackTrace}", compiledResult.Exception.InnerException.StackTrace);
+            }
+        }
+
+        var markdownStringTable = markdownTableConverter.ConvertToMarkdownTableString(summaryResults);
 
         messageLogger?.SendMessage(TestMessageLevel.Informational, markdownStringTable);
         consoleLogger.Information("{MarkdownTable}", markdownStringTable);

--- a/source/Sailfish.TestAdapter/Execution/TestExecution.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestExecution.cs
@@ -28,8 +28,8 @@ internal static class TestExecution
             .Wait(cancellationToken);
 
         var container = builder.Build();
-
-        container.Resolve<ITestAdapterExecutionProgram>().Run(testCases, frameworkHandle, cancellationToken);
+        using var scope = container.BeginLifetimeScope("TestAdapterScope");
+        scope.Resolve<ITestAdapterExecutionProgram>().Run(testCases, frameworkHandle, cancellationToken);
     }
 
     private static Type RetrieveReferenceTypeForTestProject(IReadOnlyCollection<TestCase> testCases)

--- a/source/Sailfish/Execution/SailfishExecutionCaller.cs
+++ b/source/Sailfish/Execution/SailfishExecutionCaller.cs
@@ -45,6 +45,9 @@ internal static class SailfishExecutionCaller
             ct = (CancellationToken)cancellationToken;
         }
 
-        return await builder.Build().Resolve<SailfishExecutor>().Run(ct).ConfigureAwait(false);
+        var container = builder.Build();
+
+        using var scope = container.BeginLifetimeScope("MainExecutionScope");
+        return await scope.Resolve<SailfishExecutor>().Run(ct).ConfigureAwait(false);
     }
 }

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -151,7 +151,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         }
         catch (Exception exception)
         {
-            return new TestExecutionResult(testInstanceContainer, exception);
+            return new TestExecutionResult(testInstanceContainer, exception.InnerException ?? exception);
         }
     }
 


### PR DESCRIPTION
## Description

Exceptions are logged very well when running in the IDE. This PR unpacks and logs inner exceptions that bubble up from tests.

Container disposal is now explicitly handled via lifetime scopes.
