### PR TITLE
Add tests to ensure test case and test run notifications are being consumed

### DIFF
--- a/source/Tests.E2E.ExceptionHandling/E2ETestExceptionHandlingProvider.cs
+++ b/source/Tests.E2E.ExceptionHandling/E2ETestExceptionHandlingProvider.cs
@@ -16,6 +16,6 @@ public class E2ETestExceptionHandlingProvider : IProvideARegistrationCallback
         await Task.CompletedTask;
         builder.RegisterType<WebApplicationFactory<DemoApp>>();
         builder.RegisterInstance(Log.Logger).As<ILogger>();
-        builder.RegisterType<WriteTrackingDataHandler>().As<INotificationHandler<TestRunCompletedNotification>>();
+        builder.RegisterType<TestRunCompletedNotificationHandler>().As<INotificationHandler<TestRunCompletedNotification>>();
     }
 }

--- a/source/Tests.E2E.ExceptionHandling/Handlers/TestRunCompletedNotificationHandler.cs
+++ b/source/Tests.E2E.ExceptionHandling/Handlers/TestRunCompletedNotificationHandler.cs
@@ -3,7 +3,7 @@ using Sailfish.Contracts.Public.Notifications;
 
 namespace Tests.E2E.ExceptionHandling.Handlers;
 
-public class WriteTrackingDataHandler : INotificationHandler<TestRunCompletedNotification>
+public class TestRunCompletedNotificationHandler : INotificationHandler<TestRunCompletedNotification>
 {
     public async Task Handle(TestRunCompletedNotification notification, CancellationToken cancellationToken)
     {

--- a/source/Tests.E2E.TestSuite/Discoverable/MinimalTest.cs
+++ b/source/Tests.E2E.TestSuite/Discoverable/MinimalTest.cs
@@ -2,6 +2,9 @@
 
 namespace Tests.E2E.TestSuite.Discoverable;
 
+/// <summary>
+///  These attributes are depended upon by the tests. Do Not Change.
+/// </summary>
 [WriteToCsv]
 [WriteToMarkdown]
 [Sailfish(Disabled = Constants.Disabled)]

--- a/source/Tests.E2E.TestSuite/Handlers/TestRunCompletedNotificationHandler.cs
+++ b/source/Tests.E2E.TestSuite/Handlers/TestRunCompletedNotificationHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using Sailfish;
+using Sailfish.Contracts.Public.Notifications;
+
+namespace Tests.E2E.TestSuite.Handlers;
+
+public class TestRunCompletedNotificationHandler : INotificationHandler<TestRunCompletedNotification>
+{
+    private readonly IRunSettings runSettings;
+
+    public TestRunCompletedNotificationHandler(IRunSettings runSettings)
+    {
+        this.runSettings = runSettings;
+    }
+
+    public async Task Handle(TestRunCompletedNotification notification, CancellationToken cancellationToken)
+    {
+        var outputDirectory = runSettings.LocalOutputDirectory;
+        await File.WriteAllTextAsync(Path.Join(outputDirectory, "TestRunCompleted.txt"), "TestRunComplete", cancellationToken);
+    }
+}

--- a/source/Tests.E2E.TestSuite/RegistrationProvider.cs
+++ b/source/Tests.E2E.TestSuite/RegistrationProvider.cs
@@ -1,8 +1,11 @@
 using Autofac;
 using Demo.API;
+using MediatR;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Registration;
 using Serilog;
+using Tests.E2E.TestSuite.Handlers;
 
 namespace Tests.E2E.TestSuite;
 
@@ -12,6 +15,7 @@ public class E2ETestRegistrationProvider : IProvideARegistrationCallback
     {
         await Task.CompletedTask;
         builder.RegisterType<WebApplicationFactory<DemoApp>>();
+        builder.RegisterType<TestRunCompletedNotificationHandler>().As<INotificationHandler<TestRunCompletedNotification>>();
         builder.RegisterInstance(Log.Logger).As<ILogger>();
     }
 }

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishFixture.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
 using Shouldly;
@@ -58,10 +59,11 @@ public class ScaleFishFixture
         Assert<SqrtN>();
     }
 
-
     private void Assert<TComplexityFunction>() where TComplexityFunction : ScaleFishModelFunction
     {
-        new ComplexityEstimator().EstimateComplexity(GetMeasurements<TComplexityFunction>()).ScaleFishModelFunction.Name.ShouldBe(typeof(TComplexityFunction).Name);
+        var estimation = new ComplexityEstimator().EstimateComplexity(GetMeasurements<TComplexityFunction>());
+        estimation.ShouldNotBeNull();
+        estimation.ScaleFishModelFunction.Name.ShouldBe(typeof(TComplexityFunction).Name);
     }
 
     private static ComplexityMeasurement[] GetMeasurements<TComplexityFunction>() where TComplexityFunction : ScaleFishModelFunction
