### PR TITLE
Add lifecycle method attribute analyzers

### DIFF
--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/LifecycleAttributeNames.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/LifecycleAttributeNames.cs
@@ -1,0 +1,20 @@
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.LifecycleMethods;
+
+public class LifecycleAttributes
+{
+    public static readonly string[] Names;
+
+    static LifecycleAttributes()
+    {
+        Names = new[]
+        {
+            "SailfishGlobalSetup",
+            "SailfishGlobalTeardown",
+            "SailfishMethodSetup",
+            "SailfishMethodTeardown",
+            "SailfishIterationSetup",
+            "SailfishIterationTeardown",
+            "SailfishMethod"
+        };
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/LifecycleMethodsShouldBePublicAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/LifecycleMethodsShouldBePublicAnalyzer.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.LifecycleMethods;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class LifecycleMethodsShouldBePublicAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = Descriptors.LifecycleMethodsShouldBePublic;
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        if (!Debugger.IsAttached) context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            analyzeContext =>
+                AnalyzeSyntaxNode((ClassDeclarationSyntax)analyzeContext.Node,
+                    analyzeContext.SemanticModel,
+                    analyzeContext),
+            SyntaxKind.ClassDeclaration);
+    }
+
+    private static void AnalyzeSyntaxNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        var nonPublicLifecycleMethods = GetLifecycleMethods(classDeclaration);
+        foreach (var nonPublicLifecycleMethod in nonPublicLifecycleMethods)
+        {
+            var diagnostic = Diagnostic.Create(Descriptor, nonPublicLifecycleMethod.Identifier.GetLocation(), nonPublicLifecycleMethod.Identifier.Text);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+
+    private static IEnumerable<MethodDeclarationSyntax> GetLifecycleMethods(TypeDeclarationSyntax classDeclaration)
+    {
+        return classDeclaration
+            .Members
+            .OfType<MethodDeclarationSyntax>()
+            .Where(method =>
+                !method.Modifiers
+                    .Any(SyntaxKind.PublicKeyword))
+            .Where(method => method.HasAttributeAmong(LifecycleAttributes.Names));
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/OnlyOneLifecycleAttributePerMethod.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/OnlyOneLifecycleAttributePerMethod.cs
@@ -1,0 +1,57 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.LifecycleMethods;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class OnlyOneLifecycleAttributePerMethod : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor = Descriptors.OnlyOneLifecycleAttributePerMethod;
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        if (!Debugger.IsAttached) context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            analyzeContext =>
+                AnalyzeSyntaxNode((ClassDeclarationSyntax)analyzeContext.Node,
+                    analyzeContext.SemanticModel,
+                    analyzeContext),
+            SyntaxKind.ClassDeclaration);
+    }
+
+    private static void AnalyzeSyntaxNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        var methodsWithLifecycleAttributes = classDeclaration
+            .Members
+            .OfType<MethodDeclarationSyntax>()
+            .Where(method => method.HasAttributeAmong(LifecycleAttributes.Names));
+
+        foreach (var methodsWithLifecycleAttribute in methodsWithLifecycleAttributes)
+        {
+            var lifecycleAttributes = methodsWithLifecycleAttribute
+                .AttributeLists
+                .SelectMany(attributeListSyntax =>
+                    attributeListSyntax
+                        .Attributes
+                        .Select(attributeSyntax =>
+                            attributeSyntax.Name.ToString()))
+                .Where(x => LifecycleAttributes.Names.Contains(x))
+                .ToList();
+
+            if (lifecycleAttributes.Count > 1)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, methodsWithLifecycleAttribute.Identifier.GetLocation(), methodsWithLifecycleAttribute.Identifier.Text));
+            }
+        }
+    }
+}

--- a/source/Sailfish.Analyzers/Utils/Descriptors.cs
+++ b/source/Sailfish.Analyzers/Utils/Descriptors.cs
@@ -55,6 +55,22 @@ public static class Descriptors
         description: "Property '{0}' setter must be public",
         severity: DiagnosticSeverity.Error);
 
