### PR TITLE
Pg/better packaging

### DIFF
--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.347"
+$version="0.0.349"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.345"
+$version="0.0.347"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Sailfish.TestAdapter" Version="0.0.349" PrivateAssets="All" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -7,16 +7,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.345" />
-        <PackageReference Include="Serilog" Version="2.12.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.347"/>
+        <PackageReference Include="Serilog" Version="2.12.0"/>
+        <PackageReference Include="Shouldly" Version="4.1.0"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Demo.API\Demo.API.csproj" />
-        <ProjectReference Include="..\Sailfish\Sailfish.csproj" />
+        <ProjectReference Include="..\Demo.API\Demo.API.csproj"/>
+        <ProjectReference Include="..\Sailfish\Sailfish.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.347"/>
-        <PackageReference Include="Serilog" Version="2.12.0"/>
-        <PackageReference Include="Shouldly" Version="4.1.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.0.349" PrivateAssets="All" />
+        <PackageReference Include="Serilog" Version="2.12.0" />
+        <PackageReference Include="Shouldly" Version="4.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Sailfish.TestAdapter/Execution/ConsoleWriter.cs
+++ b/source/Sailfish.TestAdapter/Execution/ConsoleWriter.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
-using Accord.Collections;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Sailfish.Execution;
 using Sailfish.Presentation;
 using Sailfish.Presentation.Console;
 using Serilog;
 using Serilog.Core;
+using System.Collections.Specialized;
 
 namespace Sailfish.TestAdapter.Execution;
 
@@ -27,7 +27,7 @@ internal class ConsoleWriter : IConsoleWriter
         this.messageLogger = messageLogger;
     }
 
-    public string Present(IEnumerable<IExecutionSummary> results, OrderedDictionary<string, string>? tags = null)
+    public string Present(IEnumerable<IExecutionSummary> results, OrderedDictionary? tags = null)
     {
         var summaryResults = results.ToList();
         foreach (var result in summaryResults)

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -5,9 +5,8 @@
         <Version>0.0.111</Version>
         <Authors>Paul E. Gradie</Authors>
         <Description>
-            Sailfish is a simple, unambitious, low resolution performace test framework for writing clean, manageable performance tests
-            against your component or API. The general intention is to provide a simple tool that teams can use to write straight forward
-            tests that assess the speed of your code, without weighing you down with all the extra ceremony.
+            Sailfish is a user friendly performace test suite for writing clean, manageable performance tests
+            against your component or API - without with all the extra ceremony.
         </Description>
         <RootNamespace>Sailfish.TestAdapter</RootNamespace>
         <TargetFramework>net6.0</TargetFramework>
@@ -31,11 +30,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
-        <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
+        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
+        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2"/>
+        <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj"/>

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -38,6 +38,6 @@
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Sailfish\Sailfish.csproj" />
+        <ProjectReference Include="..\Sailfish\Sailfish.csproj"/>
     </ItemGroup>
 </Project>

--- a/source/Sailfish/Analysis/ITrackingFileFinder.cs
+++ b/source/Sailfish/Analysis/ITrackingFileFinder.cs
@@ -1,8 +1,8 @@
-﻿using Accord.Collections;
+﻿using System.Collections.Specialized;
 
 namespace Sailfish.Analysis;
 
 internal interface ITrackingFileFinder
 {
-    BeforeAndAfterTrackingFiles GetBeforeAndAfterTrackingFiles(string directory, string beforeTarget, OrderedDictionary<string, string> tags);
+    BeforeAndAfterTrackingFiles GetBeforeAndAfterTrackingFiles(string directory, string beforeTarget, OrderedDictionary tags);
 }

--- a/source/Sailfish/Analysis/TrackingFileFinder.cs
+++ b/source/Sailfish/Analysis/TrackingFileFinder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
-using Accord.Collections;
 using Sailfish.Presentation;
 
 namespace Sailfish.Analysis;
@@ -14,23 +14,13 @@ internal class TrackingFileFinder : ITrackingFileFinder
         this.trackingFileDirectoryReader = trackingFileDirectoryReader;
     }
 