@@ -69,7 +71,7 @@ public class ScaleFishFixture
         var constructor = typeof(TComplexityFunction)
             .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
             .Single();
-        var instance = constructor.Invoke(new object[] {  }) as ScaleFishModelFunction;
+        var instance = constructor.Invoke(new object[] { }) as ScaleFishModelFunction;
         instance.ShouldNotBeNull();
 
         const double scale = 1;

--- a/source/Tests.Library/E2EScenarios/DefaultHandlerTests.cs
+++ b/source/Tests.Library/E2EScenarios/DefaultHandlerTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Sailfish;
+using Sailfish.Contracts.Public;
+using Sailfish.Contracts.Serialization.V1;
+using Sailfish.Presentation;
+using Shouldly;
+using Tests.E2E.TestSuite;
+using Tests.E2E.TestSuite.Discoverable;
+using Tests.Library.Utils;
+using Xunit;
+
+namespace Tests.Library.E2EScenarios;
+
+public class DefaultHandlerTests
+{
+    [Fact]
+    public async Task TestCaseCompleteNotificationIsInvoked()
+    {
+        var outputDirectory = Some.RandomString();
+        var timeStamp = DateTime.Now;
+        const int sampleSizeOverride = 4;
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(outputDirectory)
+            .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .TestsFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .WithTestNames(nameof(MinimalTest))
+            .CreateTrackingFiles()
+            .DisableOverheadEstimation()
+            .WithTimeStamp(timeStamp)
+            .WithGlobalSampleSize(sampleSizeOverride)
+            .WithAnalysisDisabledGlobally()
+            .Build();
+
+        await SailfishRunner.Run(runSettings);
+
+        var trackingPath = Path.Join(outputDirectory, DefaultFileSettings.DefaultExecutionSummaryTrackingDirectory, DefaultFileSettings.DefaultTrackingFileName(timeStamp));
+        File.Exists(trackingPath).ShouldBeTrue();
+
+        var content = GetFileContent(trackingPath);
+        var trackingData = SailfishSerializer.Deserialize<IEnumerable<ClassExecutionSummaryTrackingFormat>>(content)?.ToList();
+
+        trackingData.ShouldNotBeNull();
+        trackingData.Count.ShouldBe(1);
+
+        var result = trackingData.Single();
+        result.TestClass.ShouldBe(typeof(MinimalTest));
+        result.CompiledTestCaseResults.Count().ShouldBe(1);
+        result.CompiledTestCaseResults.Single().Exception.ShouldBeNull();
+        result.CompiledTestCaseResults.Single().PerformanceRunResult.ShouldNotBeNull();
+        result.CompiledTestCaseResults.Single().PerformanceRunResult!.RawExecutionResults.Length.ShouldBe(sampleSizeOverride);
+    }
+
+    [Fact]
+    public async Task TestRunCompleteIsInvoked()
+    {
+        var outputDirectory = Some.RandomString();
+        var timeStamp = DateTime.Now;
+        const int sampleSizeOverride = 4;
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(outputDirectory)
+            .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .TestsFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .WithTestNames(nameof(MinimalTest))
+            .CreateTrackingFiles()
+            .DisableOverheadEstimation()
+            .WithTimeStamp(timeStamp)
+            .WithGlobalSampleSize(sampleSizeOverride)
+            .WithAnalysisDisabledGlobally()
+            .Build();
+
+        await SailfishRunner.Run(runSettings);
+
+        var content = GetFileContent(Path.Join(outputDirectory, "TestRunCompleted.txt"));
+        content.ShouldBe("TestRunComplete");
+    }
+
+    [Fact]
+    public async Task OutputsAreWritten()
+    {
+        var outputDirectory = Some.RandomString();
+        var timeStamp = DateTime.Now;
+        const int sampleSizeOverride = 4;
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(outputDirectory)
+            .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .TestsFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .WithTestNames(nameof(MinimalTest))
+            .DisableOverheadEstimation()
+            .WithTimeStamp(timeStamp)
+            .WithGlobalSampleSize(sampleSizeOverride)
+            .WithAnalysisDisabledGlobally()
+            .Build();
+
+        await SailfishRunner.Run(runSettings);
+
+        var files = Directory.GetFiles(outputDirectory);
+        var csv = files.Single(x => x.EndsWith(DefaultFileSettings.CsvSuffix));
+        var md = files.Single(x => x.EndsWith(DefaultFileSettings.MarkdownSuffix));
+
+        var csvContent = GetFileContent(csv);
+        var mdContent = GetFileContent(md);
+
+        csvContent.ShouldContain(nameof(MinimalTest));
+        mdContent.ShouldContain(nameof(MinimalTest));
+    }
+
+    private static string GetFileContent(string md)
+    {
+        using var stream = new StreamReader(md);
+        return stream.ReadToEnd();
+    }
+}


### PR DESCRIPTION
## Description

Recently refactored to use test case and test run notifications - these each will create various files. This PR adds tests to ensure they're invoked correctly and successfully.

