### PR TITLE
[HotFix] Remove method name ordering from lib

### DIFF
--- a/source/Sailfish/Execution/SailFishTestExecutor.cs
+++ b/source/Sailfish/Execution/SailFishTestExecutor.cs
@@ -79,7 +79,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
         var totalMethodCount = testInstanceContainerProviders.Count - 1;
 
         var memoryCache = new MemoryCache(MemoryCacheName);
-        foreach (var testProvider in testInstanceContainerProviders.OrderBy(x => x.Method.Name))
+        foreach (var testProvider in testInstanceContainerProviders)
         {
             var providerPropertiesCacheKey = testProvider.Test.FullName ?? throw new SailfishException($"Failed to read the FullName of {testProvider.Test.Name}");
             TestCaseCountPrinter.PrintMethodUpdate(testProvider.Method);


### PR DESCRIPTION
## Description

Fixes an ordering bug in the library - where we were still ordering by method name


