### PR TITLE
Refactor method injections for clarity and correctness

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/ExceptionExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ExceptionExample.cs
@@ -1,5 +1,7 @@
 using Sailfish.Attributes;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PerformanceTests.ExamplePerformanceTests;
 
@@ -10,5 +12,14 @@ public class ExceptionExample
     public void ThrowException()
     {
         throw new Exception();
+    }
+
+
+    [SailfishMethod]
+    public Task DoesNotThrowException(CancellationToken ct)
+    {
+        // do nothing
+        Console.WriteLine(ct.ToString());
+        return Task.CompletedTask;
     }
 }

--- a/source/Sailfish/Execution/CoreInvoker.cs
+++ b/source/Sailfish/Execution/CoreInvoker.cs
@@ -62,10 +62,7 @@ internal class CoreInvoker(object instance, MethodInfo method, PerformanceTimer 
 
     public async Task ExecutionMethod(CancellationToken cancellationToken, bool timed = true)
     {
-        if (timed)
-            await mainMethod.TryInvokeWithTimer(instance, testCasePerformanceTimer, cancellationToken).ConfigureAwait(false);
-        else
-            await mainMethod.TryInvoke(instance, cancellationToken).ConfigureAwait(false);
+        await mainMethod.TryInvoke(instance, cancellationToken, timed ? testCasePerformanceTimer : null).ConfigureAwait(false);
     }
 
     public async Task IterationTearDown(CancellationToken cancellationToken)

--- a/source/Tests.Library/E2EScenarios/FullE2EExceptionCases.cs
+++ b/source/Tests.Library/E2EScenarios/FullE2EExceptionCases.cs
@@ -44,7 +44,7 @@ public class FullE2EExceptionCases
         result.IsValid.ShouldBeFalse();
         result.Exceptions.ShouldNotBeNull();
         result.Exceptions.Count().ShouldBe(1);
-        result.Exceptions.Single().Message.ShouldBe("Method Setup Exception");
+        result.Exceptions.Single().InnerException?.Message.ShouldBe("Method Setup Exception");
     }
 
     [Fact]
@@ -176,24 +176,6 @@ public class FullE2EExceptionCases
     }
 
     [Fact]
-    public async Task VoidMethodRequestsCancellationTokenThrows()
-    {
-        var runSettings = RunSettingsBuilder.CreateBuilder()
-            .WithLocalOutputDirectory(Some.RandomString())
-            .WithTestNames(nameof(VoidMethodRequestsCancellationToken))
-            .ProvidersFromAssembliesContaining(typeof(E2ETestExceptionHandlingProvider))
-            .TestsFromAssembliesContaining(typeof(E2ETestExceptionHandlingProvider))
-            .Build();
-
-        var result = await SailfishRunner.Run(runSettings);
-
-        result.IsValid.ShouldBeFalse();
-        result.Exceptions.ShouldNotBeNull();
-        result.Exceptions.Count().ShouldBe(1);
-        result.Exceptions.Single().Message.ShouldBe("Parameter injection is not supported for void methods");
-    }
-
-    [Fact]
     public async Task MultipleInjectionsOnAMethodThrows()
     {
         var runSettings = RunSettingsBuilder.CreateBuilder()
@@ -208,7 +190,7 @@ public class FullE2EExceptionCases
         result.IsValid.ShouldBeFalse();
         result.Exceptions.ShouldNotBeNull();
         result.Exceptions.Count().ShouldBe(1);
-        result.Exceptions.Single().Message.ShouldBe("Parameter injection is only supported for a single parameter which must be a the CancellationToken type");
+        result.Exceptions.Single().Message.ShouldBe("The 'MainMethod' method in class 'MultipleInjectionsOnAsyncMethod' may only receive a single 'CancellationToken' parameter");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The original impl of the invocation reflection concerned itself with the discrimination of different types of methods (async, sync, parameterized, non parameterized, etc). This led to poor experience when encountering exceptions or specific edge cases.

Fixes: https://github.com/paulegradie/Sailfish/issues/139

## Results

This PR cleans up the exceptions, simplifies the invocation methods, and allows cancellation tokens to be injected in any method.