### PR TITLE
convert to process ticks - to unlock microsecond resolution

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/MinimalTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/MinimalTest.cs
@@ -1,4 +1,5 @@
-﻿using Sailfish.Attributes;
+﻿using System.Threading;
+using Sailfish.Attributes;
 
 namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
 
@@ -7,8 +8,15 @@ namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
 [Sailfish(Disabled = false)]
 public class MinimalTest
 {
+    [SailfishIterationSetup]
+    public void Setup()
+    {
+        Thread.Sleep(10);
+    }
+    
     [SailfishMethod]
     public void Minimal()
     {
+        Thread.Sleep(100);
     }
 }

--- a/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
+++ b/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
@@ -42,6 +42,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     </ItemGroup>
 </Project>

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
@@ -125,7 +125,8 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
     {
         foreach (var perf in result.PerformanceTimerResults?.MethodIterationPerformances!)
         {
-            logger?.SendMessage(TestMessageLevel.Informational, $"Time: {perf.Duration.ToString()} ms");
+            var timeResult = perf.GetDurationFromTicks().MilliSeconds;
+            logger?.SendMessage(TestMessageLevel.Informational, $"Time: {timeResult.Duration.ToString()} {timeResult.TimeScale.ToString().ToLowerInvariant()}");
         }
     }
 

--- a/source/Sailfish/Contracts/Public/DescriptiveStatisticsResult.cs
+++ b/source/Sailfish/Contracts/Public/DescriptiveStatisticsResult.cs
@@ -23,7 +23,10 @@ public class DescriptiveStatisticsResult
 
     public static DescriptiveStatisticsResult ConvertFromPerfTimer(TestCaseId testCaseId, PerformanceTimer performanceTimer)
     {
-        var executionIterations = performanceTimer.ExecutionIterationPerformances.Select(x => (double)x.Duration).ToArray();
+        var executionIterations = performanceTimer.ExecutionIterationPerformances
+            .Select(x => x.GetDurationFromTicks())
+            .Select(x => x.MilliSeconds.Duration)
+            .ToArray();
 
         var mean = executionIterations.Mean().Round(5);
         var stdDev = (executionIterations.StandardDeviation() + 0.000000001).Round(5);

--- a/source/Sailfish/Execution/DurationConversion.cs
+++ b/source/Sailfish/Execution/DurationConversion.cs
@@ -1,0 +1,22 @@
+namespace Sailfish.Execution;
+
+public class DurationConversion
+{
+    public DurationConversion(double duration, TimeScaleUnit timeScaleUnit)
+    {
+        Duration = duration;
+        TimeScale = timeScaleUnit;
+    }
+
+    public double Duration { get; set; }
+    public TimeScaleUnit TimeScale { get; set; }
+
+    public enum TimeScaleUnit
+    {
+        Ns,
+        Us,
+        Ms,
+        S,
+        M
+    }
+}

--- a/source/Sailfish/Execution/IterationPerformance.cs
+++ b/source/Sailfish/Execution/IterationPerformance.cs
@@ -4,14 +4,19 @@ namespace Sailfish.Execution;
 
 public class IterationPerformance
 {
-    public IterationPerformance(DateTimeOffset startTime, DateTimeOffset endTime, long elapsedMilliseconds)
+    public IterationPerformance(DateTimeOffset startTime, DateTimeOffset endTime, long elapsedTicks)
     {
         StartTime = startTime;
         StopTime = endTime;
-        Duration = elapsedMilliseconds;
+        ElapsedTicks = elapsedTicks;
     }
 
     public DateTimeOffset StartTime { get; }
     public DateTimeOffset StopTime { get; }
-    public long Duration { get; } // milliseconds
+    private long ElapsedTicks { get; }
+
+    public TimeResult GetDurationFromTicks()
+    {
+        return TickAutoConverter.ConvertToTime(ElapsedTicks);
+    }
 }

--- a/source/Sailfish/Execution/TestInstanceContainer.cs
+++ b/source/Sailfish/Execution/TestInstanceContainer.cs
@@ -38,10 +38,11 @@ internal class TestInstanceContainer
     public int NumWarmupIterations => ExecutionSettings.NumWarmupIterations;
     public int NumIterations => ExecutionSettings.NumIterations;
 
-
     public IExecutionSettings ExecutionSettings { get; }
 
-    public AncillaryInvocation Invocation { get; private init; } = null!;
+    public CoreInvoker Invocation { get; private init; } = null!;
+
+    public OverheadEstimator OverheadEstimator { get; private init; }
 
     public static TestInstanceContainer CreateTestInstance(object instance, MethodInfo method, string[] propertyNames, object[] variables)
     {
@@ -53,7 +54,8 @@ internal class TestInstanceContainer
 
         return new TestInstanceContainer(instance.GetType(), instance, method, testCaseId, executionSettings)
         {
-            Invocation = new AncillaryInvocation(instance, method, new PerformanceTimer())
+            Invocation = new CoreInvoker(instance, method, new PerformanceTimer()),
+            OverheadEstimator = new OverheadEstimator()
         };
     }
 }

