### PR TITLE
Add test to cover override methods for global setup analyzer

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/AnalyzerExamples/AnalyzerExamples.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/AnalyzerExamples/AnalyzerExamples.cs
@@ -25,6 +25,14 @@ public class TryToDoSomethingIllegalHere : BaseAnalyzerClass
         Console.WriteLine("FIRST");
     }
 
+    public int MyInt { get; set; }
+
+    protected override async Task MyBaseMethod(CancellationToken ct)
+    {
+        await Task.CompletedTask;
+        MyInt = 123;
+    }
+
     [SailfishMethod]
     public async Task MainMethod()
     {

--- a/source/PerformanceTests/ExamplePerformanceTests/AnalyzerExamples/BaseAnalyzerClass.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/AnalyzerExamples/BaseAnalyzerClass.cs
@@ -19,6 +19,12 @@ public class BaseAnalyzerClass
         Console.WriteLine("Second");
     }
 
+    protected virtual async Task MyBaseMethod(CancellationToken ct)
+    {
+        await Task.CompletedTask;
+        // do nothing yet
+    }
+
     [SailfishGlobalSetup]
     public async Task BGlobalSetupBaseAsync(CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Description

Doubt about whether or not an analyzer was doing a particular thing - detecting private properties set inside of global setup - even when done in an override from a base. Turns out - it works perfectly fine with the current implementation.

## Results
A new test