### PR TITLE
Added more logging to help track what is going on

### DIFF
--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -112,8 +112,9 @@ internal class TestCaseIterator(IRunSettings runSettings, ILogger logger) : ITes
         return new TestCaseExecutionResult(testInstanceContainer);
     }
 
-    private static TestCaseExecutionResult CatchAndReturn(TestInstanceContainer testProvider, Exception ex)
+    private TestCaseExecutionResult CatchAndReturn(TestInstanceContainer testProvider, Exception ex)
     {
+        logger.Log(LogLevel.Error, ex, "An exception occured during test execution");
         return new TestCaseExecutionResult(testProvider, ex);
     }
 }

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Sailfish.Logging;
 
 namespace Sailfish.Execution;
 
@@ -10,7 +11,7 @@ internal interface ITestCaseIterator
     Task<TestCaseExecutionResult> Iterate(TestInstanceContainer testInstanceContainer, bool DisableOverheadEstimation, CancellationToken cancellationToken);
 }
 
-internal class TestCaseIterator(IRunSettings runSettings) : ITestCaseIterator
+internal class TestCaseIterator(IRunSettings runSettings, ILogger logger) : ITestCaseIterator
 {
     private readonly IRunSettings runSettings = runSettings;
 
@@ -27,6 +28,8 @@ internal class TestCaseIterator(IRunSettings runSettings) : ITestCaseIterator
         testInstanceContainer.CoreInvoker.SetTestCaseStart();
         for (var i = 0; i < iterations; i++)
         {
+            logger.Log(LogLevel.Information, "      ---- iteration {CurrentIteration} of {TotalIterations}", i, iterations);
+            
             cancellationToken.ThrowIfCancellationRequested();
 
             try
@@ -66,10 +69,12 @@ internal class TestCaseIterator(IRunSettings runSettings) : ITestCaseIterator
         return new TestCaseExecutionResult(testInstanceContainer);
     }
 
-    private static async Task<TestCaseExecutionResult> WarmupIterations(TestInstanceContainer testInstanceContainer, CancellationToken cancellationToken)
+    private async Task<TestCaseExecutionResult> WarmupIterations(TestInstanceContainer testInstanceContainer, CancellationToken cancellationToken)
     {
         for (var i = 0; i < testInstanceContainer.NumWarmupIterations; i++)
         {
+            logger.Log(LogLevel.Information, "      ---- warmup iteration {CurrentIteration} of {TotalIterations}", i, testInstanceContainer.NumWarmupIterations);
+
             cancellationToken.ThrowIfCancellationRequested();
 
             try

--- a/source/Sailfish/Logging/TestCaseCountPrinter.cs
+++ b/source/Sailfish/Logging/TestCaseCountPrinter.cs
@@ -68,7 +68,7 @@ internal class TestCaseCountPrinter(ILogger logger) : ITestCaseCountPrinter
 
     public void PrintCaseUpdate(string displayName)
     {
-        WriteUpdate("     --- test case {CurrentTestCase} of {TotalTestCases}: {TestCase}", currentTestCase, testCaseTotal, displayName);
+        WriteUpdate("    --- test case {CurrentTestCase} of {TotalTestCases}: {TestCase}", currentTestCase, testCaseTotal, displayName);
         IncrementCase();
     }
 


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/3ohhwfL19q2eCPaBEs/giphy.gif"/>

A few changes:
- Added logging for each itteration. I was wondering why the method setup was getting called more than once and tests were taking too long. Turns out the warmup itterations were globaly overridden. This logging helps surface this by showing what is warmup and what is actual test run
- Exceptions during test runs were not being output to the log. This meant it was hard to figure out what went wrong if you didn't have the console output
- Minor fix to the indent from 5 to 4 spaces