### PR TITLE
Fix test discovery edge case bug

### DIFF
--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -108,9 +108,13 @@ internal static class TestCaseItemCreator
         var currentlyInTheRightClass = false;
         var index = 0;
         var methodLine = 0;
-        foreach (var fileLine in fileLines)
+        var methodKey = $" {method.Name}(";
+        var classKey = $"class {testType.Name}";
+
+        foreach (var line in fileLines)
         {
-            if (fileLine.Contains($"class {testType.Name}"))
+            var fileLine = line.Trim().Split("//").First();
+            if (fileLine.Contains(classKey))
             {
                 currentlyInTheRightClass = true;
             }
@@ -119,7 +123,6 @@ internal static class TestCaseItemCreator
                 currentlyInTheRightClass = false;
             }
 
-            var methodKey = $" {method.Name}(";
             if (currentlyInTheRightClass && fileLine.Trim().Contains(methodKey))
             {
                 methodLine = index;

--- a/source/Tests.Sailfish.TestAdapter/TestResources/TestResourceDoNotRename.cs
+++ b/source/Tests.Sailfish.TestAdapter/TestResources/TestResourceDoNotRename.cs
@@ -12,6 +12,7 @@ public class SimplePerfTest
     [SailfishVariable(1_000_000, 4_000_000)]
     public int VariableB { get; set; }
 
+    // class
     [SailfishMethod]
     public void ExecutionMethod()
     {


### PR DESCRIPTION
## Description

Since we're not yet using the rosalyn C# ast analyzer, we're manaully parsing source code and file lines. With the current impl, when the correct test class has a comment like // class with the word 'class' - it breaks discovery.

For now, this will fix this edge case.
