### PR TITLE
Throw and report when duplicate lifecycle methods are used

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/ExamplePerformanceTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/ExamplePerformanceTest.cs
@@ -7,11 +7,11 @@ using Sailfish.Attributes;
 using Serilog;
 
 // Tests here are automatically discovered and executed
-namespace PerformanceTests.ExamplePerformanceTests.NonDiscoverable;
+namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
 
 [WriteToMarkdown]
 [WriteToCsv]
-[Sailfish(1, 0, Disabled = true)]
+[Sailfish]
 public class ExamplePerformanceTest : TestBase
 {
     private readonly ILogger logger;

--- a/source/Sailfish.sln
+++ b/source/Sailfish.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.E2ETestSuite", "Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTestingUserInvokedConsoleApp", "PerformanceTestingUserInvokedConsoleApp\PerformanceTestingUserInvokedConsoleApp.csproj", "{EBBA336B-1931-4340-82F5-C31815DE5357}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.E2E.ExceptionHandling", "Tests.E2E.ExceptionHandling\Tests.E2E.ExceptionHandling.csproj", "{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +66,10 @@ Global
 		{EBBA336B-1931-4340-82F5-C31815DE5357}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBBA336B-1931-4340-82F5-C31815DE5357}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBBA336B-1931-4340-82F5-C31815DE5357}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EE33D17C-3F19-40A9-8394-D966232723A6} = {AA777AE3-7608-4068-9BDE-3AE366657722}
@@ -73,5 +79,6 @@ Global
 		{2B832E9F-13DC-482C-8391-6E3ADA2CA49B} = {AA777AE3-7608-4068-9BDE-3AE366657722}
 		{E48F48D1-A39A-4F19-BE07-2312244284AA} = {74A88B77-784B-4600-9F69-097A6CDF71D5}
 		{EBBA336B-1931-4340-82F5-C31815DE5357} = {AA777AE3-7608-4068-9BDE-3AE366657722}
+		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0} = {74A88B77-784B-4600-9F69-097A6CDF71D5}
 	EndGlobalSection
 EndGlobal

--- a/source/Sailfish/ExtensionMethods/ReflectionExtensionMethods.cs
+++ b/source/Sailfish/ExtensionMethods/ReflectionExtensionMethods.cs
@@ -44,7 +44,9 @@ public static class ReflectionExtensionMethods
 
     internal static MethodInfo? GetMethodWithAttribute<TAttribute>(this object instance) where TAttribute : Attribute
     {
-        return instance.GetType().GetMethodsWithAttribute<TAttribute>().SingleOrDefault();
+        var methods = instance.GetType().GetMethodsWithAttribute<TAttribute>().ToList();
+        if (methods.Count > 1) throw new SailfishException($"Multiple methods with attribute {typeof(TAttribute).Name} found");
+        return methods.SingleOrDefault();
     }
 
     internal static bool IsAsyncMethod(this MethodInfo method)

--- a/source/Tests.E2E.ExceptionHandling/E2ETestExceptionHandlingProvider.cs
+++ b/source/Tests.E2E.ExceptionHandling/E2ETestExceptionHandlingProvider.cs
@@ -1,0 +1,17 @@
+using Autofac;
+using Demo.API;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Sailfish.Registration;
+using Serilog;
+
+namespace Tests.E2E.ExceptionHandling;
+
+public class E2ETestExceptionHandlingProvider : IProvideARegistrationCallback
+{
+    public async Task RegisterAsync(ContainerBuilder builder, CancellationToken cancellationToken)
+    {
+        await Task.CompletedTask;
+        builder.RegisterType<WebApplicationFactory<DemoApp>>();
+        builder.RegisterInstance(Log.Logger).As<ILogger>();
+    }
+}