-    public BeforeAndAfterTrackingFiles GetBeforeAndAfterTrackingFiles(string directory, string beforeTarget, OrderedDictionary<string, string> tags)
+    public BeforeAndAfterTrackingFiles GetBeforeAndAfterTrackingFiles(string directory, string beforeTarget, OrderedDictionary tags)
     {
         var files = trackingFileDirectoryReader.FindTrackingFilesInDirectoryOrderedByLastModified(directory);
-        //
-        // string? beforeTargetOverride = null;
-        // if (!string.IsNullOrEmpty(beforeTarget) && !string.IsNullOrWhiteSpace(beforeTarget))
-        // {
-        //     beforeTargetOverride = files.Select(Path.GetFileName).SingleOrDefault(x => x?.ToLowerInvariant() == beforeTarget);
-        //     if (beforeTargetOverride is null)
-        //     {
-        //         throw new SailfishException("The file name provided for the before target was not found");
-        //     }
-        // }
 
-        if (tags.Any())
+        if (tags.Count > 0)
         {
-            var joinedTags = DefaultFileSettings.JoinTags(tags); // empty string
+            var joinedTags = DefaultFileSettings.JoinTags(tags);
             files = files.Where(x => x.Replace(DefaultFileSettings.TrackingSuffix, string.Empty).EndsWith(joinedTags)).ToList();
         }
         else

--- a/source/Sailfish/Contracts/Private/WriteToConsoleCommand.cs
+++ b/source/Sailfish/Contracts/Private/WriteToConsoleCommand.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
-using Accord.Collections;
 using MediatR;
 using Sailfish.Execution;
+using System.Collections.Specialized;
 
 namespace Sailfish.Contracts.Private;
 
 internal class WriteToConsoleCommand : INotification
 {
-    public WriteToConsoleCommand(List<IExecutionSummary> content, OrderedDictionary<string, string> tags, IRunSettings settings)
+    public WriteToConsoleCommand(List<IExecutionSummary> content, OrderedDictionary tags, IRunSettings settings)
     {
         Content = content;
         Tags = tags;
@@ -15,6 +15,6 @@ internal class WriteToConsoleCommand : INotification
     }
 
     public List<IExecutionSummary> Content { get; set; }
-    public OrderedDictionary<string, string> Tags { get; }
+    public OrderedDictionary Tags { get; }
     public IRunSettings Settings { get; }
 }

--- a/source/Sailfish/Contracts/Private/WriteToCsvCommand.cs
+++ b/source/Sailfish/Contracts/Private/WriteToCsvCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 using Sailfish.Execution;
 
@@ -12,8 +12,8 @@ internal class WriteToCsvCommand : INotification
         List<IExecutionSummary> content,
         string outputDirectory,
         DateTime timeStamp,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args,
+        OrderedDictionary tags,
+        OrderedDictionary args,
         IRunSettings settings)
     {
         Content = content;
@@ -27,7 +27,7 @@ internal class WriteToCsvCommand : INotification
     public List<IExecutionSummary> Content { get; set; }
     public string OutputDirectory { get; set; }
     public DateTime TimeStamp { get; }
-    public OrderedDictionary<string, string> Tags { get; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; }
+    public OrderedDictionary Args { get; }
     public IRunSettings Settings { get; }
 }

--- a/source/Sailfish/Contracts/Private/WriteToMarkDownCommand.cs
+++ b/source/Sailfish/Contracts/Private/WriteToMarkDownCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 using Sailfish.Execution;
 
