### PR TITLE
Rewrite line-finder to only find in the right class

### DIFF
--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.349"
+$version="0.0.355"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/WeirdBehaviorTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/WeirdBehaviorTest.cs
@@ -1,0 +1,60 @@
+﻿using System.Text;
+using Sailfish.Attributes;
+
+namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
+
+[Sailfish(NumIterations = 6)]
+public class ExampleComponentTest
+{
+    public const string A = "Wow";
+    public const string B = "SoFast";
+
+    [SailfishVariable(10000, 100000, 1000000)]
+    public int N { get; set; }
+
+    [SailfishMethod]
+    public void Interpolate()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            ExampleOctopusComponent.InterpolateStrings(A, B);
+        }
+    }
+
+    [SailfishMethod]
+    public void Concatenate()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            ExampleOctopusComponent.ConcatenateStrings(A, B);
+        }
+    }
+
+    [SailfishMethod]
+    public void StringBuilder()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            ExampleOctopusComponent.StringBuilder(A, B);
+        }
+    }
+}
+
+public class ExampleOctopusComponent
+{
+    public static string InterpolateStrings(string a, string b)
+    {
+        return $"{a}-{b}";
+    }
+
+    public static string ConcatenateStrings(string a, string b)
+    {
+        return a + "-" + b;
+    }
+
+    public static string StringBuilder(string a, string b)
+    {
+        var builder = new StringBuilder();
+        return builder.Append(a).Append('-').Append(b).ToString();
+    }
+}

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>11</LangVersion>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Sailfish.TestAdapter" Version="0.1.163" PrivateAssets="All" />
+        <PackageReference Include="Sailfish.TestAdapter" Version="0.1.164" PrivateAssets="All" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
     </ItemGroup>

--- a/source/Tests.Sailfish.TestAdapter/TestResources/DuplicateMethodNameInFileScenario.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestResources/DuplicateMethodNameInFileScenario.cs
@@ -3,7 +3,7 @@ using Sailfish.Attributes;
 
 namespace Tests.Sailfish.TestAdapter.TestResources;
 
-[Sailfish(NumIterations = 6)]
+[Sailfish(Disabled = true)]
 public class ExampleComponentTest
 {
     public const string A = "Wow";
@@ -17,7 +17,7 @@ public class ExampleComponentTest
     {
         for (var i = 0; i < N; i++)
         {
-            ExampleOctopusComponent.InterpolateStrings(A, B);
+            ExampleComponent.InterpolateStrings(A, B);
         }
     }
 
@@ -26,7 +26,7 @@ public class ExampleComponentTest
     {
         for (var i = 0; i < N; i++)
         {
-            ExampleOctopusComponent.ConcatenateStrings(A, B);
+            ExampleComponent.ConcatenateStrings(A, B);
         }
     }
 
@@ -35,12 +35,12 @@ public class ExampleComponentTest
     {
         for (var i = 0; i < N; i++)
         {
-            ExampleOctopusComponent.StringBuilder(A, B);
+            ExampleComponent.StringBuilder(A, B);
         }
     }
 }
 
-public class ExampleOctopusComponent
+public class ExampleComponent
 {
     public static string InterpolateStrings(string a, string b)
     {

--- a/source/Tests.Sailfish.TestAdapter/TestResources/DuplicateMethodNameInFileScenario.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestResources/DuplicateMethodNameInFileScenario.cs
@@ -1,0 +1,60 @@
+﻿using System.Text;
+using Sailfish.Attributes;
+
+namespace Tests.Sailfish.TestAdapter.TestResources;
+
+[Sailfish(NumIterations = 6)]
+public class ExampleComponentTest
+{
+    public const string A = "Wow";
+    public const string B = "SoFast";
+
+    [SailfishVariable(1, 10, 100)]
+    public int N { get; set; }
+
+    [SailfishMethod]
+    public void Interpolate()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            ExampleOctopusComponent.InterpolateStrings(A, B);
+        }
+    }
+
+    [SailfishMethod]
+    public void Concatenate()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            ExampleOctopusComponent.ConcatenateStrings(A, B);
+        }
+    }
+
+    [SailfishMethod]
+    public void StringBuilder()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            ExampleOctopusComponent.StringBuilder(A, B);
+        }
+    }
+}
+
+public class ExampleOctopusComponent
+{
+    public static string InterpolateStrings(string a, string b)
+    {
+        return $"{a}-{b}";
+    }
+
+    public static string ConcatenateStrings(string a, string b)
+    {
+        return a + "-" + b;
+    }
+
+    public static string StringBuilder(string a, string b)
+    {
+        var builder = new StringBuilder();
+        return builder.Append(a).Append('-').Append(b).ToString();
+    }
+}

--- a/source/Tests.Sailfish.TestAdapter/TestResources/TestResourceDoNotRename.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestResources/TestResourceDoNotRename.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using Sailfish.Attributes;
 
 namespace Tests.Sailfish.TestAdapter.TestResources;

--- a/source/Tests.Sailfish.TestAdapter/WhenDiscoveringTests.cs
+++ b/source/Tests.Sailfish.TestAdapter/WhenDiscoveringTests.cs
@@ -17,7 +17,7 @@ public class WhenDiscoveringTests
         // Assumes there is one valid test file.
         // And The discoverer tests will be those found from inside the 
         var testCases = TestDiscovery.DiscoverTests(sources, new LoggerHelper()).ToList();
-        testCases.Count.ShouldBe(7);
+        testCases.Count.ShouldBe(16);
     }
 
     [Fact]
@@ -26,6 +26,6 @@ public class WhenDiscoveringTests
         var sources = DllFinder.FindAllDllsRecursively();
         var testCases = TestDiscovery.DiscoverTests(sources, new LoggerHelper()).ToList();
         var aTestCase = testCases.First();
-        aTestCase.DisplayName.ShouldBe("TestClassWithRegistrationProviderDependency.ExecutionMethodB()");
+        aTestCase.DisplayName.ShouldBe("ExampleComponentTest.Interpolate(N: 1)");
     }
 }

--- a/source/Tests.Sailfish/E2EScenarios/FullE2EExceptionCases.cs
+++ b/source/Tests.Sailfish/E2EScenarios/FullE2EExceptionCases.cs
@@ -6,7 +6,7 @@ using Tests.E2E.ExceptionHandling;
 using Tests.E2E.ExceptionHandling.Tests;
 using Xunit;
 
-namespace Test.Execution;
+namespace Test.E2EScenarios;
 
 public class FullE2EExceptionCases
 {

--- a/source/Tests.Sailfish/E2EScenarios/FullE2EFixture.cs
+++ b/source/Tests.Sailfish/E2EScenarios/FullE2EFixture.cs
@@ -5,7 +5,7 @@ using Shouldly;
 using Tests.E2ETestSuite;
 using Xunit;
 
-namespace Test.Execution;
+namespace Test.E2EScenarios;
 
 public class FullE2EFixture
 {


### PR DESCRIPTION
## Description

The line finder in the test adapter test discovered previously would throw when multiple methods with the same name as the primary sailfish method were in the given file. This PR fixes that by modifying the implementation to determine if the line is from the current test case class.


## Results
TestAdapter shouldn't throw when multiple methods with the same name are present in the same file.