### PR TITLE
Standard methodname parsing for better consistency

### DIFF
--- a/source/ModelPredictions/Program.cs
+++ b/source/ModelPredictions/Program.cs
@@ -1,10 +1,12 @@
 ﻿using Sailfish.Analysis.Scalefish;
 
-Console.WriteLine("This demo shows you how to load a model file and then use it to make predictions on scale.");
-Console.WriteLine("This is V1, so over the next number of iterations, we'll add more tooling around processing these models to make it easier to make predictions.");
-
-var (cm, mm, pm) = GetBestFitModelForFirstMethod();
 Console.Clear();
+Console.WriteLine("\nThis demo shows you how to load a model file and then use it to make predictions on scale.");
+Console.WriteLine("\nThis is V1, so over the next number of iterations, we'll add more tooling around processing these models to make it easier to make predictions.");
+
+var (cm, mm, pm) = 
+    GetBestFitModelForFirstMethod();
+
 Console.WriteLine($"\nModel for : {cm.TestClassName}.{mm.TestMethodName}");
 Console.WriteLine($"With respect to {pm.PropertyName.Split(".").Last()}\n");
 
@@ -13,12 +15,17 @@ var function = pm.ComplexityResult.ComplexityFunction;
 Console.WriteLine($"Type:    {function.Name} - that's {function.OName}...");
 Console.WriteLine($"Quality: {function.Quality}\n");
 
+Console.WriteLine("Model predictions:\n");
 var nValues = new List<int>() { 1, 10, 100, 1000, 50_000 };
 foreach (var val in nValues)
 {
     var result = pm.ComplexityResult.ComplexityFunction.Predict(val);
-    Console.WriteLine($"f({val}) = " + Math.Round(result, 3));
+    Console.WriteLine($"f({val}) = " + Math.Round(result, 3) + " ms");
 }