@@ -8,7 +8,7 @@ namespace Sailfish.Contracts.Private;
 
 internal class WriteToMarkDownCommand : INotification
 {
-    public WriteToMarkDownCommand(List<IExecutionSummary> content, string outputDirectory, DateTime timeStamp, OrderedDictionary<string, string> tags, OrderedDictionary<string, string> args, IRunSettings settings)
+    public WriteToMarkDownCommand(List<IExecutionSummary> content, string outputDirectory, DateTime timeStamp, OrderedDictionary tags, OrderedDictionary args, IRunSettings settings)
     {
         Content = content;
         OutputDirectory = outputDirectory;
@@ -21,7 +21,7 @@ internal class WriteToMarkDownCommand : INotification
     public List<IExecutionSummary> Content { get; set; }
     public string OutputDirectory { get; set; }
     public DateTime TimeStamp { get; }
-    public OrderedDictionary<string, string> Tags { get; set; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; set; }
+    public OrderedDictionary Args { get; }
     public IRunSettings Settings { get; }
 }

--- a/source/Sailfish/Contracts/Public/Commands/BeforeAndAfterFileLocationCommand.cs
+++ b/source/Sailfish/Contracts/Public/Commands/BeforeAndAfterFileLocationCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 
 namespace Sailfish.Contracts.Public.Commands;
@@ -8,9 +8,9 @@ public class BeforeAndAfterFileLocationCommand : IRequest<BeforeAndAfterFileLoca
 {
     public BeforeAndAfterFileLocationCommand(
         string trackingDirectory,
-        OrderedDictionary<string, string> tags,
+        OrderedDictionary tags,
         IEnumerable<string> providedBeforeTrackingFiles,
-        OrderedDictionary<string, string> args)
+        OrderedDictionary args)
     {
         TrackingDirectory = trackingDirectory;
         Tags = tags;
@@ -19,7 +19,7 @@ public class BeforeAndAfterFileLocationCommand : IRequest<BeforeAndAfterFileLoca
     }
 
     public string TrackingDirectory { get; set; }
-    public OrderedDictionary<string, string> Tags { get; }
+    public OrderedDictionary Tags { get; }
     public IEnumerable<string> ProvidedBeforeTrackingFiles { get; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Args { get; }
 }

--- a/source/Sailfish/Contracts/Public/Commands/NotifyOnTestResultCommand.cs
+++ b/source/Sailfish/Contracts/Public/Commands/NotifyOnTestResultCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 using Sailfish.Analysis;
 
@@ -11,8 +11,8 @@ public class NotifyOnTestResultCommand : INotification
         TestResultFormats testResultFormats,
         TestSettings testSettings,
         DateTime timeStamp,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args)
+        OrderedDictionary tags,
+        OrderedDictionary args)
     {
         TestResultFormats = testResultFormats;
         TestSettings = testSettings;
@@ -24,6 +24,6 @@ public class NotifyOnTestResultCommand : INotification
     public TestResultFormats TestResultFormats { get; }
     public TestSettings TestSettings { get; }
     public DateTime TimeStamp { get; }
-    public OrderedDictionary<string, string> Tags { get; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; }
+    public OrderedDictionary Args { get; }
 }

--- a/source/Sailfish/Contracts/Public/Commands/ReadInBeforeAndAfterDataCommand.cs
+++ b/source/Sailfish/Contracts/Public/Commands/ReadInBeforeAndAfterDataCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 
 namespace Sailfish.Contracts.Public.Commands;
@@ -8,14 +8,14 @@ public class ReadInBeforeAndAfterDataCommand : IRequest<ReadInBeforeAndAfterData
 {
     public IEnumerable<string> BeforeFilePaths { get; set; }
     public IEnumerable<string> AfterFilePaths { get; set; }
-    public OrderedDictionary<string, string> Tags { get; set; }
-    public OrderedDictionary<string, string> Args { get; set; }
+    public OrderedDictionary Tags { get; set; }
+    public OrderedDictionary Args { get; set; }
 
     public ReadInBeforeAndAfterDataCommand(
         IEnumerable<string> beforeFilePaths,
         IEnumerable<string> afterFilePaths,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args)
+        OrderedDictionary tags,
+        OrderedDictionary args)
     {
         BeforeFilePaths = beforeFilePaths;
         AfterFilePaths = afterFilePaths;

--- a/source/Sailfish/Contracts/Public/Commands/WriteCurrentTrackingFileCommand.cs
+++ b/source/Sailfish/Contracts/Public/Commands/WriteCurrentTrackingFileCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 using Sailfish.Presentation;
 
@@ -12,8 +12,8 @@ public class WriteCurrentTrackingFileCommand : INotification
         string trackingFileTrackingFileContent,
         string localOutputDirectory,
         DateTime timeStamp,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args)