+    public static readonly DiagnosticDescriptor LifecycleMethodsShouldBePublic = DescriptorHelper.CreateDescriptor(
+        AnalyzerGroups.EssentialAnalyzers,
+        1020,
+        isEnabledByDefault: true,
+        title: "Sailfish lifecycle methods must be public",
+        description: "Method '{0}' must be public",
+        severity: DiagnosticSeverity.Error);    
+    
+    public static readonly DiagnosticDescriptor OnlyOneLifecycleAttributePerMethod = DescriptorHelper.CreateDescriptor(
+        AnalyzerGroups.EssentialAnalyzers,
+        1021,
+        isEnabledByDefault: true,
+        title: "Only one Sailfish lifecycle attribute is allowed per method",
+        description: "Method '{0}' may only be decorated with a single Sailfish lifecycle attribute",
+        severity: DiagnosticSeverity.Error);
+
     public static readonly DiagnosticDescriptor SuppressNonNullablePropertiesNotSetRule = DescriptorHelper.CreateDescriptor(
         AnalyzerGroups.SuppressionAnalyzers,
         idValue: 7000,

--- a/source/Sailfish.Analyzers/Utils/TreeParsingExtensionMethods/SailfishFeatureDiscoveryExtensionMethods.cs
+++ b/source/Sailfish.Analyzers/Utils/TreeParsingExtensionMethods/SailfishFeatureDiscoveryExtensionMethods.cs
@@ -51,6 +51,16 @@ public static class NodeExtensionMethods
         return methodDeclarationSyntax.AttributeLists.SelectMany(x => x.Attributes).All(a => attributeName.Contains(a.Name.ToString()));
     }
 
+    public static bool HasAttributeAmong(this MethodDeclarationSyntax methodDeclarationSyntax, IEnumerable<string> attributeNames)
+    {
+        return methodDeclarationSyntax.GetAllAttributesAmong(attributeNames).Any();
+    }
+
+    public static IEnumerable<string> GetAllAttributesAmong(this MethodDeclarationSyntax methodDeclarationSyntax, IEnumerable<string> attributeNames)
+    {
+        return methodDeclarationSyntax.AttributeLists.SelectMany(a => a.Attributes).Select(s => s.Name.ToString()).Intersect(attributeNames);
+    }
+
     public static bool HasAttributesWithNames(this PropertyDeclarationSyntax propertyDeclarationSyntax, params string[] attributeNames)
     {
         var foundAttributes = propertyDeclarationSyntax

--- a/source/Sailfish/Attributes/SailfishIterationSetupAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishIterationSetupAttribute.cs
@@ -12,7 +12,6 @@ namespace Sailfish.Attributes;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public sealed class SailfishIterationSetupAttribute : Attribute, IInnerLifecycleAttribute
 {
-    
     /// <summary>
     /// Initializes a new instance of the <see cref="SailfishIterationSetupAttribute"/> class
     /// with the specified method names.
@@ -21,7 +20,7 @@ public sealed class SailfishIterationSetupAttribute : Attribute, IInnerLifecycle
     /// <remarks>This feature is EXPERIMENTAL</remarks>
     public SailfishIterationSetupAttribute(params string[] methodNames)
     {
-        MethodNames = methodNames;
+        MethodNames = methodNames.Length > 0 ? methodNames : Array.Empty<string>();
     }
 
     /// <summary>

--- a/source/Sailfish/Attributes/SailfishIterationTeardownAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishIterationTeardownAttribute.cs
@@ -20,7 +20,7 @@ public sealed class SailfishIterationTeardownAttribute : Attribute, IInnerLifecy
     /// <remarks>This feature is EXPERIMENTAL</remarks>
     public SailfishIterationTeardownAttribute(params string[] methodNames)
     {
-        MethodNames = methodNames;
+        MethodNames = methodNames.Length > 0 ? methodNames : Array.Empty<string>();
     }
 
     /// <summary>

--- a/source/Sailfish/Attributes/SailfishMethodSetupAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodSetupAttribute.cs
@@ -19,7 +19,7 @@ public sealed class SailfishMethodSetupAttribute : Attribute, IInnerLifecycleAtt
     /// <remarks>This feature is EXPERIMENTAL</remarks>
     public SailfishMethodSetupAttribute(params string[] methodNames)
     {
-        MethodNames = methodNames;
+        MethodNames = methodNames.Length > 0 ? methodNames : Array.Empty<string>();
     }
 
     /// <summary>

--- a/source/Sailfish/Attributes/SailfishMethodTeardownAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodTeardownAttribute.cs
@@ -19,7 +19,7 @@ public sealed class SailfishMethodTeardownAttribute : Attribute, IInnerLifecycle
     /// <remarks>This feature is EXPERIMENTAL</remarks>
     public SailfishMethodTeardownAttribute(params string[] methodNames)
     {
-        MethodNames = methodNames;
+        MethodNames = methodNames.Length > 0 ? methodNames : Array.Empty<string>();
     }
 
     /// <summary>

--- a/source/Tests.Sailfish.Analyzers/LifecycleMethods/OnlyOnePerMethodAllowed.cs
+++ b/source/Tests.Sailfish.Analyzers/LifecycleMethods/OnlyOnePerMethodAllowed.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.LifecycleMethods;
+using Sailfish.Analyzers.Utils;
+using Tests.Sailfish.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Sailfish.Analyzers.LifecycleMethods;
+
+public class OnlyOnePerMethodAllowed
+{
+    [Fact]
+    public async Task ShouldDiscoverError()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishIterationSetup]
+    [SailfishGlobalSetup]
+    public void {|#0:GlobalSetup|}()
+    {
+    }
+
+    [SailfishMethodSetup]
+    public void SomeOtherTeardown()
+    {
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        // do nothing
+    }
+}";
+        await AnalyzerVerifier<OnlyOneLifecycleAttributePerMethod>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(Descriptors.OnlyOneLifecycleAttributePerMethod).WithLocation(0)
+        );
+    }
+}

