### PR TITLE
Flatten and filter exceptions when compiling results

### DIFF
--- a/source/Sailfish.TestAdapter/Execution/AdapterConsoleWriter.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterConsoleWriter.cs
@@ -53,24 +53,22 @@ internal class AdapterConsoleWriter : IAdapterConsoleWriter
         {
             foreach (var compiledResult in result.CompiledTestCaseResults)
             {
-                if (!compiledResult.Exceptions.Any()) continue;
-                foreach (var exception in compiledResult.Exceptions)
-                {
-                    WriteMessage(exception.Message, TestMessageLevel.Error);
-                    consoleLogger.Error("{Error}", exception.Message);
+                if (compiledResult.Exception is null) continue;
+                WriteMessage(compiledResult.Exception.Message, TestMessageLevel.Error);
+                consoleLogger.Error("{Error}", compiledResult.Exception.Message);
 
-                    if (exception.StackTrace == null) continue;
-                    WriteMessage(exception.StackTrace, TestMessageLevel.Error);
-                    consoleLogger.Error("{StackTrace}", exception.Message);
+                if (compiledResult.Exception.StackTrace == null) continue;
+                WriteMessage(compiledResult.Exception.StackTrace, TestMessageLevel.Error);
+                consoleLogger.Error("{StackTrace}", compiledResult.Exception.Message);
 
-                    if (exception.InnerException is null) continue;
-                    WriteMessage(exception.InnerException.Message, TestMessageLevel.Error);
-                    consoleLogger.Error("{InnerError}", exception.InnerException.Message);
+                if (compiledResult.Exception.InnerException is null) continue;
+                WriteMessage(compiledResult.Exception.InnerException.Message, TestMessageLevel.Error);
+                consoleLogger.Error("{InnerError}", compiledResult.Exception.InnerException.Message);
 
-                    if (exception.InnerException.StackTrace == null) continue;
-                    WriteMessage(exception.InnerException.StackTrace, TestMessageLevel.Error);
-                    consoleLogger.Error("{InnerStackTrace}", exception.InnerException.StackTrace);
-                }
+                if (compiledResult.Exception.InnerException.StackTrace == null) continue;
+                WriteMessage(compiledResult.Exception.InnerException.StackTrace, TestMessageLevel.Error);
+                consoleLogger.Error("{InnerStackTrace}", compiledResult.Exception.InnerException.StackTrace);
+            
             }
         }
 
@@ -105,11 +103,11 @@ internal class AdapterConsoleWriter : IAdapterConsoleWriter
 
     private static string CreateIdeTestOutputWindowContent(ICompiledTestCaseResult testCaseResult)
     {
-        if (testCaseResult.Exceptions.Any())
+        if (testCaseResult.Exception is not null)
         {
             var exceptionBuilder = new StringBuilder();
             exceptionBuilder.AppendLine("____ Exceptions ____");
-            exceptionBuilder.AppendLine(string.Join("\n\n", testCaseResult.Exceptions.Select(x => x.Message)));
+            exceptionBuilder.AppendLine(string.Join("\n\n", testCaseResult.Exception.Message));
             return exceptionBuilder.ToString();
         }
 

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
@@ -68,7 +68,7 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
         consoleWriter.Present(executionSummaries, new OrderedDictionary());
         await executionSummaryWriter.Write(executionSummaries, timeStamp, trackingDir, runSettings, cancellationToken);
 
-        if (executionSummaries.SelectMany(x => x.CompiledTestCaseResults).SelectMany(x => x.Exceptions).Any())
+        if (executionSummaries.SelectMany(x => x.CompiledTestCaseResults).Select(x => x.Exception).Any())
         {
             return;
         }

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Sailfish.Analysis.ScaleFish.CurveFitting;
 

--- a/source/Sailfish/Analysis/TrackingFileConversionExtensionMethods.cs
+++ b/source/Sailfish/Analysis/TrackingFileConversionExtensionMethods.cs
@@ -27,7 +27,7 @@ public static class TrackingFileConversionExtensionMethods
             x => new CompiledTestCaseResultTrackingFormatV1(
                 x.GroupingId!,
                 x.PerformanceRunResult!.ToTrackingFormat(),
-                x.Exceptions,
+                x.Exception,
                 x.TestCaseId!));
     }
 