+        OrderedDictionary tags,
+        OrderedDictionary args)
     {
         TrackingDataFormats = trackingDataFormats;
         TrackingFileContent = trackingFileTrackingFileContent;
@@ -26,7 +26,7 @@ public class WriteCurrentTrackingFileCommand : INotification
     public ITrackingDataFormats TrackingDataFormats { get; }
     public string TrackingFileContent { get; }
     public string LocalOutputDirectory { get; }
-    public OrderedDictionary<string, string> Tags { get; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; }
+    public OrderedDictionary Args { get; }
     public string DefaultFileName { get; }
 }

--- a/source/Sailfish/Contracts/Public/Commands/WriteTestResultsAsCsvCommand.cs
+++ b/source/Sailfish/Contracts/Public/Commands/WriteTestResultsAsCsvCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 using Sailfish.Analysis;
 
@@ -13,16 +12,16 @@ public class WriteTestResultsAsCsvCommand : INotification
     public IEnumerable<TestCaseResults> CsvFormat { get; }
     public string OutputDirectory { get; }
     public TestSettings TestSettings { get; }
-    public OrderedDictionary<string, string> Tags { get; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; }
+    public OrderedDictionary Args { get; }
 
     public WriteTestResultsAsCsvCommand(
         IEnumerable<TestCaseResults> csvFormat,
         string outputDirectory,
         TestSettings testSettings,
         DateTime timeStamp,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args)
+        OrderedDictionary tags,
+        OrderedDictionary args)
     {
         TimeStamp = timeStamp;
         CsvFormat = csvFormat;

--- a/source/Sailfish/Contracts/Public/Commands/WriteTestResultsAsMarkdownCommand.cs
+++ b/source/Sailfish/Contracts/Public/Commands/WriteTestResultsAsMarkdownCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Accord.Collections;
+using System.Collections.Specialized;
 using MediatR;
 using Sailfish.Analysis;
 
@@ -12,8 +12,8 @@ public class WriteTestResultsAsMarkdownCommand : INotification
         string outputDirectory,
         TestSettings testSettings,
         DateTime timeStamp,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args)
+        OrderedDictionary tags,
+        OrderedDictionary args)
     {
         MarkdownTable = markdownTable;
         OutputDirectory = outputDirectory;
@@ -26,7 +26,7 @@ public class WriteTestResultsAsMarkdownCommand : INotification
     public string MarkdownTable { get; set; }
     public string OutputDirectory { get; set; }
     public DateTime TimeStamp { get; }
-    public OrderedDictionary<string, string> Tags { get; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; }
+    public OrderedDictionary Args { get; }
     public TestSettings TestSettings { get; set; }
 }

--- a/source/Sailfish/Contracts/Public/DescriptiveStatisticsResult.cs
+++ b/source/Sailfish/Contracts/Public/DescriptiveStatisticsResult.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using Accord.Statistics;
+using MathNet.Numerics.Statistics;
 using Sailfish.Analysis;
 using Sailfish.Execution;
 

--- a/source/Sailfish/IRunSettings.cs
+++ b/source/Sailfish/IRunSettings.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using Sailfish.Analysis;
 
 namespace Sailfish;
@@ -15,8 +15,8 @@ public interface IRunSettings
     TestSettings Settings { get; }
     IEnumerable<Type> TestLocationAnchors { get; }
     IEnumerable<Type> RegistrationProviderAnchors { get; }
-    OrderedDictionary<string, string> Tags { get; set; }
-    OrderedDictionary<string, string> Args { get; }
+    OrderedDictionary Tags { get; set; }
+    OrderedDictionary Args { get; }
     IEnumerable<string> ProvidedBeforeTrackingFiles { get; }
     DateTime? TimeStamp { get; }
     bool Debug { get; set; }

--- a/source/Sailfish/Presentation/Console/ConsoleWriter.cs
+++ b/source/Sailfish/Presentation/Console/ConsoleWriter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using Accord.Collections;
+using System.Collections.Specialized;
 using Sailfish.Execution;
 
 namespace Sailfish.Presentation.Console;
@@ -15,14 +15,14 @@ internal class ConsoleWriter : IConsoleWriter
         this.markdownTableConverter = markdownTableConverter;
     }
 
