### PR TITLE
safe resample when having to downsample

### DIFF
--- a/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
+++ b/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
@@ -42,6 +42,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     </ItemGroup>
 </Project>

--- a/source/Sailfish/Statistics/Tests/ITestPreprocessor.cs
+++ b/source/Sailfish/Statistics/Tests/ITestPreprocessor.cs
@@ -9,7 +9,6 @@ public interface ITestPreprocessor
     double[] PreprocessWithDownSample(
         double[] rawData,
         bool useInnerQuartile,
-        bool downSample,
         [Range(3, int.MaxValue)] int maxArraySize,
         [Range(3, int.MaxValue)] int minArraySize = 3,
         int? seed = null);

--- a/source/Sailfish/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTestSailfish.cs
+++ b/source/Sailfish/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTestSailfish.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Accord.Statistics;
 using Accord.Statistics.Testing;
+using MathNet.Numerics.Statistics;
 using Sailfish.Analysis;
 using Sailfish.Contracts;
 
@@ -27,29 +31,47 @@ public class MannWhitneyWilcoxonTestSailfish : IMannWhitneyWilcoxonTestSailfish
         var sigDig = settings.Round;
 
         const int maxArraySize = 12;
-        var sample1 = preprocessor.PreprocessWithDownSample(before, settings.UseInnerQuartile, true, maxArraySize);
-        var sample2 = preprocessor.PreprocessWithDownSample(after, settings.UseInnerQuartile, true, maxArraySize);
 
-        var test = new MannWhitneyWilcoxonTest(sample1, sample2, TwoSampleHypothesis.ValuesAreDifferent);
+        var iterations = before.Length + after.Length > 20 ? 60 : 1;
+        var tests = new ConcurrentBag<MannWhitneyWilcoxonTest>();
+        Parallel.ForEach(
+            Enumerable.Range(0, iterations),
+            new ParallelOptions()
+            {
+                MaxDegreeOfParallelism = 5
+            }, (_) =>
+            {
+                var sample1 = preprocessor.PreprocessWithDownSample(before, settings.UseInnerQuartile, maxArraySize: maxArraySize);
+                var sample2 = preprocessor.PreprocessWithDownSample(after, settings.UseInnerQuartile, maxArraySize: maxArraySize);
 
-        var meanBefore = Math.Round(sample1.Mean(), sigDig);
-        var meanAfter = Math.Round(sample2.Mean(), sigDig);
+                var test = new MannWhitneyWilcoxonTest(sample1, sample2, TwoSampleHypothesis.ValuesAreDifferent);
+                tests.Add(test);
+            });
 
-        var medianBefore = Math.Round(sample1.Median(), sigDig);
-        var medianAfter = Math.Round(sample2.Median(), sigDig);
 
-        var testStatistic = Math.Round(test.Statistic, sigDig);
-        var pVal = Math.Round(test.PValue, TestConstants.PValueSigDig);
+        var meanBefore = Math.Round(before.Mean(), sigDig);
+        var meanAfter = Math.Round(after.Mean(), sigDig);
 
-        var isSignificant = test.PValue <= settings.Alpha;
+        var medianBefore = Math.Round(before.Median(), sigDig);
+        var medianAfter = Math.Round(after.Median(), sigDig);
+
+        var testStatistic = Math.Round(tests.Select(x => x.Statistic).Mean(), sigDig);
+
+        var significantPValues = tests
+            .Select(x => x.PValue)
+            .Where(p => p < TestConstants.PValueSigDig)
+            .ToList();
+
+        var isSignificant = significantPValues.Count / (double)tests.Count > 0.5;
+        var pVal = Math.Round(significantPValues.Mean(), TestConstants.PValueSigDig);
+
         var changeDirection = meanAfter > meanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