--- a/source/Sailfish/Attributes/SailfishVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishVariableAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/source/Sailfish/Contracts/Serialization/V1/CompiledTestCaseResultTrackingFormatV1.cs
+++ b/source/Sailfish/Contracts/Serialization/V1/CompiledTestCaseResultTrackingFormatV1.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Sailfish.Analysis;
 using Sailfish.Contracts.Serialization.V1.Converters;
@@ -23,18 +22,18 @@ public class CompiledTestCaseResultTrackingFormatV1
     public CompiledTestCaseResultTrackingFormatV1(
         string groupingId,
         PerformanceRunResultTrackingFormatV1 performanceRunResultTrackingFormatV1,
-        List<Exception> exceptions,
+        Exception? exception,
         TestCaseId testCaseId)
     {
         GroupingId = groupingId;
         PerformanceRunResultTrackingFormatV1 = performanceRunResultTrackingFormatV1;
-        Exceptions = exceptions;
+        Exception = exception ?? new Exception();
         TestCaseId = testCaseId;
     }
 
     public string GroupingId { get; set; }
     public PerformanceRunResultTrackingFormatV1 PerformanceRunResultTrackingFormatV1 { get; set; }
-    public List<Exception> Exceptions { get; set; } = new();
+    public Exception Exception { get; set; } = new();
 
     [JsonConverter(typeof(TestCaseIdConverter))]
     public TestCaseId? TestCaseId { get; set; }

--- a/source/Sailfish/DefaultHandlers/SailfishWriteTrackingFileHandler.cs
+++ b/source/Sailfish/DefaultHandlers/SailfishWriteTrackingFileHandler.cs
@@ -47,7 +47,7 @@ internal class SailfishWriteTrackingFileHandler : INotificationHandler<WriteCurr
 
     private bool AnyExceptions(IEnumerable<IClassExecutionSummary> notificationExecutionSummaries)
     {
-        var allResults = notificationExecutionSummaries.SelectMany(x => x.CompiledTestCaseResults).SelectMany(x => x.Exceptions).ToList();
+        var allResults = notificationExecutionSummaries.SelectMany(x => x.CompiledTestCaseResults).Select(x => x.Exception).ToList();
         return allResults.Any();
     }
 }

--- a/source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs
+++ b/source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs
@@ -38,7 +38,11 @@ internal class ClassExecutionSummaryCompiler : IClassExecutionSummaryCompiler
     {
         if (!testCaseExecutionResult.IsSuccess)
         {
-            return new CompiledTestCaseResult(testCaseExecutionResult.Exception ?? new SailfishException("Encountered test failure but could not find an exception"));
+            return new CompiledTestCaseResult(
+                testCaseExecutionResult.TestInstanceContainer?.TestCaseId,
+                testCaseExecutionResult.TestInstanceContainer?.GroupingId,
+                testCaseExecutionResult.Exception ?? new SailfishException("Encountered test failure but could not find an exception")
+            );
         }
 
         if (testCaseExecutionResult is { PerformanceTimerResults.IsValid: false, IsSuccess: true })
@@ -55,9 +59,10 @@ internal class ClassExecutionSummaryCompiler : IClassExecutionSummaryCompiler
             testCaseExecutionResult.TestInstanceContainer?.GroupingId!,
             descriptiveStatistics);
 
+        // should never be the case...
         if (testCaseExecutionResult.Exception is not null)
         {
-            compiledResult.Exceptions.Add(testCaseExecutionResult.Exception);
+            throw testCaseExecutionResult.Exception;
         }
 
         return compiledResult;

--- a/source/Sailfish/Execution/SailfishExecutor.cs
+++ b/source/Sailfish/Execution/SailfishExecutor.cs
@@ -79,9 +79,12 @@ internal class SailfishExecutor
                 .SelectMany(classExecutionSummary =>
                     classExecutionSummary
                         .CompiledTestCaseResults
-                        .SelectMany(c => c.Exceptions));
+                        .Where(e => e.Exception is not null)
+                        .Select(c => c.Exception))
+                .Cast<Exception>()
+                .ToList();
 