-    public string Present(IEnumerable<IExecutionSummary> results, OrderedDictionary<string, string> tags)
+    public string Present(IEnumerable<IExecutionSummary> results, OrderedDictionary tags)
     {
         var markdownStringTable = markdownTableConverter.ConvertToMarkdownTableString(results);
 
-        if (tags.Any()) System.Console.WriteLine($"{Environment.NewLine}Tags:");
-        foreach (var (key, value) in tags)
+        if ((tags.Count > 0)) System.Console.WriteLine($"{Environment.NewLine}Tags:");
+        foreach (DictionaryEntry entry in tags)
         {
-            System.Console.WriteLine($"{key}: {value}");
+            System.Console.WriteLine($"{entry.Key}: {entry.Value}");
         }
 
         System.Console.WriteLine(markdownStringTable);

--- a/source/Sailfish/Presentation/Console/IConsoleWriter.cs
+++ b/source/Sailfish/Presentation/Console/IConsoleWriter.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using Sailfish.Execution;
 
 namespace Sailfish.Presentation.Console;
 
 internal interface IConsoleWriter
 {
-    string Present(IEnumerable<IExecutionSummary> result, OrderedDictionary<string, string> tags);
-}   
+    string Present(IEnumerable<IExecutionSummary> result, OrderedDictionary tags);
+}

--- a/source/Sailfish/Presentation/DefaultFileSettings.cs
+++ b/source/Sailfish/Presentation/DefaultFileSettings.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Accord.Collections;
 using Sailfish.Analysis;
 using Sailfish.Exceptions;
 
@@ -20,7 +21,7 @@ public static class DefaultFileSettings
     public const string MapDelimiter = "__";
     public const string DefaultTrackingDirectory = "sailfish_tracking_output";
     public const string DefaultOutputDirectory = "sailfish_default_output";
-    
+
     public static readonly Func<DateTime, string> DefaultPerformanceFileNameStem =
         (DateTime timestamp) =>
             $"PerformanceResults_{timestamp.ToString(SortableFormat)}"; // sortable file name with date
@@ -34,24 +35,24 @@ public static class DefaultFileSettings
     public static readonly Func<DateTime, string> DefaultTrackingFileName = (timeStamp) =>
         $"PerformanceTracking_{timeStamp.ToLocalTime().ToString(SortableFormat)}{TrackingSuffix}";
 
-    public static string JoinTags(OrderedDictionary<string, string> tags)
+    public static string JoinTags(OrderedDictionary tags)
     {
-        if (!tags.Any()) return string.Empty;
+        if (!(tags.Count > 0)) return string.Empty;
 
         var result = new StringBuilder();
         result.Append(TagsPrefix);
-        foreach (var tagPair in tags)
+        foreach (DictionaryEntry entry in tags)
         {
-            var joinedTag = string.Join(KeyValueDelimiter, tagPair.Key, tagPair.Value);
+            var joinedTag = string.Join(KeyValueDelimiter, entry.Key, entry.Value);
             result.Append(joinedTag + MapDelimiter);
         }
 
         return result.ToString().TrimEnd(MapDelimiter.ToCharArray());
     }
 
