### PR TITLE
Make TTestSailfish public

### DIFF
--- a/source/Sailfish/Statistics/Tests/TTestSailfish/TTestSailfish.cs
+++ b/source/Sailfish/Statistics/Tests/TTestSailfish/TTestSailfish.cs
@@ -8,7 +8,7 @@ using Sailfish.Contracts.Public;
 
 namespace Sailfish.Statistics.Tests.TTestSailfish;
 
-internal class TTestSailfish : ITTestSailfish
+public class TTestSailfish : ITTestSailfish
 {
     private readonly ITestPreprocessor preprocessor;
 


### PR DESCRIPTION
## Description
For some reason, the TTestSailfish class was internal. This should be public