-
         var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
 
         var additionalResults = new Dictionary<string, object>
         {
-            { AdditionalResults.Statistic1, test.Statistic1 },
-            { AdditionalResults.Statistic2, test.Statistic2 }
+            { AdditionalResults.Statistic1, tests.Select(x => x.Statistic1).Mean() },
+            { AdditionalResults.Statistic2, tests.Select(x => x.Statistic2).Mean() }
         };
 
         return new TestResults(

--- a/source/Sailfish/Statistics/Tests/TestPreprocessor.cs
+++ b/source/Sailfish/Statistics/Tests/TestPreprocessor.cs
@@ -22,13 +22,12 @@ public class TestPreprocessor : ITestPreprocessor
     public double[] PreprocessWithDownSample(
         double[] rawData,
         bool useInnerQuartile,
-        bool downSample,
-        [Range(3, int.MaxValue)] int maxArraySize,
+        [Range(3, int.MaxValue)] int maxArraySize = 10,
         [Range(3, int.MaxValue)] int minArraySize = 3,
         int? seed = null)
     {
         var preDownSampled = Preprocess(rawData, useInnerQuartile);
-        return downSample ? DownSampleWithRandomUniform(preDownSampled, maxArraySize, minArraySize, seed) : preDownSampled;
+        return DownSampleWithRandomUniform(preDownSampled, maxArraySize, minArraySize, seed);
     }
 
 

--- a/source/Sailfish/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTestSailfish.cs
+++ b/source/Sailfish/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTestSailfish.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Accord.Statistics;
 using Accord.Statistics.Testing;
+using MathNet.Numerics.Statistics;
 using Sailfish.Analysis;
 using Sailfish.Contracts;
 
@@ -22,26 +26,42 @@ public class TwoSampleWilcoxonSignedRankTestSailfish : ITwoSampleWilcoxonSignedR
 
         var downSampleSize = Math.Min(before.Length, after.Length);
         var minSampleSize = Math.Min(downSampleSize, 3);
+        var iterations = before.Length + after.Length > 20 ? 60 : 1;
 
-        var sample1 = preprocessor.PreprocessWithDownSample(before, settings.UseInnerQuartile, true, downSampleSize, minSampleSize);
-        var sample2 = preprocessor.PreprocessWithDownSample(after, settings.UseInnerQuartile, true, downSampleSize, minSampleSize);
+        var tests = new ConcurrentBag<TwoSampleWilcoxonSignedRankTest>();
+        Parallel.ForEach(
+            Enumerable.Range(0, iterations),
+            new ParallelOptions()
+            {
+                MaxDegreeOfParallelism = 5
+            }, (_) =>
+            {
+                var sample1 = preprocessor.PreprocessWithDownSample(before, settings.UseInnerQuartile, downSampleSize, minSampleSize);
+                var sample2 = preprocessor.PreprocessWithDownSample(after, settings.UseInnerQuartile, downSampleSize, minSampleSize);
 
-        var test = new TwoSampleWilcoxonSignedRankTest(
-            sample1,
-            sample2,
-            TwoSampleHypothesis.ValuesAreDifferent);
+                var test = new TwoSampleWilcoxonSignedRankTest(
+                    sample1,
+                    sample2,
+                    TwoSampleHypothesis.ValuesAreDifferent);
+                tests.Add(test);
+            });
 
-        var meanBefore = Math.Round(sample1.Mean(), sigDig);
-        var meanAfter = Math.Round(sample2.Mean(), sigDig);
+        var meanBefore = Math.Round(before.Mean(), sigDig);
+        var meanAfter = Math.Round(after.Mean(), sigDig);
 
-        var medianBefore = Math.Round(sample1.Median(), sigDig);
-        var medianAfter = Math.Round(sample2.Median(), sigDig);
+        var medianBefore = Math.Round(before.Median(), sigDig);
+        var medianAfter = Math.Round(after.Median(), sigDig);
 
-        var testStatistic = test.Statistic;
-        var isSignificant = test.PValue <= settings.Alpha;
-        var pVal = Math.Round(test.PValue, TestConstants.PValueSigDig);
+        var testStatistic = Math.Round(tests.Select(x => x.Statistic).Mean(), sigDig);
+        var significantPValues = tests
+            .Select(x => x.PValue)
+            .Where(p => p < TestConstants.PValueSigDig)
+            .ToList();
+        
+        var isSignificant = significantPValues.Count / (double)tests.Count > 0.5;
+
+        var pVal = Math.Round(significantPValues.Mean(), TestConstants.PValueSigDig);
         var changeDirection = medianAfter > medianBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
-
         var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
 
         var additionalResults = new Dictionary<string, object>();

--- a/source/Tests.Sailfish/ExtensionMethods/TableParserExtensionMethodsFixture.cs
+++ b/source/Tests.Sailfish/ExtensionMethods/TableParserExtensionMethodsFixture.cs
@@ -42,13 +42,12 @@ public class TableParserExtensionMethodsFixture
         var result = new StatisticalTestExecutor(
             new MannWhitneyWilcoxonTestSailfish(preprocessor),
             new TTestSailfish(preprocessor),
-            new TwoSampleWilcoxonSignedRankTestSailfish(preprocessor), 
+            new TwoSampleWilcoxonSignedRankTestSailfish(preprocessor),
             new KolmogorovSmirnovTestSailfish(preprocessor)
         ).ExecuteStatisticalTest(
             new double[] { 2, 3, 4, 4, 5, 5, 6, 6, 6 },
             new double[] { 9, 8, 7, 6, 4, 4, 1, 2, 3, 2 },
             new TestSettings(0.01, 0, false, TestType.WilcoxonRankSumTest));
-
 
         var testCaseId = new TestCaseId("MyClass.MySampleTest(N: 2, X: 4)");
         var testCaseResults = new List<TestCaseResults>() { new TestCaseResults(testCaseId, result) };

--- a/source/Tests.Sailfish/Statistics/ConvergenceChecks.cs
+++ b/source/Tests.Sailfish/Statistics/ConvergenceChecks.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Accord.Statistics.Distributions.Univariate;
+using Sailfish.Analysis;
+using Sailfish.Contracts;
+using Sailfish.Statistics.Tests;
+using Sailfish.Statistics.Tests.MWWilcoxonTestSailfish;
+using Sailfish.Statistics.Tests.TwoSampleWilcoxonSignedRankTestSailfish;
+using Shouldly;
+using Xunit;
+
+namespace Test.Statistics;
+
+public class ConvergenceChecks
+{
+    [Fact]
+    public void TwoSampleWilcoxonSignedRankTestSailfish_NoChange()
+    {
+        var test = new TwoSampleWilcoxonSignedRankTestSailfish(new TestPreprocessor());
+
+        var results = new List<TestResults>();
+        for (var i = 0; i < 1000; i++)
+        {
+            var bf = GenerateRandomNormalDistribution(30, 10, 10);
+            var af = GenerateRandomNormalDistribution(30, 11, 10);
+
+            results.Add(test.ExecuteTest(bf, af, new TestSettings(0.0001, 4, false, TestType.TwoSampleWilcoxonSignedRankTest)));
+        }
+
+        var converged = results.All(x => x.ChangeDescription == SailfishChangeDirection.NoChange);
+        converged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TwoSampleWilcoxonSignedRankTestSailfish_Regresssed()
+    {
+        var test = new TwoSampleWilcoxonSignedRankTestSailfish(new TestPreprocessor());
+
+        var results = new List<TestResults>();
+
+        for (var i = 0; i < 1000; i++)
+        {
+            var bf = GenerateRandomNormalDistribution(30, 10, 1);
+            var af = GenerateRandomNormalDistribution(30, 13, 1);
+
+            results.Add(test.ExecuteTest(bf, af, new TestSettings(0.0001, 4, false, TestType.TwoSampleWilcoxonSignedRankTest)));
+        }
+
+        var converged = results.All(x => x.ChangeDescription == SailfishChangeDirection.Regressed);
+        converged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MannWhitneyWilcoxonTestSailfish_NoChange()
+    {
+        var bf = GenerateRandomNormalDistribution(30, 10, 5);
+        var af = GenerateRandomNormalDistribution(30, 11, 5);
+
+        var results = new List<TestResults>();
+
+        var test = new MannWhitneyWilcoxonTestSailfish(new TestPreprocessor());
+        for (var i = 0; i < 20; i++)
+        {
+            results.Add(test.ExecuteTest(bf, af, new TestSettings(0.0001, 4, false, TestType.WilcoxonRankSumTest)));
+        }
+
+        var converged = results.All(x => x.ChangeDescription == SailfishChangeDirection.NoChange);
+        converged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MannWhitneyWilcoxonTestSailfish_Regressed()
+    {
+        var bf = GenerateRandomNormalDistribution(30, 10, 1);
+        var af = GenerateRandomNormalDistribution(30, 15, 1);
+
+        var results = new List<TestResults>();
+
+        var test = new MannWhitneyWilcoxonTestSailfish(new TestPreprocessor());
+        for (var i = 0; i < 20; i++)
+        {
+            results.Add(test.ExecuteTest(bf, af, new TestSettings(0.0001, 4, false, TestType.WilcoxonRankSumTest)));
+        }
+
+        var converged = results.All(x => x.ChangeDescription == SailfishChangeDirection.Regressed);
+        converged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MannWhitneyWilcoxonTestSailfish_HiStdDevNoChange()
+    {
+        var bf = GenerateRandomNormalDistribution(30, 10, 10);
+        var af = GenerateRandomNormalDistribution(30, 15, 10);
+
+        var results = new List<TestResults>();
+
+        var test = new MannWhitneyWilcoxonTestSailfish(new TestPreprocessor());
+        for (var i = 0; i < 20; i++)
+        {
+            results.Add(test.ExecuteTest(bf, af, new TestSettings(0.0001, 4, false, TestType.WilcoxonRankSumTest)));
+        }
+
+        var converged = results.All(x => x.ChangeDescription == SailfishChangeDirection.NoChange);
+        converged.ShouldBeTrue();
+    }
+
+    private readonly Random random = new(42);
+
+    double[] GenerateRandomNormalDistribution(int numSamples, double mean, double standardDeviation)
+    {
+        return new NormalDistribution(mean, standardDeviation).Generate(numSamples, random);
+    }
+}

--- a/source/Tests.Sailfish/Statistics/DownSampleIsUniformFixture.cs
+++ b/source/Tests.Sailfish/Statistics/DownSampleIsUniformFixture.cs
@@ -13,7 +13,7 @@ public class DownSampleIsUniformFixture
     public void TestDownSampleIsUniform()
     {
         var input = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
-        var output = preprocessor.PreprocessWithDownSample(input, false, true, 10, seed: seed);
+        var output = preprocessor.PreprocessWithDownSample(input, false, maxArraySize: 10, seed: seed);
 
         var expected = new double[] { 14, 3, 11, 4, 6, 15, 16, 5, 7, 8 };
         output.ShouldBe(expected);
@@ -23,7 +23,7 @@ public class DownSampleIsUniformFixture
     public void TestDownSampleIsUniformAlternate()
     {
         var input = new double[] { 14, 15, 532, 52, 534, 78, 47, 732, 226, 27, 277, 234, 620, 206, 342, 623, 66, 342, 26, 342 };
-        var output = preprocessor.PreprocessWithDownSample(input, false, true, 10, seed: seed);
+        var output = preprocessor.PreprocessWithDownSample(input, false, maxArraySize: 10, seed: seed);
 
         var expected = new double[] { 206, 532, 277, 52, 78, 342, 623, 534, 47, 732 };
         output.ShouldBe(expected);
@@ -34,7 +34,7 @@ public class DownSampleIsUniformFixture
     {
         var input = new double[] { 1, 2, 3 };
 
-        var output = preprocessor.PreprocessWithDownSample(input, false, true, 10, seed: seed);
+        var output = preprocessor.PreprocessWithDownSample(input, false, maxArraySize: 10, seed: seed);
 
         output.Length.ShouldBe(3);
         input.ShouldBe(output);
@@ -45,7 +45,7 @@ public class DownSampleIsUniformFixture
     {
         var input = new double[] { 1, 2, 3, 4, 5 };
 
-        var output = preprocessor.PreprocessWithDownSample(input, false, true, 2, 5, seed: seed);
+        var output = preprocessor.PreprocessWithDownSample(input, false, maxArraySize: 2, 5, seed: seed);
 
         output.Length.ShouldBe(5);
         input.ShouldBe(output);
@@ -56,7 +56,7 @@ public class DownSampleIsUniformFixture
     {
         var input = new double[] { 1, 2, 3, 4, 5 };
 
-        var output = preprocessor.PreprocessWithDownSample(input, false, true, 3, 3, seed: seed);
+        var output = preprocessor.PreprocessWithDownSample(input, false, 3, 3, seed: seed);
         output.Length.ShouldBe(3);
     }
 
@@ -65,7 +65,7 @@ public class DownSampleIsUniformFixture
     {
         var input = new double[] { 1, 2, 3, 4, 5 };
 
-        var output = preprocessor.PreprocessWithDownSample(input, false, true, 10, seed: seed);
+        var output = preprocessor.PreprocessWithDownSample(input, false, maxArraySize: 10, seed: seed);
         input.ShouldBe(output);
     }
 }

--- a/source/Tests.Sailfish/Statistics/DownSampleReturnsTheCorrectSizeFixture.cs
+++ b/source/Tests.Sailfish/Statistics/DownSampleReturnsTheCorrectSizeFixture.cs
@@ -22,37 +22,37 @@ public class DownSampleFixture : IAsyncLifetime
     [Fact]
     public void DownSampleReturnsCorrectSize()
     {
-        preprocessor.PreprocessWithDownSample(data, false, true, 1).Length.ShouldBe(3);
+        preprocessor.PreprocessWithDownSample(data, false,  1).Length.ShouldBe(3);
     }
 
     [Fact]
     public void DownSampleReturnsCorrectSizeB()
     {
-        preprocessor.PreprocessWithDownSample(data, false, true, 3).Length.ShouldBe(3);
+        preprocessor.PreprocessWithDownSample(data, false,  3).Length.ShouldBe(3);
     }
 
     [Fact]
     public void DownSampleReturnsCorrectSizeC()
     {
-        preprocessor.PreprocessWithDownSample(data, false, true, 10).Length.ShouldBe(10);
+        preprocessor.PreprocessWithDownSample(data, false,  10).Length.ShouldBe(10);
     }
 
     [Fact]
     public void DownSampleReturnsCorrectSizeD()
     {
-        preprocessor.PreprocessWithDownSample(data, false, true, 50).Length.ShouldBe(data.Length);
+        preprocessor.PreprocessWithDownSample(data, false,  50).Length.ShouldBe(data.Length);
     }
 
     [Fact]
     public void DownSampleReturnsCorrectSizeE()
     {
-        preprocessor.PreprocessWithDownSample(data, false, true, 1, 5).Length.ShouldBe(5);
+        preprocessor.PreprocessWithDownSample(data, false, 1, 5).Length.ShouldBe(5);
     }
 
     [Fact]
     public void DownSampleReturnsCorrectSizeF()
     {
-        preprocessor.PreprocessWithDownSample(data, false, true, 10).Length.ShouldBe(10);
+        preprocessor.PreprocessWithDownSample(data, false,  10).Length.ShouldBe(10);
     }
 
 

--- a/source/Tests.Sailfish/Statistics/TestShouldCompleteSuccessfullyFixture.cs
+++ b/source/Tests.Sailfish/Statistics/TestShouldCompleteSuccessfullyFixture.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Test.Statistics;
 
-public class ShouldNotThrowTests : IAsyncLifetime
+public class TestShouldCompleteSuccessfullyFixture : IAsyncLifetime
 {
     private double[] before = null!;
     private double[] after = null!;


### PR DESCRIPTION
## Description

When we perform certain tests, we have to limit the size of the arrays that are passed to the tests to avoid running out of array allocation space. This is an impl detail of Accord (which I know... is deprecated, but find me these tests please!)

## Results
We resample and take a vote. Then we average the winners.