-    public static string AppendTagsToFilename(string fileName, OrderedDictionary<string, string> tags)
+    public static string AppendTagsToFilename(string fileName, OrderedDictionary tags)
     {
-        if (!tags.Any()) return fileName;
+        if (!(tags.Count > 0)) return fileName;
         var joinedTags = JoinTags(tags);
 
         if (fileName.EndsWith(TrackingSuffix))

--- a/source/Sailfish/Program/SailfishProgramBase.cs
+++ b/source/Sailfish/Program/SailfishProgramBase.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Accord.Collections;
 using Autofac;
 using McMaster.Extensions.CommandLineUtils;
 using Sailfish.Execution;
@@ -17,7 +17,7 @@ namespace Sailfish.Program;
 
 public abstract class SailfishProgramBase
 {
-    public static SailfishRunResult RunResult { get; set; } = null!;
+    protected static SailfishRunResult RunResult { get; set; } = null!;
 
     protected static async Task SailfishMain<TProgram>(string[] userRequestedTestNames) where TProgram : class
     {
@@ -71,13 +71,13 @@ public abstract class SailfishProgramBase
             Directories.EnsureDirectoryExists(TrackingDirectory);
         }
 
-        var parsedTags = new OrderedDictionary<string, string>();
+        var parsedTags = new OrderedDictionary();
         if (Tags is not null)
         {
             parsedTags = ColonParser.Parse(Tags);
         }
 
-        var parsedArgs = new OrderedDictionary<string, string>();
+        var parsedArgs = new OrderedDictionary();
         if (Args is not null)
         {
             parsedArgs = ColonParser.Parse(Args);

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using Sailfish.Analysis;
 
 namespace Sailfish;
@@ -15,8 +15,8 @@ internal class RunSettings : IRunSettings
     public TestSettings Settings { get; }
     public IEnumerable<Type> TestLocationAnchors { get; }
     public IEnumerable<Type> RegistrationProviderAnchors { get; }
-    public OrderedDictionary<string, string> Tags { get; set; }
-    public OrderedDictionary<string, string> Args { get; }
+    public OrderedDictionary Tags { get; set; }
+    public OrderedDictionary Args { get; }
     public IEnumerable<string> ProvidedBeforeTrackingFiles { get; }
     public DateTime? TimeStamp { get; }
     public bool Debug { get; set; }
@@ -28,8 +28,8 @@ internal class RunSettings : IRunSettings
         bool analyze,
         bool notify,
         TestSettings settings,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args,
+        OrderedDictionary tags,
+        OrderedDictionary args,
         IEnumerable<string> providedBeforeTrackingFiles,
         DateTime? timeStamp,
         IEnumerable<Type> testLocationAnchors,
@@ -57,8 +57,8 @@ internal class RunSettings : IRunSettings
         bool analyze,
         bool notify,
         TestSettings settings,
-        OrderedDictionary<string, string> tags,
-        OrderedDictionary<string, string> args,
+        OrderedDictionary tags,
+        OrderedDictionary args,
         IEnumerable<string> providedBeforeTrackingFiles,
         DateTime? timeStamp,
         IEnumerable<Type> testLocationAnchors,
@@ -87,8 +87,8 @@ internal class RunSettings : IRunSettings
         Settings = new TestSettings(0.001, 3);
         TestLocationAnchors = new[] { GetType() };
         RegistrationProviderAnchors = new[] { GetType() };
-        Tags = new OrderedDictionary<string, string>();
-        Args = new OrderedDictionary<string, string>();
+        Tags = new OrderedDictionary();
+        Args = new OrderedDictionary();
         ProvidedBeforeTrackingFiles = Array.Empty<string>();
     }
 }

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Accord.Collections;
+using System.Collections.Specialized;
 using Sailfish.Analysis;
 using Sailfish.Presentation;
 
@@ -16,8 +16,8 @@ public class RunSettingsBuilder
     private readonly List<Type> testAssembliesAnchorTypes = new();
     private readonly List<Type> registrationProviderAnchorTypes = new();
     private readonly List<string> providedBeforeTrackingFiles = new();
-    private OrderedDictionary<string, string> tags = new();
-    private OrderedDictionary<string, string> args = new();
+    private OrderedDictionary tags = new();
+    private OrderedDictionary args = new();
     private string? localOutputDir;
     private TestSettings? tSettings;
     private DateTime? timeStamp;
@@ -94,7 +94,7 @@ public class RunSettingsBuilder
         return this;
     }
 
-    public RunSettingsBuilder WithTags(OrderedDictionary<string, string> tags)
+    public RunSettingsBuilder WithTags(OrderedDictionary tags)
     {
         this.tags = tags;
         return this;
@@ -107,7 +107,7 @@ public class RunSettingsBuilder
         return this;
     }
 
