### PR TITLE
Distinct dlls in dll finder in test project

### DIFF
--- a/source/Sailfish.TestAdapter/Discovery/TestDiscovery.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestDiscovery.cs
@@ -35,7 +35,7 @@ internal static class TestDiscovery
                 previousSearchDir = currentSearchDir;
             }
 
-            if (project is null) throw new Exception();
+            if (project is null) throw new Exception("Failed to discover the test project");
 
             Type[] perfTestTypes;
             try

--- a/source/Tests.Sailfish.TestAdapter/Utils/DllFinder.cs
+++ b/source/Tests.Sailfish.TestAdapter/Utils/DllFinder.cs
@@ -15,6 +15,6 @@ public static class DllFinder
 
         var allDlls = DirectoryRecursion.FindAllFilesRecursively(projFile, "*.dll", Substitute.For<IMessageLogger>(),
             path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"));
-        return allDlls;
+        return allDlls.DistinctBy(x => x.EndsWith("Tests.Sailfish.TestAdapter.dll")); // will discover release and debug dlls
     }
 }


### PR DESCRIPTION
## Description
Local tests will break if you run them in release mode, and then again in debug mode - since the dll finder will discover multiple Tests.Sailfish.TestAdapter.dll s

## Results
Make the results distinct to remove the duplicate dlls.