--- a/source/Tests.Sailfish.Analyzers/LifecycleMethods/ShouldBePublic.cs
+++ b/source/Tests.Sailfish.Analyzers/LifecycleMethods/ShouldBePublic.cs
@@ -1,0 +1,144 @@
+using Xunit;
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.LifecycleMethods;
+using Sailfish.Analyzers.Utils;
+using Tests.Sailfish.Analyzers.Utils;
+
+
+namespace Tests.Sailfish.Analyzers.LifecycleMethods;
+
+public class ShouldBePublic
+{
+    [Fact]
+    public async Task ShouldNotError()
+    {
+        const string source = @"
+[Sailfish]
+public class MethodSpecificLifecycles
+{
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+    }
+
+    [SailfishMethodSetup(nameof(TestOne))]
+    public void ExecutionMethodSetup()
+    {
+    }
+
+    [SailfishIterationSetup(nameof(TestOne), nameof(TestTwo))]
+    public void IterationSetup()
+    {
+    }
+
+    [SailfishMethod]
+    public async Task TestOne(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    [SailfishMethod]
+    public async Task TestTwo(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    [SailfishIterationTeardown(nameof(TestTwo))]
+    public void IterationTeardown()
+    {
+    }
+
+    [SailfishMethodTeardown]
+    public async Task ExecutionMethodTeardown(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    [SailfishGlobalTeardown]
+    public async Task GlobalTeardown(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    void TestMethod()
+    {
+    }
+}
+";
+
+        await AnalyzerVerifier<LifecycleMethodsShouldBePublicAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies()
+        );
+    }
+
+    [Fact]
+    public async Task ShouldCatchAllErrors()
+    {
+        const string source = @"
+[Sailfish]
+public class MethodSpecificLifecycles
+{
+    [SailfishGlobalSetup]
+    void {|#0:GlobalSetup|}()
+    {
+    }
+
+    [SailfishMethodSetup(nameof(TestOne))]
+    void {|#1:ExecutionMethodSetup|}()
+    {
+    }
+
+    [SailfishIterationSetup(nameof(TestOne), nameof(TestTwo))]
+    void {|#2:IterationSetup|}()
+    {
+    }
+
+    [SailfishMethod]
+    async Task {|#3:TestOne|}(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    [SailfishMethod]
+    async Task {|#4:TestTwo|}(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    [SailfishIterationTeardown(nameof(TestTwo))]
+    void {|#5:IterationTeardown|}()
+    {
+    }
+
+    [SailfishMethodTeardown]
+    async Task {|#6:ExecutionMethodTeardown|}(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    [SailfishGlobalTeardown]
+    async Task {|#7:GlobalTeardown|}(CancellationToken cancellationToken)
+    {
+        await Task.Delay(20, cancellationToken);
+    }
+
+    void TestMethod()
+    {
+    }
+}
+";
+
+        await AnalyzerVerifier<LifecycleMethodsShouldBePublicAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(0),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(1),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(2),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(3),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(4),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(5),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(6),
+            new DiagnosticResult(Descriptors.LifecycleMethodsShouldBePublic).WithLocation(7)
+        );
+    }
+}

--- a/source/Tests.Sailfish.Analyzers/Utils/TestDependencyExtensionMethods.cs
+++ b/source/Tests.Sailfish.Analyzers/Utils/TestDependencyExtensionMethods.cs
@@ -8,6 +8,8 @@ public static class TestDependencyExtensionMethods
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Sailfish.AnalyzerTests;
 


### PR DESCRIPTION
## Description

Adds analyzers that enforce rules around lifecycle method attribute usage not already handled by the compiler.

## Results
- Multiple lifecycle attributes on a single method are not allowed
- Non-public lifecycle methods are not allowed