### PR TITLE
remove testhost

### DIFF
--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.344"
+$version="0.0.345"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.344" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.345" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
     </ItemGroup>

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -36,7 +36,6 @@
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
         <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0" />
-        <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.11.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" />


### PR DESCRIPTION
## Description

The testhost reference is not needed for the test adapter to work - ides already hold this reference for us.


## Results

Remove test host reference