### PR TITLE
Use Microsoft.CodeAnalysis to parse source files

### DIFF
--- a/source/Sailfish.Analyzers/Discovery/ClassMetaData.cs
+++ b/source/Sailfish.Analyzers/Discovery/ClassMetaData.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis;
+
+namespace Sailfish.Analyzers.Discovery;
+
+public sealed class ClassMetaData
+{
+    public ClassMetaData(string filePath, string className, SyntaxTree syntaxTree, MethodMetaData[] methods)
+    {
+        FilePath = filePath;
+        ClassName = className;
+        SyntaxTree = syntaxTree;
+        Methods = methods;
+    }
+
+    public string FilePath { get; set; }
+    public string ClassName { get; set; }
+
+    public SyntaxTree SyntaxTree { get; set; }
+    public MethodMetaData[] Methods { get; set; }
+}

--- a/source/Sailfish.Analyzers/Discovery/DiscoveryAnalysisMethods.cs
+++ b/source/Sailfish.Analyzers/Discovery/DiscoveryAnalysisMethods.cs
@@ -1,0 +1,103 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+// ReSharper disable HeapView.ClosureAllocation
+
+// ReSharper disable HeapView.ObjectAllocation
+// ReSharper disable HeapView.DelegateAllocation
+// ReSharper disable HeapView.BoxingAllocation
+// ReSharper disable HeapView.ObjectAllocation.Evident
+
+
+namespace Sailfish.Analyzers.Discovery;
+
+public static class DiscoveryAnalysisMethods
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="sourceFiles"></param>
+    /// <param name="classAttributePrefix"></param>
+    /// <param name="methodAttributePrefix"></param>
+    /// <returns>Dictionary of className:ClassMetaData</returns>
+    /// <exception cref="Exception"></exception>
+    public static IEnumerable<ClassMetaData> CompilePreRenderedSourceMap(
+        IEnumerable<string> sourceFiles,
+        string classAttributePrefix = "Sailfish",
+        string methodAttributePrefix = "SailfishMethod")
+    {
+        var classMetas = new List<ClassMetaData>();
+        var lockObject = new object();
+        var result = Parallel.ForEach(sourceFiles, filePath =>
+        {
+            string fileContents;
+            try
+            {
+                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var streamReader = new StreamReader(fileStream);
+                fileContents = streamReader.ReadToEnd();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                return;
+            }
+
+            // ReSharper disable once HeapView.ClosureAllocation
+            SyntaxTree syntaxTree;
+            try
+            {
+                syntaxTree = CSharpSyntaxTree.ParseText(fileContents);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                return;
+            }
+
+            var root = syntaxTree.GetCompilationUnitRoot();
+
+            var classDeclarations = root
+                .DescendantNodes()
+                .OfType<ClassDeclarationSyntax>()
+                .Where(cls => cls
+                    .AttributeLists
+                    .SelectMany(attrList => attrList.Attributes)
+                    .Any(attr =>
+                        attr.Name.ToString() == classAttributePrefix || attr.Name.ToString() == $"{classAttributePrefix}Attribute"));
+
+            // ReSharper disable once HeapView.ObjectAllocation.Possible
+            foreach (var classDeclaration in classDeclarations)
+            {
+                var methodDeclarations = classDeclaration
+                    .DescendantNodes()
+                    .OfType<MethodDeclarationSyntax>()
+                    .Where(method => method.AttributeLists
+                        .SelectMany(attrList => attrList.Attributes)
+                        .Any(attr =>
+                            attr.Name.ToString() == methodAttributePrefix
+                            || attr.Name.ToString() == $"{methodAttributePrefix}Attribute"));
+
+                var className = classDeclaration.Identifier.ValueText;
+                var classMetaData = new ClassMetaData(
+                    className: className,
+                    filePath: filePath,
+                    methods: (
+                        from methodDeclaration in methodDeclarations
+                        let lineSpan = syntaxTree.GetLineSpan(methodDeclaration.Span)
+                        let lineNumber = lineSpan.StartLinePosition.Line + 1
+                        select new MethodMetaData(methodName: methodDeclaration.Identifier.ValueText, lineNumber: lineNumber))
+                    .ToArray(),
+                    syntaxTree: syntaxTree);
+
+                lock (lockObject)
+                {
+                    classMetas.Add(classMetaData);
+                }
+            }
+        });
+        if (!result.IsCompleted) throw new Exception("Exception encountered while reading and parsing source files");
+        return classMetas;
+    }
+}