-            return SailfishRunResult.CreateResult(classExecutionSummaries, exceptions.ToList());
+            return SailfishRunResult.CreateResult(classExecutionSummaries, exceptions);
         }
 
         Log.Logger.Error("{NumErrors} errors encountered while discovering tests",

--- a/source/Sailfish/Presentation/MarkdownTableConverter.cs
+++ b/source/Sailfish/Presentation/MarkdownTableConverter.cs
@@ -25,7 +25,7 @@ public class MarkdownTableConverter : IMarkdownTableConverter
         {
             AppendResults(result.TestClass.Name, result.CompiledTestCaseResults, stringBuilder);
 
-            var exceptions = result.CompiledTestCaseResults.SelectMany(x => x.Exceptions).ToList();
+            var exceptions = result.CompiledTestCaseResults.Select(x => x.Exception).ToList();
             AppendExceptions(exceptions, stringBuilder);
         }
 

--- a/source/Sailfish/Statistics/CompiledResult.cs
+++ b/source/Sailfish/Statistics/CompiledResult.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Sailfish.Analysis;
 using Sailfish.Contracts.Public;
 
@@ -9,7 +8,7 @@ public interface ICompiledTestCaseResult
 {
     public string? GroupingId { get; set; }
     public PerformanceRunResult? PerformanceRunResult { get; set; }
-    public List<Exception> Exceptions { get; set; }
+    public Exception? Exception { get; set; }
     public TestCaseId? TestCaseId { get; set; }
 }
 
@@ -22,17 +21,15 @@ internal class CompiledTestCaseResult : ICompiledTestCaseResult
         PerformanceRunResult = performanceRunResult;
     }
 
-    public CompiledTestCaseResult(Exception exception) : this(new List<Exception>() { exception })
+    public CompiledTestCaseResult(TestCaseId? testCaseId, string? groupingId, Exception exception)
     {
-    }
-
-    public CompiledTestCaseResult(IEnumerable<Exception> exceptions)
-    {
-        Exceptions.AddRange(exceptions);
+        TestCaseId = testCaseId;
+        GroupingId = groupingId;
+        Exception = exception;
     }
 
     public string? GroupingId { get; set; }
     public PerformanceRunResult? PerformanceRunResult { get; set; }
-    public List<Exception> Exceptions { get; set; } = new();
+    public Exception? Exception { get; set; }
     public TestCaseId? TestCaseId { get; set; }
 }

--- a/source/Tests.E2E.ExceptionHandling/Handlers/WriteTrackingDataHandler.cs
+++ b/source/Tests.E2E.ExceptionHandling/Handlers/WriteTrackingDataHandler.cs
@@ -8,8 +8,17 @@ public class WriteTrackingDataHandler : INotificationHandler<WriteCurrentTrackin
     public async Task Handle(WriteCurrentTrackingFileCommand notification, CancellationToken cancellationToken)
     {
         var classExecutionSummaries = notification.ClassExecutionSummaries.ToList();
-        var successes = classExecutionSummaries.SelectMany(x => x.GetSuccessfulTestCases());
-        var failures = classExecutionSummaries.SelectMany(x => x.GetFailedTestCases());
+        var successes = classExecutionSummaries.SelectMany(x => x.GetSuccessfulTestCases()).ToList();
+        var failures = classExecutionSummaries.SelectMany(x => x.GetFailedTestCases()).ToList();
+
+        if (failures.Any())
+        {
+            foreach (var failure in failures)
+            {
+                var exceptions = failure.Exception;
+            }
+        }
+
         await Task.CompletedTask;
     }
 }

--- a/source/Tests.Sailfish/E2EScenarios/FullE2EExceptionCases.cs
+++ b/source/Tests.Sailfish/E2EScenarios/FullE2EExceptionCases.cs
@@ -215,7 +215,7 @@ public class FullE2EExceptionCases
         result.Exceptions.ShouldNotBeNull();
         result.Exceptions?.Count().ShouldBe(1);
         result.ExecutionSummaries
-            .SelectMany(x => x.CompiledTestCaseResults.Select(x => x.PerformanceRunResult))
+            .SelectMany(x => x.CompiledTestCaseResults.Select(c => c.PerformanceRunResult))
             .Count(x => x is null)
             .ShouldBe(1);
     }


### PR DESCRIPTION
## Description

Test case failures shoudl eminate from a single exception. The first exception encountered should fail the test.


## Results

Flattens exceptions and returns a test case result with a single exception on error.