### PR TITLE
fix parsing error when structure is wrong

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/ReadmeExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ReadmeExample.cs
@@ -6,15 +6,9 @@ using Sailfish.Attributes;
 namespace PerformanceTests.ExamplePerformanceTests
 {
     [WriteToMarkdown]
-    [Sailfish(Disabled = false, DisableOverheadEstimation = true)]
+    [Sailfish(Disabled = false)]
     public class ReadmeExample
     {
-        [SailfishGlobalSetup]
-        public void Setup()
-        {
-            Console.WriteLine("DO IT");
-        }
-        
         [SailfishVariable(1, 10)] public int N { get; set; }
 
         [SailfishMethod]

--- a/source/PerformanceTests/ExamplePerformanceTests/ReadmeExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ReadmeExample.cs
@@ -1,13 +1,20 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Sailfish.Attributes;
 
 namespace PerformanceTests.ExamplePerformanceTests
 {
     [WriteToMarkdown]
-    [Sailfish(Disabled = false)]
+    [Sailfish(Disabled = false, DisableOverheadEstimation = true)]
     public class ReadmeExample
     {
+        [SailfishGlobalSetup]
+        public void Setup()
+        {
+            Console.WriteLine("DO IT");
+        }
+        
         [SailfishVariable(1, 10)] public int N { get; set; }
 
         [SailfishMethod]

--- a/source/Sailfish.TestAdapter/TestSettingsParser/SailfishSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/SailfishSettings.cs
@@ -6,7 +6,7 @@ namespace Sailfish.TestAdapter.TestSettingsParser;
 #pragma warning disable CS8618
 public class SailfishSettings
 {
-    public SailDiffSettings SailDiffSettings { get; set; }
+    public SailDiffSettings SailDiffSettings { get; set; } = new();
 
     [JsonPropertyName("ResultsDirectory")] public string ResultsDirectory { get; set; }
 

--- a/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
+++ b/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
@@ -22,8 +22,8 @@ public class SailDiffSettings
         DisableOrdering = disableOrdering;
     }
 
-    public double Alpha { get; private set; }
-    public int Round { get; private set; }
+    public double Alpha { get; private set; } = 0.001;
+    public int Round { get; private set; } = 5;
     public bool UseOutlierDetection { get; private set; }
     public TestType TestType { get; private set; }
     public int MaxDegreeOfParallelism { get; private set; }


### PR DESCRIPTION
## Description

Sets some more defaults when the .sailfish.json config doesn't provide values.