--- a/source/Sailfish.Analyzers/Discovery/MethodMetaData.cs
+++ b/source/Sailfish.Analyzers/Discovery/MethodMetaData.cs
@@ -1,0 +1,13 @@
+namespace Sailfish.Analyzers.Discovery;
+
+public sealed class MethodMetaData
+{
+    public MethodMetaData(string methodName, int lineNumber)
+    {
+        MethodName = methodName;
+        LineNumber = lineNumber;
+    }
+
+    public string MethodName { get; set; }
+    public int LineNumber { get; set; }
+}

--- a/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
+++ b/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
+      <PackageReference Include="Roslyn.Analyzers" Version="1.0.3.4" />
+    </ItemGroup>
+
+</Project>

--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Sailfish.Attributes;
+using Sailfish.Analyzers.Discovery;
 using Sailfish.Execution;
 using Sailfish.TestAdapter.TestProperties;
 using Sailfish.Utils;
@@ -15,55 +14,28 @@ internal static class TestCaseItemCreator
 {
     private static PropertySetGenerator PropertySetGenerator => new(new ParameterCombinator(), new IterationVariableRetriever());
 
-    public static IEnumerable<TestCase> AssembleTestCases(Type testType, List<string> testCsFileContent, string testCsFilePath, string sourceDll, IMessageLogger logger)
+    public static IEnumerable<TestCase> AssembleTestCases(Type testType, ClassMetaData classMetaData, string sourceDll, IMessageLogger logger)
     {
         var testCaseSets = new List<TestCase>();
-        var methods = testType.GetMethodsWithAttribute<SailfishMethodAttribute>()?.ToArray();
-        if (methods is null)
-        {
-            logger.SendMessage(TestMessageLevel.Informational,
-                $"No method with {nameof(SailfishMethodAttribute)} attribute found -- this shouldn't have made it into the test type scan!");
-            return testCaseSets;
-        }
 
         var propertySets = PropertySetGenerator.GeneratePropertySets(testType).ToArray();
-
-        foreach (var method in methods)
+        foreach (var methodMetaData in classMetaData.Methods)
         {
-            var methodNameLine = GetMethodNameLine(testType, testCsFileContent, method, logger);
-            if (methodNameLine == 0) continue;
-
-            if (propertySets.Length > 0)
+            var numToMake = Math.Max(propertySets.Length, 1);
+            for (var i = 0; i < numToMake; i++)
             {
-                foreach (var propertySet in propertySets)
-                {
-                    var propertyNames = propertySet.GetPropertyNames();
-                    var propertyValues = propertySet.GetPropertyValues();
-                    var testCase = CreateTestCase(
-                        testType,
-                        sourceDll,
-                        logger,
-                        method,
-                        propertyNames,
-                        propertyValues);
-                    testCase.CodeFilePath = testCsFilePath;
-                    testCase.ExecutorUri = TestExecutor.ExecutorUri;
-                    testCase.LineNumber = methodNameLine;
-                    testCaseSets.Add(testCase);
-                }
-            }
-            else
-            {
+                var propertyNames = propertySets.Length > 0 ? propertySets[i].GetPropertyNames() : Array.Empty<string>();
+                var propertyValues = propertySets.Length > 0 ? propertySets[i].GetPropertyValues() : Array.Empty<string>();
                 var testCase = CreateTestCase(
                     testType,
                     sourceDll,
                     logger,
-                    method,
-                    Array.Empty<string>(),
-                    Array.Empty<object>());
-                testCase.CodeFilePath = testCsFilePath;
+                    methodMetaData.MethodName,
+                    propertyNames,
+                    propertyValues);
+                testCase.CodeFilePath = classMetaData.FilePath;
                 testCase.ExecutorUri = TestExecutor.ExecutorUri;
-                testCase.LineNumber = methodNameLine;
+                testCase.LineNumber = methodMetaData.LineNumber;
                 testCaseSets.Add(testCase);
             }
         }
@@ -75,12 +47,12 @@ internal static class TestCaseItemCreator
         Type testType,
         string sourceDll,
         IMessageLogger logger,
-        MemberInfo method,
+        string methodName,
         IEnumerable<string> propertyNames,
         IEnumerable<object> propertyValues)
     {
-        var testCaseId = DisplayNameHelper.CreateTestCaseId(testType, method.Name, propertyNames.ToArray(), propertyValues.ToArray());
-        var fullyQualifiedName = $"{testType.Namespace}.{testType.Name}.{method.Name}{testCaseId.TestCaseVariables.FormVariableSection()}";
+        var testCaseId = DisplayNameHelper.CreateTestCaseId(testType, methodName, propertyNames.ToArray(), propertyValues.ToArray());
+        var fullyQualifiedName = $"{testType.Namespace}.{testType.Name}.{methodName}{testCaseId.TestCaseVariables.FormVariableSection()}";
         var testCase = new TestCase(fullyQualifiedName, TestExecutor.ExecutorUri, sourceDll)
         {
             DisplayName = testCaseId.DisplayName
@@ -90,54 +62,16 @@ internal static class TestCaseItemCreator
 
         if (testType.FullName is null)
         {
-            var msg = $"ERROR!: testType fullname not defined - fullname: {testType.FullName}";
-            logger.SendMessage(TestMessageLevel.Informational, msg);
+            var msg = $"Error: testType fullname not defined - fullname: {testType.FullName}";
+            logger.SendMessage(TestMessageLevel.Error, msg);
             throw new Exception(msg);
         }
 
         testCase.SetPropertyValue(SailfishTestTypeFullNameDefinition.SailfishTestTypeFullNameDefinitionProperty, testType.FullName);
         testCase.SetPropertyValue(SailfishDisplayNameDefinition.SailfishDisplayNameDefinitionProperty, testCaseId.DisplayName);
         testCase.SetPropertyValue(SailfishFormedVariableSectionDefinition.SailfishFormedVariableSectionDefinitionProperty, testCaseId.TestCaseVariables.FormVariableSection());
-        testCase.SetPropertyValue(SailfishMethodNameDefinition.SailfishMethodNameDefinitionProperty, method.Name);
+        testCase.SetPropertyValue(SailfishMethodNameDefinition.SailfishMethodNameDefinitionProperty, methodName);
 
         return testCase;
-    }
-
-    private static int GetMethodNameLine(MemberInfo testType, List<string> fileLines, MemberInfo method, IMessageLogger logger)
-    {
-        var currentlyInTheRightClass = false;
-        var index = 0;
-        var methodLine = 0;
-        var methodKey = $" {method.Name}(";
-        var classKey = $"class {testType.Name}";
-
-        foreach (var line in fileLines)
-        {
-            var fileLine = line.Trim().Split("//").First();
-            if (fileLine.Contains(classKey))
-            {
-                currentlyInTheRightClass = true;
-            }
-            else if (fileLine.Contains("class"))
-            {
-                currentlyInTheRightClass = false;
-            }
-
-            if (currentlyInTheRightClass && fileLine.Trim().Contains(methodKey))
-            {
-                methodLine = index;
-            }
-
-            index++;
-        }
-
-        if (methodLine != 0) return methodLine;
-        logger.SendMessage(TestMessageLevel.Error, $"Failed to discover the test method for {method.Name} in type {testType.Name} amongst these file lines:\n");
-        foreach (var line in fileLines)
-        {
-            logger.SendMessage(TestMessageLevel.Error, line);
-        }
-
-        return methodLine;
     }
 }

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -37,6 +37,7 @@
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.6.2" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
+        <ProjectReference Include="..\Sailfish.Analyzers\Sailfish.Analyzers.csproj" />
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" IncludeAssets="All" />
     </ItemGroup>
 </Project>

