### PR TITLE
Seal variable attributes

### DIFF
--- a/source/Sailfish/Attributes/SailfishRangeVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishRangeVariableAttribute.cs
@@ -15,7 +15,7 @@ namespace Sailfish.Attributes;
 /// This attribute should be applied to public properties. It has no effect when applied to fields.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
-public class SailfishRangeVariableAttribute : Attribute, ISailfishVariableAttribute
+public sealed class SailfishRangeVariableAttribute : Attribute, ISailfishVariableAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SailfishVariableAttribute"/> class with the specified values.

--- a/source/Sailfish/Attributes/SailfishVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishVariableAttribute.cs
@@ -13,8 +13,8 @@ namespace Sailfish.Attributes;
 /// <remarks>
 /// This attribute should be applied to public properties. It has no effect when applied to fields.
 /// </remarks>
-[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
-public class SailfishVariableAttribute : Attribute, ISailfishVariableAttribute
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SailfishVariableAttribute"/> class with the specified values.


### PR DESCRIPTION
## Description

Unless someone can think of a good reason to allow inheritence on the Saiflish variable attributes, I think we should seal them. Otherwise we'll need to modify the discovery logic to allow for that, and in general I think it makes the tests a little more obfuscated.