--- a/source/Sailfish/Execution/TickAutoConverter.cs
+++ b/source/Sailfish/Execution/TickAutoConverter.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+
+namespace Sailfish.Execution;
+
+public static class TickAutoConverter
+{
+    private static long _systemFrequency = Stopwatch.Frequency;
+
+    private static DurationConversion ConvertToNanoseconds(long elapsedTicks)
+    {
+        var result = ConvertToSeconds(elapsedTicks).Duration * 1_000_000_000;
+        return new DurationConversion(result, DurationConversion.TimeScaleUnit.Ns);
+    }
+
+    private static DurationConversion ConvertToMicroseconds(long elapsedTicks)
+    {
+        var result = ConvertToSeconds(elapsedTicks).Duration * 1_000_000;
+        return new DurationConversion(result, DurationConversion.TimeScaleUnit.Us);
+    }
+
+    private static DurationConversion ConvertToMilliseconds(long elapsedTicks)
+    {
+        var result = ConvertToSeconds(elapsedTicks).Duration * 1_000;
+        return new DurationConversion(result, DurationConversion.TimeScaleUnit.Ms);
+    }
+
+    private static DurationConversion ConvertToSeconds(long elapsedTicks)
+    {
+        var result = (double)elapsedTicks / (double)Stopwatch.Frequency;
+        return new DurationConversion(result, DurationConversion.TimeScaleUnit.S);
+    }
+
+    private static DurationConversion ConvertToSeconds(double elapsedTicks)
+    {
+        var result = (double)elapsedTicks / (double)Stopwatch.Frequency;
+        return new DurationConversion(result, DurationConversion.TimeScaleUnit.S);
+    }
+
+    private static DurationConversion ConvertToMinutes(long elapsedTicks)
+    {
+        var result = (long)(ConvertToSeconds(elapsedTicks).Duration / 60.0);
+        return new DurationConversion(result, DurationConversion.TimeScaleUnit.M);
+    }
+
+    public static TimeResult ConvertToTime(long elapsedTicks)
+    {
+        return new TimeResult(
+            ConvertToNanoseconds(elapsedTicks),
+            ConvertToMicroseconds(elapsedTicks),
+            ConvertToMilliseconds(elapsedTicks),
+            ConvertToSeconds(elapsedTicks),
+            ConvertToMinutes(elapsedTicks)
+        );
+    }
+
+    public static double ToMilliseconds(this double elapsedTicks)
+    {
+        return ConvertToSeconds(elapsedTicks).Duration * 1_000;
+    }
+}

--- a/source/Sailfish/Execution/TimeResult.cs
+++ b/source/Sailfish/Execution/TimeResult.cs
@@ -1,0 +1,24 @@
+namespace Sailfish.Execution;
+
+public class TimeResult
+{
+    public TimeResult(
+        DurationConversion nanoSeconds,
+        DurationConversion microSeconds,
+        DurationConversion milliSeconds,
+        DurationConversion seconds,
+        DurationConversion minutes)
+    {
+        NanoSeconds = nanoSeconds;
+        MicroSeconds = microSeconds;
+        MilliSeconds = milliSeconds;
+        Seconds = seconds;
+        Minutes = minutes;
+    }
+
+    public DurationConversion NanoSeconds { get; set; }
+    public DurationConversion MicroSeconds { get; set; }
+    public DurationConversion MilliSeconds { get; set; }
+    public DurationConversion Seconds { get; set; }
+    public DurationConversion Minutes { get; set; }
+}


### PR DESCRIPTION
## Description
Moving sailfish to use Ticks instead of the precanned elapsed milliseconds. This provides better resolution for end users. Everything is still based in milliseconds. Future updates may allow this to be customized.

In Addition:

 - adds overhead estimation
 - decided to not implement JIT compiling support in this PR. But that is possibility. Likely won't try and get that optimal - instead preferring ScaleFish - a project to perfom ML estimations on scalability of a given test method.