--- a/source/Sailfish.sln
+++ b/source/Sailfish.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTestingUserInvok
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.E2E.ExceptionHandling", "Tests.E2E.ExceptionHandling\Tests.E2E.ExceptionHandling.csproj", "{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sailfish.Analyzers", "Sailfish.Analyzers\Sailfish.Analyzers.csproj", "{042345EC-1A8D-41CC-BB57-8D8354D5F698}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -70,6 +72,10 @@ Global
 		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F806AE1E-4D04-4EBF-BEA5-47731A37B0F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{042345EC-1A8D-41CC-BB57-8D8354D5F698}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{042345EC-1A8D-41CC-BB57-8D8354D5F698}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{042345EC-1A8D-41CC-BB57-8D8354D5F698}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{042345EC-1A8D-41CC-BB57-8D8354D5F698}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EE33D17C-3F19-40A9-8394-D966232723A6} = {AA777AE3-7608-4068-9BDE-3AE366657722}

--- a/source/Tests.Sailfish/E2EScenarios/FullE2EFixture.cs
+++ b/source/Tests.Sailfish/E2EScenarios/FullE2EFixture.cs
@@ -23,7 +23,7 @@ public class FullE2EFixture
         result.Exceptions.ShouldNotBeNull();
         result.Exceptions.Count().ShouldBe(0);
     }
-    
+
     // will need to update this if more tests are added to the the project
     [Fact]
     public async Task AFullTestRunOfTheDemoShouldFind11Tests()


### PR DESCRIPTION
## Description

The test discoverer in the test adapter is extremely inefficient. This PR refactors to the code to use the Microsoft.CodeAnalysis package to parse source code when discovering tests. Several optimizations are included to reduce the runtime of the discovery process.


## Results
Much faster, less error prone test class and test method discovery.