-    public RunSettingsBuilder WithArgs(OrderedDictionary<string, string> args)
+    public RunSettingsBuilder WithArgs(OrderedDictionary args)
     {
         this.args = args;
         return this;

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -4,7 +4,7 @@
         <Version>0.0.117</Version>
         <Authors>Paul E. Gradie</Authors>
         <Description>
-            Sailfish is a simple, unambitious, low resolution performace test framework for writing clean, manageable performance tests
+            Sailfish is a simple in-process performace test framework for writing clean, manageable performance tests
             against your component or API. The general intention is to provide a simple tool that teams can use to write straight forward
             tests that assess the speed of your code, without weighing you down with all the extra ceremony.
         </Description>
@@ -22,20 +22,21 @@
         <RepositoryUrl>https://github.com/paulegradie/Sailfish</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Accord.Statistics" Version="3.8.0" />
-        <PackageReference Include="Autofac" Version="4.9.2" />
-        <PackageReference Include="CsvHelper" Version="30.0.1" />
-        <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="All" />
-        <PackageReference Include="MediatR" Version="11.1.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-        <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
-        <PackageReference Include="Serilog" Version="2.12.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+        <PackageReference Include="Accord.Statistics" Version="3.8.0" PrivateAssets="All"/>
+        <PackageReference Include="MathNet.Numerics" Version="5.0.0" PrivateAssets="All"/>
+        <PackageReference Include="Autofac" Version="4.9.2"/>
+        <PackageReference Include="CsvHelper" Version="30.0.1"/>
+        <PackageReference Include="MediatR" Version="11.1.0"/>
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2"/>
+        <PackageReference Include="System.Collections.Specialized" Version="4.3.0"/>
+        <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageReference Include="System.Runtime.Caching" Version="7.0.0"/>
+        <PackageReference Include="Serilog" Version="2.12.0"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
+        <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0"/>
     </ItemGroup>
 </Project>

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -22,8 +22,8 @@
         <RepositoryUrl>https://github.com/paulegradie/Sailfish</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Accord.Statistics" Version="3.8.0" PrivateAssets="All"/>
-        <PackageReference Include="MathNet.Numerics" Version="5.0.0" PrivateAssets="All"/>
+        <PackageReference Include="Accord.Statistics" Version="3.8.0"/>
+        <PackageReference Include="MathNet.Numerics" Version="5.0.0"/>
         <PackageReference Include="Autofac" Version="4.9.2"/>
         <PackageReference Include="CsvHelper" Version="30.0.1"/>
         <PackageReference Include="MediatR" Version="11.1.0"/>

--- a/source/Sailfish/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTestSailfish.cs
+++ b/source/Sailfish/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTestSailfish.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Accord.Statistics;
 using Accord.Statistics.Testing;
+using MathNet.Numerics.Statistics;
 using Sailfish.Analysis;
 using Sailfish.Contracts;
 

--- a/source/Sailfish/Utils/ColonParser.cs
+++ b/source/Sailfish/Utils/ColonParser.cs
@@ -1,12 +1,12 @@
-﻿using Accord.Collections;
+﻿using System.Collections.Specialized;
 
 namespace Sailfish.Utils;
 
 internal static class ColonParser
 {
-    public static OrderedDictionary<string, string> Parse(string[]? tags)
+    public static OrderedDictionary Parse(string[]? tags)
     {
-        var keyValues = new OrderedDictionary<string, string>();
+        var keyValues = new OrderedDictionary();
         if (tags is null) return keyValues;
 
         foreach (var tag in tags)

--- a/source/Tests.Sailfish.TestAdapter/Tests.Sailfish.TestAdapter.csproj
+++ b/source/Tests.Sailfish.TestAdapter/Tests.Sailfish.TestAdapter.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="NSubstitute" Version="4.4.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/source/Tests.Sailfish/Tests.Sailfish.csproj
+++ b/source/Tests.Sailfish/Tests.Sailfish.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
         <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
## Description

There is a general intention to rely on as few external packages as possible - so we've moved off of accord's OrderedDictionary implementation. (In the future, we'll reimplement the command line to use the new microsoft package). 

In addition, we can improve sailfish packaging and not expose certain things that shouldn't be, like abstraction.dlls and the testhost. In general, we don't really even need to reference the test host - since sailfish isn't intended to executed via the dotnet test cli. The test adapter only facilitates local execution in an IDE - since there is no way currently to implement tracking data handling via the test adapter.

## Results
 - uses `using System.Collections.Specialized;` isntead of Accords OrderedDictionary
 -  switches the object model to private assets
 - preferes Math.Numerics for all things except the stat test implementations