### PR TITLE
Inject testCaseId when requested

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Pack
         run: dotnet pack ./source/Sailfish/Sailfish.csproj --configuration Release /p:Version=${{ env.VERSION }} --no-build --output .
 
-      - name: Push
-        run: dotnet nuget push Sailfish.${{ env.VERSION }}.nupkg --source https://www.nuget.org --api-key ${{secrets.NUGET_API_KEY}}
-
       - name: Pack Adapter
         run: dotnet pack ./source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj --configuration Release /p:Version=${{ env.VERSION }} --no-build --output .
+
+      - name: Push
+        run: dotnet nuget push Sailfish.${{ env.VERSION }}.nupkg --source https://www.nuget.org --api-key ${{secrets.NUGET_API_KEY}}
 
       - name: Push Adapter
         run: dotnet nuget push Sailfish.TestAdapter.${{ env.VERSION }}.nupkg --source https://www.nuget.org --api-key ${{secrets.NUGET_API_KEY}}

--- a/packageTestAdapter.ps1
+++ b/packageTestAdapter.ps1
@@ -1,5 +1,5 @@
 # manually increment this until you figure out how to autoincrement :D
-$version="0.0.380"
+$version="0.0.381"
 $path = "../SailfishLocalPackages"
 If(!(test-path -PathType container $path))
 {

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -37,6 +37,6 @@
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.5.0" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Sailfish\Sailfish.csproj" />
+        <ProjectReference Include="..\Sailfish\Sailfish.csproj" IncludeAssets="All" />
     </ItemGroup>
 </Project>

--- a/source/Sailfish/Execution/ITypeActivator.cs
+++ b/source/Sailfish/Execution/ITypeActivator.cs
@@ -1,8 +1,9 @@
 using System;
+using Sailfish.Analysis;
 
 namespace Sailfish.Execution;
 
 public interface ITypeActivator
 {
-    object CreateDehydratedTestInstance(Type test);
+    object CreateDehydratedTestInstance(Type test, TestCaseId testCaseId);
 }

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -45,7 +45,6 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         Action<TestInstanceContainer?>? exceptionCallback = null,
         CancellationToken cancellationToken = default)
     {
-
         if (testProviderIndex > totalTestProviderCount)
         {
             throw new SailfishException($"The test provider index {testProviderIndex} cannot be greater than total test provider count {totalTestProviderCount}");

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Sailfish.Utils;
 
 namespace Sailfish.Execution;
 
@@ -34,19 +35,21 @@ internal class TestInstanceContainerProvider
     {
         if (GetNumberOfPropertySetsInTheQueue() is 0)
         {
-            var instance = typeActivator.CreateDehydratedTestInstance(Test);
+            var testCaseId = DisplayNameHelper.CreateTestCaseId(Test, Method.Name, Array.Empty<string>(), Array.Empty<object>()); // a uniq id
+            var instance = typeActivator.CreateDehydratedTestInstance(Test, testCaseId);
             yield return TestInstanceContainer.CreateTestInstance(instance, Method, Array.Empty<string>(), Array.Empty<object>());
         }
         else
         {
             foreach (var nextPropertySet in propertySets)
             {
-                var instance = typeActivator.CreateDehydratedTestInstance(Test);
-
-                HydrateInstance(instance, nextPropertySet);
-
                 var propertyNames = nextPropertySet.GetPropertyNames().ToArray();
                 var variableValues = nextPropertySet.GetPropertyValues().ToArray();
+                var testCaseId = DisplayNameHelper.CreateTestCaseId(Test, Method.Name, propertyNames, variableValues); // a uniq id
+
+                var instance = typeActivator.CreateDehydratedTestInstance(Test, testCaseId);
+                HydrateInstance(instance, nextPropertySet);
+
                 yield return TestInstanceContainer.CreateTestInstance(instance, Method, propertyNames, variableValues);
             }
         }

--- a/source/Tests.E2ETestSuite/Discoverable/ResolveTestCaseIdTest.cs
+++ b/source/Tests.E2ETestSuite/Discoverable/ResolveTestCaseIdTest.cs
@@ -1,0 +1,39 @@
+﻿using Sailfish.Analysis;
+using Sailfish.Attributes;
+using Shouldly;
+using Tests.E2ETestSuite.Utils;
+
+namespace Tests.E2ETestSuite.Discoverable;
+
+[Sailfish]
+public class ResolveTestCaseIdTest
+{
+    private readonly TestCaseId testCaseId;
+
+    public ResolveTestCaseIdTest(TestCaseId testCaseId)
+    {
+        this.testCaseId = testCaseId;
+    }
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        testCaseId.DisplayName.ShouldBe($"{nameof(ResolveTestCaseIdTest)}.{nameof(MainMethod)}()");
+    }
+}
+
+[Sailfish]
+public class ResolveTestCaseIdTestMultipleCtorArgs
+{
+    private readonly TestCaseId testCaseId;
+
+    public ResolveTestCaseIdTestMultipleCtorArgs(ExampleDependencyForAltRego dep, TestCaseId testCaseId)
+    {
+        this.testCaseId = testCaseId;
+    }
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        testCaseId.DisplayName.ShouldBe($"{nameof(ResolveTestCaseIdTestMultipleCtorArgs)}.{nameof(MainMethod)}()");
+    }
+}
+

--- a/source/Tests.Sailfish/E2EScenarios/FullE2EFixture.cs
+++ b/source/Tests.Sailfish/E2EScenarios/FullE2EFixture.cs
@@ -27,7 +27,7 @@ public class FullE2EFixture
 
     // will need to update this if more tests are added to the the project
     [Fact]
-    public async Task AFullTestRunOfTheDemoShouldFind8Tests()
+    public async Task AFullTestRunOfTheDemoShouldFind11Tests()
     {
         var runSettings = RunSettingsBuilder.CreateBuilder()
             .RegistrationProvidersFromAssembliesFromAnchorTypes(typeof(E2ETestRegistrationProvider))
@@ -37,6 +37,6 @@ public class FullE2EFixture
         var result = await SailfishRunner.Run(runSettings);
 
         result.IsValid.ShouldBe(true);
-        result.ExecutionSummaries.Count().ShouldBe(9);
+        result.ExecutionSummaries.Count().ShouldBe(11);
     }
 }


### PR DESCRIPTION
## Description

A useful feature for Saiflish when running in a production regression detection system is to be able to resovle the current test case ID for tracking purposes (e.g. if you'd like to write the current unique test identifier name to a meta data dict in whichyou associate certain test specific pieces of information.

## Results

If you request a TestCaseId (a sailfish type), it will be injected.