### PR TITLE
Add ordering support to SailfishMethod attribute

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/MinimalTestExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/MinimalTestExample.cs
@@ -5,25 +5,9 @@ namespace PerformanceTests.ExamplePerformanceTests;
 
 [WriteToCsv]
 [WriteToMarkdown]
-[Sailfish(SampleSize = 5, DisableOverheadEstimation = true, NumWarmupIterations = 0)]
+[Sailfish(SampleSize = 10, DisableOverheadEstimation = true, NumWarmupIterations = 0)]
 public class MinimalTestExample
 {
-    [SailfishIterationSetup]
-    public void Setup()
-    {
-        Thread.Sleep(10);
-    }
-
-    [SailfishMethod]
-    public void Minimal()
-    {
-        Thread.Sleep(50);
-    }
-    
-    [SailfishMethod]
-    public void OtherMinimal()
-    {
-        Thread.Sleep(50);
-    }
-    
+    [SailfishMethod(Order = 3)]
+    public void Minimal() => Thread.Sleep(50);
 }

--- a/source/PerformanceTests/ExamplePerformanceTests/OrderingExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/OrderingExample.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using Sailfish.Attributes;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+[WriteToCsv]
+[WriteToMarkdown]
+[Sailfish(SampleSize = 1, DisableOverheadEstimation = true, NumWarmupIterations = 0)]
+public class OrderingExample
+{
+    [SailfishMethod(Order = 3)]
+    public void Second() => Thread.Sleep(50);
+
+    [SailfishMethod(Order = 2)]
+    public void First() => Thread.Sleep(50);
+
+    [SailfishMethod]
+    public void Last() => Thread.Sleep(50);
+}

--- a/source/Sailfish/Attributes/SailfishMethodAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodAttribute.cs
@@ -13,9 +13,10 @@ namespace Sailfish.Attributes;
 public sealed class SailfishMethodAttribute : Attribute
 {
     /// <summary>
-    /// Indicates whether the Sailfish method is disabled.
+    /// Sets the order of execution for a method within the Sailfish class.
+    /// Ordered methods are always executed before unordered methods.
+    /// Order of unordered methods is not guaranteed.
     /// </summary>
-    /// <value><c>true</c> if the test is disabled; otherwise, <c>false</c>.</value>
     [Range(0, int.MaxValue)]
     public int Order { get; set; } = int.MaxValue;
 

--- a/source/Sailfish/Attributes/SailfishMethodAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodAttribute.cs
@@ -13,7 +13,7 @@ namespace Sailfish.Attributes;
 public sealed class SailfishMethodAttribute : Attribute
 {
     /// <summary>
-    /// Sets the order of execution for a method within the Sailfish class.
+    /// Sets the order of execution for a SailfishMethod within the Sailfish class.
     /// Ordered methods are always executed before unordered methods.
     /// Order of unordered methods is not guaranteed.
     /// </summary>

--- a/source/Sailfish/Attributes/SailfishMethodAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Sailfish.Attributes;
 
@@ -11,6 +12,13 @@ namespace Sailfish.Attributes;
 [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
 public sealed class SailfishMethodAttribute : Attribute
 {
+    /// <summary>
+    /// Indicates whether the Sailfish method is disabled.
+    /// </summary>
+    /// <value><c>true</c> if the test is disabled; otherwise, <c>false</c>.</value>
+    [Range(0, int.MaxValue)]
+    public int Order { get; set; } = int.MaxValue;
+
     /// <summary>
     /// Indicates whether the Sailfish method is disabled.
     /// </summary>

--- a/source/Sailfish/Execution/TestInstanceContainerCreator.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerCreator.cs
@@ -35,10 +35,13 @@ internal class TestInstanceContainerCreator : ITestInstanceContainerCreator
             sailfishVariableSets = sailfishVariableSets.Where(propertyTensorFilter);
         }
 
-        var sailfishMethods = testType.GetMethodsWithAttribute<SailfishMethodAttribute>();
+        var sailfishMethods = testType
+            .GetMethodsWithAttribute<SailfishMethodAttribute>()
+            .OrderBy(x => x.GetCustomAttribute<SailfishMethodAttribute>()?.Order).ToList();
+
         if (instanceContainerFilter is not null)
         {
-            sailfishMethods = sailfishMethods.Where(instanceContainerFilter);
+            sailfishMethods = sailfishMethods.Where(instanceContainerFilter).ToList();
         }
 
         return sailfishMethods


### PR DESCRIPTION
## Description

Some scenarios would benefit from being able to specify an order to the execution of sailfish methods. For example when the first method times how long it takes to create a resource, and the second method times how long it takes to delete those resources.


## Results

You can now specify the order of execution by providing an 'Order' apram to the SailfishMethodAttribute.