### PR TITLE
Handle new tracking file streaming gracefully

### DIFF
--- a/source/Sailfish/DefaultHandlers/Sailfish/SailfishUpdateTrackingDataNotificationHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/SailfishUpdateTrackingDataNotificationHandler.cs
@@ -45,8 +45,9 @@ public class SailfishUpdateTrackingDataNotificationHandler : INotificationHandle
         var fileContents = await streamReader.ReadToEndAsync();
         streamReader.Close();
 
-        var classExecutionSummaryTrackingFormats = trackingFileSerialization.Deserialize(fileContents)?.ToList()
-                                                   ?? new List<ClassExecutionSummaryTrackingFormat>();
+        var classExecutionSummaryTrackingFormats = string.IsNullOrEmpty(fileContents)
+            ? new List<ClassExecutionSummaryTrackingFormat>()
+            : trackingFileSerialization.Deserialize(fileContents)?.ToList() ?? new List<ClassExecutionSummaryTrackingFormat>();
 
         foreach (var failedSummary in notification.TestCaseExecutionResult.GetFailedTestCases())
         {


### PR DESCRIPTION
## Description

When we first begin our tracking file streaming up date - the new file created will be empty. In this case, a json exception will be thrown when attempting to write. Instead of throwing, we should handle this and return an empty list to which we can add updates.
