### PR TITLE
Fix wording in analyzer messages and fix edge case for sailfishvariable analyzers

### DIFF
--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/SailfishVariable/ShouldHavePublicGettersAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/SailfishVariable/ShouldHavePublicGettersAnalyzer.cs
@@ -45,7 +45,7 @@ public class ShouldHavePublicGettersAnalyzer : DiagnosticAnalyzer
             if (!isSailfishVariableProperty) continue;
 
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(property);
-            if (propertySymbol is null) continue;
+            if (propertySymbol is null || propertySymbol.DeclaredAccessibility != Accessibility.Public) continue;
 
             var getterIsPublic = propertySymbol
                 .ContainingType

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/SailfishVariable/ShouldHavePublicSettersAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/SailfishVariable/ShouldHavePublicSettersAnalyzer.cs
@@ -47,7 +47,7 @@ public class ShouldHavePublicSettersAnalyzer : DiagnosticAnalyzer
             if (!isSailfishVariableProperty) continue;
 
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(property);
-            if (propertySymbol is null) continue;
+            if (propertySymbol is null || propertySymbol.DeclaredAccessibility != Accessibility.Public) continue;
 
             var setterIsPublic = propertySymbol
                 .ContainingType

--- a/source/Sailfish.Analyzers/Utils/Descriptors.cs
+++ b/source/Sailfish.Analyzers/Utils/Descriptors.cs
@@ -8,17 +8,17 @@ public static class Descriptors
         AnalyzerGroups.EssentialAnalyzers,
         1000,
         isEnabledByDefault: true,
-        title: "Properties initialized in the global setup should be public",
+        title: "Properties initialized in the global setup must be public",
         description: "Properties that are assigned in the SailfishGlobalSetup must be public",
-        messageFormat: "Property '{0}' must be public when used within a method decorated with the SailfishGlobalSetup attribute",
+        messageFormat: "Property '{0}' must be public when assigned within a method decorated with the SailfishGlobalSetup attribute",
         severity: DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor PropertiesAssignedInGlobalSetupShouldHavePublicGettersDescriptor = DescriptorHelper.CreateDescriptor(
         AnalyzerGroups.EssentialAnalyzers,
         1001,
         isEnabledByDefault: true,
-        title: "Properties assigned in the global setup should have public getters",
-        description: "Properties assigned in the global setup should have public getters",
+        title: "Properties assigned in the global setup must have public getters",
+        description: "Properties assigned in the global setup must have public getters",
         messageFormat: "Property '{0}' must have a public getter when assigned within a method decorated with the SailfishGlobalSetup attribute",
         severity: DiagnosticSeverity.Error);
 
@@ -26,8 +26,8 @@ public static class Descriptors
         AnalyzerGroups.EssentialAnalyzers,
         1002,
         isEnabledByDefault: true,
-        title: "Properties assigned in the global setup have public setters",
-        description: "Properties assigned in the global setup should have public setters",
+        title: "Properties assigned in the global setup must have public setters",
+        description: "Properties assigned in the global setup must have public setters",
         messageFormat: "Property '{0}' must have a public setter when assigned within a method decorated with the SailfishGlobalSetup attribute",
         severity: DiagnosticSeverity.Error);
 
@@ -35,7 +35,7 @@ public static class Descriptors
         AnalyzerGroups.EssentialAnalyzers,
         1010,
         isEnabledByDefault: true,
-        title: "Properties decorated with the SailfishVariableAttribute should be public",
+        title: "Properties decorated with the SailfishVariableAttribute must be public",
         description: "Property '{0}' must be public",
         severity: DiagnosticSeverity.Error);
 
@@ -43,7 +43,7 @@ public static class Descriptors
         AnalyzerGroups.EssentialAnalyzers,
         1011,
         isEnabledByDefault: true,
-        title: "Properties decorated with the SailfishVariableAttribute should have public getters",
+        title: "Properties decorated with the SailfishVariableAttribute must have public getters",
         description: "Property '{0}' getter must be public",
         severity: DiagnosticSeverity.Error);
 
@@ -51,7 +51,7 @@ public static class Descriptors
         AnalyzerGroups.EssentialAnalyzers,
         1012,
         isEnabledByDefault: true,
-        title: "Properties decorated with the SailfishVariableAttribute should have public setters",
+        title: "Properties decorated with the SailfishVariableAttribute must have public setters",
         description: "Property '{0}' setter must be public",
         severity: DiagnosticSeverity.Error);
 

--- a/source/Tests.Sailfish.Analyzers/SailfishVariables/SailfishVariablesShouldHavePublicGetters.cs
+++ b/source/Tests.Sailfish.Analyzers/SailfishVariables/SailfishVariablesShouldHavePublicGetters.cs
@@ -90,7 +90,7 @@ namespace Two
     public class BaseAnalyzerClass
     {
         [SailfishVariable(1, 2, 3)] 
-        public int {|#1:MyVar|} { private get; set; }
+        public int {|#0:MyVar|} { private get; set; }
 
         public int BaseValue { get; set; }
 
@@ -108,7 +108,7 @@ namespace Sailfish.AnalyzerTests
     [Sailfish]
     public class AnalyzerExample : BaseAnalyzerClass
     {
-        [SailfishVariable(1, 2, 3)] int {|#0:Placeholder|} { get; set; }
+        [SailfishVariable(1, 2, 3)] int Placeholder { get; set; }
 
         [SailfishMethod]
         public void MainMethod()
@@ -256,7 +256,6 @@ namespace Sailfish.AnalyzerTests
 ";
         await AnalyzerVerifier<ShouldHavePublicGettersAnalyzer>.VerifyAnalyzerAsync(
             source,
-            new DiagnosticResult(Descriptors.SailfishVariablesShouldHavePublicGettersDescriptor).WithLocation(0),
-            new DiagnosticResult(Descriptors.SailfishVariablesShouldHavePublicGettersDescriptor).WithLocation(1));
+            new DiagnosticResult(Descriptors.SailfishVariablesShouldHavePublicGettersDescriptor).WithLocation(0));
     }
 }


### PR DESCRIPTION
## Description

Fixes edge case with the sailfish variable analyzers where redundant messages appear with a non-public modifier on the property


## Results

Clearer more direct messages and fixed edge case