+
+var scale =  Math.Round(pm.ComplexityResult.ComplexityFunction.FunctionParameters.Scale, 5);
+var bias = Math.Round(pm.ComplexityResult.ComplexityFunction.FunctionParameters.Bias, 8);
+Console.WriteLine($"\nFitted Model: f(x) = {scale}x + {bias}");
 
 (TestClassComplexityResult, TestMethodComplexityResult, TestPropertyComplexityResult) GetBestFitModelForFirstMethod()
 {

--- a/source/PerformanceTests/ExamplePerformanceTests/Discoverable/ExamplePerformanceTest.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/Discoverable/ExamplePerformanceTest.cs
@@ -14,65 +14,28 @@ namespace PerformanceTests.ExamplePerformanceTests.Discoverable;
 [Sailfish]
 public class ExamplePerformanceTest : TestBase
 {
-    private readonly ILogger logger;
-
-    public ExamplePerformanceTest(WebApplicationFactory<DemoApp> factory, ILogger logger) : base(factory)
+    public ExamplePerformanceTest(
+        WebApplicationFactory<DemoApp> factory,
+        ILogger logger) : base(factory)
     {
-        this.logger = logger;
     }
 
-    public int Type { get; private set; }
+    [SailfishVariable(true, 20, 50, 100, 200, 300)]
+    public int WaitPeriod { get; set; }
 
-    [SailfishVariable(true, 200, 300)] public int WaitPeriod { get; set; }
-    [SailfishVariable(1, 2)] public int NTries { get; set; } // try to avoid multiple variables if you can manage
-    [SailfishVariable(1, 2)] public int NTriess { get; set; } // try to avoid multiple variables if you can manage
-
-    [SailfishGlobalSetup]
-    public void GlobalSetup()
-    {
-        // logger.Information("This is the Global Setup");
-    }
-
-    [SailfishMethodSetup]
-    public void ExecutionMethodSetup()
-    {
-        // logger.Information("This is the Execution Method Setup");
-    }
-
-    [SailfishIterationSetup]
-    public void IterationSetup()
-    {
-        // logger.Warning("This is the Iteration Setup - use sparingly");
-    }
+    [SailfishVariable(1, 2)] 
+    public int NTries { get; set; }
 
     [SailfishMethod]
-    public async Task WaitPeriodPerfTest(CancellationToken cancellationToken)
+    public async Task WaitPeriodPerfTest(CancellationToken ct)
     {
-        await Task.Delay(WaitPeriod, cancellationToken);
-        await Client.GetStringAsync("/", cancellationToken);
+        await Task.Delay(WaitPeriod, ct);
+        await Client.GetStringAsync("/", ct);
     }
 
     [SailfishMethod]
     public async Task Other(CancellationToken cancellationToken)
     {
         await Task.Delay(WaitPeriod, cancellationToken);
-    }
-
-    [SailfishIterationTeardown]
-    public void IterationTeardown()
-    {
-        // logger.Warning("This is the Iteration Teardown - use sparingly");
-    }
-
-    [SailfishMethodTeardown]
-    public void ExecutionMethodTeardown()
-    {
-        // logger.Verbose("This is the Execution Method Teardown");
-    }
-
-    [SailfishGlobalTeardown]
-    public override async Task GlobalTeardown(CancellationToken cancellationToken)
-    {
-        await Task.Yield();
     }
 }

--- a/source/PerformanceTests/ExamplePerformanceTests/NonDiscoverable/DisabledTestIsNotDiscoverable.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/NonDiscoverable/DisabledTestIsNotDiscoverable.cs
@@ -3,12 +3,12 @@ using Sailfish.Attributes;
 
 namespace PerformanceTests.ExamplePerformanceTests.NonDiscoverable;
 
-[Sailfish(Disabled = false)]
+[Sailfish(Disabled = true)]
 public class DisabledTestIsNotDiscoverable
 {
     [SailfishMethod]
     public void MethodShouldNotHavePlayButton()
     {
-        Thread.Sleep(1000);
+        Thread.Sleep(300);
     }
 }

--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -50,7 +50,7 @@ internal static class TestCaseItemCreator
         var testCase = new TestCase(fullyQualifiedName, TestExecutor.ExecutorUri, sourceDll)
         {
             Id = hasher.GuidFromString(TestExecutor.ExecutorUri + $"{testType.Namespace}.{testType.Name}.{methodName}"),
-            DisplayName = testCaseId.DisplayName.Split(".").Last(),
+            DisplayName = testCaseId.GetMethodWithVariables(),
             LineNumber = lineNumber,
             ExecutorUri = TestExecutor.ExecutorUri,
             CodeFilePath = filePath

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionEngine.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionEngine.cs
@@ -278,7 +278,7 @@ internal class TestAdapterExecutionEngine : ITestAdapterExecutionEngine
         {
             if (container is null || testCaseGroup is null) return;
 
-            var currentTestCase = testCaseGroup.Single(x => x.DisplayName == container.TestCaseId.DisplayName);
+            var currentTestCase = testCaseGroup.Single(x => x.DisplayName == container.TestCaseId.GetMethodWithVariables());
             var testResult = new TestResult(currentTestCase)
             {
                 ErrorMessage = $"Test Disabled",

--- a/source/Sailfish/Analysis/TestCaseId.cs
+++ b/source/Sailfish/Analysis/TestCaseId.cs
@@ -30,6 +30,11 @@ public class TestCaseId
 
     [JsonIgnore] public string DisplayName => FormDisplayName();
 
+    public string GetMethodWithVariables()
+    {
+        return TestCaseName.GetMethodPart() + TestCaseVariables.FormVariableSection();
+    }
+
     private string FormDisplayName()
     {
         return TestCaseName.Name + TestCaseVariables.FormVariableSection();

--- a/source/Sailfish/Analysis/TestCaseName.cs
+++ b/source/Sailfish/Analysis/TestCaseName.cs
@@ -43,6 +43,11 @@ public class TestCaseName
         return displayName.Split(OpenBracket).First().Split(Dot).ToArray();
     }
 
+    public string GetMethodPart()
+    {
+        return Name.Split(Dot).Last();
+    }
+
     /// <summary>
     /// Method to parse and return an index of the '.' delimited test name.
     /// /// e.g. some.test, index 0 = 


### PR DESCRIPTION
## Description

A but was introduced when matching a testcase display name to a container display bc they were parsed differently.


## Results

Fixes the bug.