--- a/source/Tests.E2E.ExceptionHandling/Tests.E2E.ExceptionHandling.csproj
+++ b/source/Tests.E2E.ExceptionHandling/Tests.E2E.ExceptionHandling.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
+        <PackageReference Include="Shouldly" Version="4.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Demo.API\Demo.API.csproj" />
+        <ProjectReference Include="..\Sailfish\Sailfish.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/source/Tests.E2E.ExceptionHandling/Tests/ADuplicateLifeCycle.cs
+++ b/source/Tests.E2E.ExceptionHandling/Tests/ADuplicateLifeCycle.cs
@@ -1,0 +1,20 @@
+﻿using Sailfish.Attributes;
+using Tests.E2ETestSuite.Discoverable;
+
+namespace Tests.E2E.ExceptionHandling.Tests;
+
+[Sailfish]
+public class ADuplicateLifeCycle : ATestBase
+{
+    [SailfishIterationSetup]
+    public async Task TheIterationSetup(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    [SailfishMethod]
+    public async Task TheSingularMethod(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+}

--- a/source/Tests.E2E.ExceptionHandling/Tests/ATestBase.cs
+++ b/source/Tests.E2E.ExceptionHandling/Tests/ATestBase.cs
@@ -1,0 +1,72 @@
+﻿using Sailfish.Attributes;
+
+namespace Tests.E2ETestSuite.Discoverable;
+
+public class ATestBase
+{
+    [SailfishGlobalSetup]
+    public async Task EnforcedGlobalSetup(CancellationToken cancellationToken)
+    {
+        await GlobalSetup(cancellationToken);
+    }
+
+    [SailfishMethodSetup]
+    public async Task EnforcedMethodSetup(CancellationToken cancellationToken)
+    {
+        await MethodSetup(cancellationToken);
+    }
+
+    [SailfishIterationSetup]
+    public async Task EnforcedIterationSetup(CancellationToken cancellationToken)
+    {
+        await IterationSetup(cancellationToken);
+    }
+
+    [SailfishIterationTeardown]
+    public async Task EnforcedIterationTeardown(CancellationToken cancellationToken)
+    {
+        await IterationTeardown(cancellationToken);
+    }
+
+    [SailfishMethodTeardown]
+    public async Task EnforcedMethodTeardown(CancellationToken cancellationToken)
+    {
+        await MethodTeardown(cancellationToken);
+    }
+
+    [SailfishGlobalTeardown]
+    public async Task EnforcedGlobalTeardown(CancellationToken cancellationToken)
+    {
+        await GlobalTeardown(cancellationToken);
+    }
+
+    protected virtual Task GlobalSetup(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task MethodSetup(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task IterationSetup(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task IterationTeardown(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task MethodTeardown(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task GlobalTeardown(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/source/Tests.E2ETestSuite/Discoverable/ATestBase.cs
+++ b/source/Tests.E2ETestSuite/Discoverable/ATestBase.cs
@@ -1,0 +1,72 @@
+﻿using Sailfish.Attributes;
+
+namespace Tests.E2ETestSuite.Discoverable;
+
+public class ATestBase
+{
+    [SailfishGlobalSetup]
+    public async Task EnforcedGlobalSetup(CancellationToken cancellationToken)
+    {
+        await GlobalSetup(cancellationToken);
+    }
+
+    [SailfishMethodSetup]
+    public async Task EnforcedMethodSetup(CancellationToken cancellationToken)
+    {
+        await MethodSetup(cancellationToken);
+    }
+
+    [SailfishIterationSetup]
+    public async Task EnforcedIterationSetup(CancellationToken cancellationToken)
+    {
+        await IterationSetup(cancellationToken);
+    }
+
+    [SailfishIterationTeardown]
+    public async Task EnforcedIterationTeardown(CancellationToken cancellationToken)
+    {
+        await IterationTeardown(cancellationToken);
+    }
+
+    [SailfishMethodTeardown]
+    public async Task EnforcedMethodTeardown(CancellationToken cancellationToken)
+    {
+        await MethodTeardown(cancellationToken);
+    }
+
+    [SailfishGlobalTeardown]
+    public async Task EnforcedGlobalTeardown(CancellationToken cancellationToken)
+    {
+        await GlobalTeardown(cancellationToken);
+    }
+
+    protected virtual Task GlobalSetup(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task MethodSetup(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task IterationSetup(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task IterationTeardown(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task MethodTeardown(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual Task GlobalTeardown(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/source/Tests.E2ETestSuite/Discoverable/ExamplePerformanceTestFull.cs
+++ b/source/Tests.E2ETestSuite/Discoverable/ExamplePerformanceTestFull.cs
@@ -1,0 +1,80 @@
+using Demo.API;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Sailfish.Attributes;
+using Serilog;
+using Tests.E2ETestSuite.Utils;
+
+// Tests here are automatically discovered and executed
+namespace Tests.E2ETestSuite.Discoverable;
+
+[WriteToMarkdown]
+[WriteToCsv]
+[Sailfish(1, 0, Disabled = false)]
+public class ExamplePerformanceTestFull : TestBase
+{
+    private readonly ILogger logger;
+
+    public ExamplePerformanceTestFull(WebApplicationFactory<DemoApp> factory, ILogger logger) : base(factory)
+    {
+        this.logger = logger;
+    }
+
+    [SailfishVariable(200, 300)] public int WaitPeriod { get; set; }
+    [SailfishVariable(1, 2)] public int NTries { get; set; } // try to avoid multiple variables if you can manage
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup(CancellationToken cancellationToken)
+    {
+        ;
+        // logger.Information("This is the Global Setup");
+    }
+
+    [SailfishMethodSetup]
+    public void ExecutionMethodSetup(CancellationToken cancellationToken)
+    {
+        ;
+        // logger.Information("This is the Execution Method Setup");
+    }
+
+    [SailfishIterationSetup]
+    public void IterationSetup(CancellationToken cancellationToken)
+    {
+        ;
+        // logger.Warning("This is the Iteration Setup - use sparingly");
+    }
+
+    [SailfishMethod]
+    public async Task WaitPeriodPerfTest(CancellationToken cancellationToken)
+    {
+        await Task.Delay(WaitPeriod, cancellationToken);
+        await Client.GetStringAsync("/", cancellationToken);
+    }
+
+    [SailfishMethod]
+    public async Task Other(CancellationToken cancellationToken)
+    {
+        await Task.Delay(WaitPeriod, cancellationToken);
+        await Task.CompletedTask;
+    }
+
+    [SailfishIterationTeardown]
+    public void IterationTeardown(CancellationToken cancellationToken)
+    {
+        ;
+        // logger.Warning("This is the Iteration Teardown - use sparingly");
+    }
+
+    [SailfishMethodTeardown]
+    public void ExecutionMethodTeardown(CancellationToken cancellationToken)
+    {
+        ;
+        // logger.Verbose("This is the Execution Method Teardown");
+    }
+
+    [SailfishGlobalTeardown]
+    public override async Task GlobalTeardown(CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+        // logger.Verbose("This is the Global Teardown");
+    }
+}

--- a/source/Tests.E2ETestSuite/Discoverable/UsesBaseLifecycleMethods.cs
+++ b/source/Tests.E2ETestSuite/Discoverable/UsesBaseLifecycleMethods.cs
@@ -1,0 +1,42 @@
+﻿using Sailfish.Attributes;
+
+namespace Tests.E2ETestSuite.Discoverable;
+
+public class UsesBaseLifecycleMethods : ATestBase
+{
+    protected override async Task GlobalSetup(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    protected override async Task MethodSetup(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    protected override async Task IterationSetup(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    [SailfishMethod]
+    public async Task MyTestMethod(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    protected override async Task IterationTeardown(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    protected override async Task MethodTeardown(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+
+    protected override async Task GlobalTeardown(CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken);
+    }
+}

--- a/source/Tests.Sailfish/Execution/FullE2EExceptionCases.cs
+++ b/source/Tests.Sailfish/Execution/FullE2EExceptionCases.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Sailfish;
+using Shouldly;
+using Tests.E2E.ExceptionHandling;
+using Tests.E2E.ExceptionHandling.Tests;
+using Xunit;
+
+namespace Test.Execution;
+
+public class FullE2EExceptionCases
+{
+    [Fact]
+    public async Task ATestRunWithDuplicateLifecycleMethodsReturnsException()
+    {
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithTestNames(nameof(ADuplicateLifeCycle))
+            .RegistrationProvidersFromAssembliesFromAnchorTypes(typeof(E2ETestExceptionHandlingProvider))
+            .TestsFromAssembliesFromAnchorTypes(typeof(E2ETestExceptionHandlingProvider))
+            .Build();
+
+        var result = await SailfishRunner.Run(runSettings);
+
+        result.IsValid.ShouldBe(false);
+        result.Exceptions.ShouldNotBeNull();
+        result.Exceptions.Count().ShouldBe(1);
+        result.Exceptions.Single().Message.ShouldBe("Multiple methods with attribute SailfishIterationSetupAttribute found");
+    }
+}

--- a/source/Tests.Sailfish/Execution/FullE2EFixture.cs
+++ b/source/Tests.Sailfish/Execution/FullE2EFixture.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Sailfish;
 using Shouldly;
 using Tests.E2ETestSuite;
-using Tests.E2ETestSuite.Discoverable;
 using Xunit;
 
 namespace Test.Execution;
@@ -11,7 +10,7 @@ namespace Test.Execution;
 public class FullE2EFixture
 {
     [Fact]
-    public async Task AFullTestRunOfTheDemoDoesNotContainErrors()
+    public async Task AFullTestRunOfTheDemoDoesNotError()
     {
         var runSettings = RunSettingsBuilder.CreateBuilder()
             .RegistrationProvidersFromAssembliesFromAnchorTypes(typeof(E2ETestRegistrationProvider))
@@ -21,6 +20,7 @@ public class FullE2EFixture
         var result = await SailfishRunner.Run(runSettings);
 
         result.IsValid.ShouldBe(true);
+        result.Exceptions.ShouldNotBeNull();
         result.Exceptions.Count().ShouldBe(0);
     }
 
@@ -37,6 +37,6 @@ public class FullE2EFixture
         var result = await SailfishRunner.Run(runSettings);
 
         result.IsValid.ShouldBe(true);
-        result.ExecutionSummaries.Count().ShouldBe(8);
+        result.ExecutionSummaries.Count().ShouldBe(9);
     }
 }

--- a/source/Tests.Sailfish/Tests.Sailfish.csproj
+++ b/source/Tests.Sailfish/Tests.Sailfish.csproj
@@ -27,6 +27,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" />
         <ProjectReference Include="..\Demo.API\Demo.API.csproj" />
+        <ProjectReference Include="..\Tests.E2E.ExceptionHandling\Tests.E2E.ExceptionHandling.csproj" />
         <ProjectReference Include="..\Tests.E2ETestSuite\Tests.E2ETestSuite.csproj" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

We don't log exceptions very well at the moment. This is a step to improve that.


## Results

Fixes: https://github.com/paulegradie/Sailfish/issues/48