### PR TITLE
Allow remaining test cases to succeed if one fails and print case counts correctly

### DIFF
--- a/source/ConsoleAppDemo/Program.cs
+++ b/source/ConsoleAppDemo/Program.cs
@@ -8,7 +8,7 @@ var settings = RunSettingsBuilder
     .CreateBuilder()
     .TestsFromAssembliesContaining(typeof(PerformanceTestProjectDiscoveryAnchor))
     .ProvidersFromAssembliesContaining(typeof(AppRegistrationProvider))
-    // .WithTestNames(typeof(ExceptionExample).FullName!, typeof(MinimalTestExample).FullName)
+    // .WithTestNames(typeof(TestsRunIfException).FullName!)
     .WithSailDiff()
     .WithScaleFish()
     .WithGlobalSampleSize(5)

--- a/source/PerformanceTests/ExamplePerformanceTests/TestsRunIfException.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/TestsRunIfException.cs
@@ -1,0 +1,37 @@
+﻿using Sailfish.Attributes;
+using System;
+using System.Threading.Tasks;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+[Sailfish]
+public class TestsRunIfException
+{
+    [SailfishMethodSetup]
+    public async Task MethodSetupThrows()
+    {
+        await Task.Yield();
+        throw new Exception();
+    }
+    
+    [SailfishMethod(Order = 1)]
+    public async Task WillItRun()
+    {
+        await Task.Yield();
+        Console.WriteLine("It Ran");
+    }
+
+    [SailfishMethod(Order = 2)]
+    public async Task ThisWillThrow()
+    {
+        await Task.Yield();
+        throw new Exception("OH No");
+    }
+
+    [SailfishMethod(Order = 3)]
+    public async Task ItHadBetterRun()
+    {
+        await Task.Yield();
+        Console.WriteLine("It also ran!");
+    }
+}

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionEngine.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionEngine.cs
@@ -1,7 +1,6 @@
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Sailfish.Exceptions;
 using Sailfish.Execution;
-using Sailfish.Extensions.Types;
 using Sailfish.TestAdapter.TestProperties;
 using System;
 using System.Collections.Generic;

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
@@ -2,10 +2,8 @@
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
-using Sailfish.Contracts.Public.Requests;
-using Sailfish.Extensions.Types;
+using Sailfish.Logging;
 using Sailfish.Presentation;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,6 +24,7 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
     private readonly IRunSettings runSettings;
     private readonly IAdapterSailDiff sailDiff;
     private readonly IAdapterScaleFish scaleFish;
+    private readonly ITestCaseCountPrinter testCaseCountPrinter;
     private readonly ITestAdapterExecutionEngine testAdapterExecutionEngine;
 
     public TestAdapterExecutionProgram(
@@ -35,7 +34,8 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
         IMediator mediator,
         IAdapterConsoleWriter consoleWriter,
         IAdapterSailDiff sailDiff,
-        IAdapterScaleFish scaleFish)
+        IAdapterScaleFish scaleFish,
+        ITestCaseCountPrinter testCaseCountPrinter)
     {
         this.runSettings = runSettings;
         this.testAdapterExecutionEngine = testAdapterExecutionEngine;
@@ -44,6 +44,7 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
         this.consoleWriter = consoleWriter;
         this.sailDiff = sailDiff;
         this.scaleFish = scaleFish;
+        this.testCaseCountPrinter = testCaseCountPrinter;
     }
 
     public async Task Run(List<TestCase> testCases, CancellationToken cancellationToken)
@@ -54,6 +55,9 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
             return;
         }
 
+        testCaseCountPrinter.SetTestCaseTotal(testCases.Count);
+        testCaseCountPrinter.PrintDiscoveredTotal();
+        
         var executionSummaries = await testAdapterExecutionEngine.Execute(testCases, cancellationToken);
 
         // Something weird is going on here when there is an exception - all of the testcases runs get logged into the test output window for the errored case

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterModule.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterModule.cs
@@ -3,7 +3,8 @@ using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.ScaleFish;
-using Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
+using Sailfish.Logging;
 using Sailfish.TestAdapter.FrameworkHandlers;
 
 namespace Sailfish.TestAdapter.Execution;
@@ -23,6 +24,7 @@ internal class TestAdapterModule(IFrameworkHandle? frameworkHandle) : Module
         builder.RegisterType<AdapterSailDiff>().As<IAdapterSailDiff>();
         builder.RegisterType<AdapterScaleFish>().As<IScaleFishInternal>();
         builder.RegisterType<AdapterScaleFish>().As<IAdapterScaleFish>();
+        builder.RegisterType<TestCaseCountPrinter>().As<ITestCaseCountPrinter>().SingleInstance();
 
         builder.RegisterType<ExecutionStartingNotificationHandler>().As<INotificationHandler<ExecutionStartingNotification>>();
         builder.RegisterType<ExecutionCompletedNotificationHandler>().As<INotificationHandler<ExecutionCompletedNotification>>();

--- a/source/Sailfish.TestAdapter/FrameworkHandlers/ExceptionNotificationHandler.cs
+++ b/source/Sailfish.TestAdapter/FrameworkHandlers/ExceptionNotificationHandler.cs
@@ -1,9 +1,7 @@
 ﻿using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Perfolizer.Mathematics.SignificanceTesting;
-using Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 using Sailfish.TestAdapter.Execution;
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/source/Sailfish.TestAdapter/FrameworkHandlers/ExecutionCompletedNotificationHandler.cs
+++ b/source/Sailfish.TestAdapter/FrameworkHandlers/ExecutionCompletedNotificationHandler.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Requests;
 using Sailfish.Exceptions;

--- a/source/Sailfish.TestAdapter/FrameworkHandlers/ExecutionDisabledNotificationHandler.cs
+++ b/source/Sailfish.TestAdapter/FrameworkHandlers/ExecutionDisabledNotificationHandler.cs
@@ -1,6 +1,6 @@
 ﻿using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 using Sailfish.TestAdapter.Execution;
 using System;
 using System.Linq;

--- a/source/Sailfish.TestAdapter/FrameworkHandlers/ExecutionStartingNotificationHandler.cs
+++ b/source/Sailfish.TestAdapter/FrameworkHandlers/ExecutionStartingNotificationHandler.cs
@@ -1,9 +1,8 @@
 ﻿using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 using Sailfish.TestAdapter.Execution;
 using Sailfish.TestAdapter.TestProperties;
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/source/Sailfish.TestAdapter/FrameworkHandlers/TestInstanceContainerExtensionMethods.cs
+++ b/source/Sailfish.TestAdapter/FrameworkHandlers/TestInstanceContainerExtensionMethods.cs
@@ -1,11 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Sailfish.Execution;
 using Sailfish.TestAdapter.TestProperties;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sailfish.TestAdapter.FrameworkHandlers;
 internal static class TestInstanceContainerExtensionMethods

--- a/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExceptionNotification.cs
+++ b/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExceptionNotification.cs
@@ -2,9 +2,9 @@
 using Sailfish.Execution;
 using System.Collections.Generic;
 
-namespace Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+namespace Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 internal class ExceptionNotification(TestInstanceContainer testInstanceContainer, IEnumerable<dynamic> testCaseGroup) : INotification
 {
-    public TestInstanceContainer TestInstanceContainer { get; set; } = testInstanceContainer;
+    public TestInstanceContainer? TestInstanceContainer { get; set; } = testInstanceContainer;
     public IEnumerable<dynamic> TestCaseGroup { get; set; } = testCaseGroup;
 }

--- a/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExecutionCompletedNotification.cs
+++ b/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExecutionCompletedNotification.cs
@@ -1,10 +1,8 @@
 ﻿using MediatR;
 using Sailfish.Execution;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
-namespace Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+namespace Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 internal class ExecutionCompletedNotification(TestCaseExecutionResult testCaseExecutionResult, TestInstanceContainer testInstanceContainer, IEnumerable<dynamic> testCaseGroup) : INotification
 {
     public TestCaseExecutionResult TestCaseExecutionResult { get; set; } = testCaseExecutionResult;

--- a/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExecutionDisabledNotification.cs
+++ b/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExecutionDisabledNotification.cs
@@ -1,12 +1,8 @@
 ﻿using MediatR;
 using Sailfish.Execution;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+namespace Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 internal class ExecutionDisabledNotification(TestInstanceContainer testInstanceContainer, IEnumerable<dynamic> testCaseGroup, bool disableTheGroup) : INotification
 {
     public TestInstanceContainer TestInstanceContainer { get; set; } = testInstanceContainer;

--- a/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExecutionStartingNotification.cs
+++ b/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExecutionStartingNotification.cs
@@ -1,12 +1,8 @@
 ﻿using MediatR;
 using Sailfish.Execution;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Sailfish.Contracts.Private.ExecutionCallbackHandlers;
+namespace Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 
 
 internal class ExecutionStartingNotification(TestInstanceContainer testInstanceContainer, IEnumerable<dynamic> testCaseGroup) : INotification

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -8,14 +8,16 @@ namespace Sailfish.Execution;
 
 internal interface ITestCaseIterator
 {
-    Task<TestCaseExecutionResult> Iterate(TestInstanceContainer testInstanceContainer, bool DisableOverheadEstimation, CancellationToken cancellationToken);
+    Task<TestCaseExecutionResult> Iterate(TestInstanceContainer testInstanceContainer, bool DisableOverheadEstimation,
+        CancellationToken cancellationToken);
 }
 
 internal class TestCaseIterator(IRunSettings runSettings, ILogger logger) : ITestCaseIterator
 {
     private readonly IRunSettings runSettings = runSettings;
 
-    public async Task<TestCaseExecutionResult> Iterate(TestInstanceContainer testInstanceContainer, bool disableOverheadEstimation, CancellationToken cancellationToken)
+    public async Task<TestCaseExecutionResult> Iterate(TestInstanceContainer testInstanceContainer,
+        bool disableOverheadEstimation, CancellationToken cancellationToken)
     {
         var overheadEstimator = new OverheadEstimator();
         var warmupResult = await WarmupIterations(testInstanceContainer, cancellationToken);
@@ -23,13 +25,15 @@ internal class TestCaseIterator(IRunSettings runSettings, ILogger logger) : ITes
 
         if (!disableOverheadEstimation) await overheadEstimator.Estimate();
 
-        var iterations = runSettings.SampleSizeOverride is not null ? Math.Max(runSettings.SampleSizeOverride.Value, 1) : testInstanceContainer.SampleSize;
+        var iterations = runSettings.SampleSizeOverride is not null
+            ? Math.Max(runSettings.SampleSizeOverride.Value, 1)
+            : testInstanceContainer.SampleSize;
 
         testInstanceContainer.CoreInvoker.SetTestCaseStart();
         for (var i = 0; i < iterations; i++)
         {
-            logger.Log(LogLevel.Information, "      ---- iteration {CurrentIteration} of {TotalIterations}", i, iterations);
-            
+            logger.Log(LogLevel.Information, "      ---- iteration {CurrentIteration} of {TotalIterations}", i + 1,
+                iterations);
             cancellationToken.ThrowIfCancellationRequested();
 
             try
@@ -69,11 +73,13 @@ internal class TestCaseIterator(IRunSettings runSettings, ILogger logger) : ITes
         return new TestCaseExecutionResult(testInstanceContainer);
     }
 
-    private async Task<TestCaseExecutionResult> WarmupIterations(TestInstanceContainer testInstanceContainer, CancellationToken cancellationToken)
+    private async Task<TestCaseExecutionResult> WarmupIterations(TestInstanceContainer testInstanceContainer,
+        CancellationToken cancellationToken)
     {
         for (var i = 0; i < testInstanceContainer.NumWarmupIterations; i++)
         {
-            logger.Log(LogLevel.Information, "      ---- warmup iteration {CurrentIteration} of {TotalIterations}", i, testInstanceContainer.NumWarmupIterations);
+            logger.Log(LogLevel.Information, "      ---- warmup iteration {CurrentIteration} of {TotalIterations}", i + 1,
+                testInstanceContainer.NumWarmupIterations);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/source/Sailfish/Extensions/Methods/InvocationReflectionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/InvocationReflectionExtensionMethods.cs
@@ -1,0 +1,108 @@
+﻿using Sailfish.Attributes;
+using Sailfish.Exceptions;
+using Sailfish.Execution;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sailfish.Extensions.Methods;
+
+internal static class InvocationReflectionExtensionMethods 
+{
+
+    internal static bool IsAsyncMethod(this MethodInfo method)
+    { return method.HasAttribute<AsyncStateMachineAttribute>(); }
+
+    internal static bool ReturnTypeIsTask(Type returnType)
+    {
+        return returnType == typeof(Task) ||
+            returnType.IsGenericType &&
+            returnType.GetGenericTypeDefinition() == typeof(Task<>);
+    }
+
+    internal static bool ReturnTypeIsValueTask(Type returnType)
+    {
+        return returnType == typeof(ValueTask) ||
+            returnType.IsGenericType &&
+            returnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
+    }
+
+    internal static async Task TryInvoke(this MethodInfo? method, object instance, CancellationToken cancellationToken, PerformanceTimer? performanceTimer = null)
+    {
+        if (method is null) return;
+        var parameters = method.GetParameters().ToList();
+        var arguments = new List<object> { };
+        var errorMsg = $"The '{method.Name}' method in class '{instance.GetType().Name}' may only receive a single '{nameof(CancellationToken)}' parameter";
+        if (parameters.Count > 1)
+        {
+            throw new TestFormatException(errorMsg);
+        }
+        if (parameters.Count == 1)
+        {
+            var paramIsCancellationToken = parameters.Single().ParameterType == typeof(CancellationToken);
+            if (!paramIsCancellationToken)
+            {
+                throw new TestFormatException(errorMsg);
+            }
+            arguments.Add(cancellationToken);
+        }
+
+        if (method.IsAsyncMethod())
+        {
+            if (ReturnTypeIsTask(method.ReturnType))
+            {
+                performanceTimer?.StartSailfishMethodExecutionTimer();
+                await (Task)method.Invoke(instance, [.. arguments])!;
+                performanceTimer?.StopSailfishMethodExecutionTimer();
+            }
+            else if (ReturnTypeIsValueTask(method.ReturnType))
+            {
+                performanceTimer?.StartSailfishMethodExecutionTimer();
+                await (ValueTask)method.Invoke(instance, [.. arguments])!;
+                performanceTimer?.StopSailfishMethodExecutionTimer();
+            }
+            else
+            {
+                throw new TestFormatException($"The async '{method.Name}' method in class '{instance.GetType().Name}' may only return '{nameof(Task)}' or '{nameof(ValueTask)}'");
+            }
+        }
+        else
+        {
+            performanceTimer?.StartSailfishMethodExecutionTimer();
+            method.Invoke(instance, [.. arguments]);
+            performanceTimer?.StopSailfishMethodExecutionTimer();
+        }
+    }
+
+    internal static int GetSampleSize(this Type type)
+    {
+        return type
+            .GetCustomAttributes(true)
+            .OfType<SailfishAttribute>()
+            .Single()
+            .SampleSize;
+    }
+
+    internal static int GetWarmupIterations(this Type type)
+    {
+        return type
+            .GetCustomAttributes(true)
+            .OfType<SailfishAttribute>()
+            .Single()
+            .NumWarmupIterations;
+    }
+
+    internal static bool SailfishTypeIsDisabled(this Type type)
+    {
+        return type
+            .GetCustomAttributes(true)
+            .OfType<SailfishAttribute>()
+            .Single()
+            .Disabled;
+    }
+
+}

--- a/source/Sailfish/Extensions/Methods/ReflectionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/ReflectionExtensionMethods.cs
@@ -1,13 +1,7 @@
-﻿using Sailfish.Attributes;
-using Sailfish.Exceptions;
-using Sailfish.Execution;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Sailfish.Extensions.Methods;
 
@@ -31,97 +25,6 @@ public static class ReflectionExtensionMethods
     internal static IEnumerable<MethodInfo> GetMethodsWithAttribute<TAttribute>(this Type type)
         where TAttribute : Attribute
     { return type.GetMethods(BindingFlags.Public | BindingFlags.Instance).Where(x => x.HasAttribute<TAttribute>()); }
-
-    internal static bool IsAsyncMethod(this MethodInfo method)
-    { return method.HasAttribute<AsyncStateMachineAttribute>(); }
-
-    internal static bool ReturnTypeIsTask(Type returnType)
-    {
-        return returnType == typeof(Task) ||
-            returnType.IsGenericType &&
-            returnType.GetGenericTypeDefinition() == typeof(Task<>);
-    }
-
-    internal static bool ReturnTypeIsValueTask(Type returnType)
-    {
-        return returnType == typeof(ValueTask) ||
-            returnType.IsGenericType &&
-            returnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
-    }
-
-    internal static async Task TryInvoke(this MethodInfo? method, object instance, CancellationToken cancellationToken, PerformanceTimer? performanceTimer = null)
-    {
-        if (method is null) return;
-        var parameters = method.GetParameters().ToList();
-        var arguments = new List<object> { };
-        var errorMsg = $"The '{method.Name}' method in class '{instance.GetType().Name}' may only receive a single '{nameof(CancellationToken)}' parameter";
-        if (parameters.Count > 1)
-        {
-            throw new TestFormatException(errorMsg);
-        }
-        if (parameters.Count == 1)
-        {
-            var paramIsCancellationToken = parameters.Single().ParameterType == typeof(CancellationToken);
-            if (!paramIsCancellationToken)
-            {
-                throw new TestFormatException(errorMsg);
-            }
-            arguments.Add(cancellationToken);
-        }
-
-        if (method.IsAsyncMethod())
-        {
-            if (ReturnTypeIsTask(method.ReturnType))
-            {
-                performanceTimer?.StartSailfishMethodExecutionTimer();
-                await (Task)method.Invoke(instance, [.. arguments])!;
-                performanceTimer?.StopSailfishMethodExecutionTimer();
-            }
-            else if (ReturnTypeIsValueTask(method.ReturnType))
-            {
-                performanceTimer?.StartSailfishMethodExecutionTimer();
-                await (ValueTask)method.Invoke(instance, [.. arguments])!;
-                performanceTimer?.StopSailfishMethodExecutionTimer();
-            }
-            else
-            {
-                throw new TestFormatException($"The async '{method.Name}' method in class '{instance.GetType().Name}' may only return '{nameof(Task)}' or '{nameof(ValueTask)}'");
-            }
-        }
-        else
-        {
-            performanceTimer?.StartSailfishMethodExecutionTimer();
-            method.Invoke(instance, [.. arguments]);
-            performanceTimer?.StopSailfishMethodExecutionTimer();
-        }
-    }
-
-    internal static int GetSampleSize(this Type type)
-    {
-        return type
-            .GetCustomAttributes(true)
-            .OfType<SailfishAttribute>()
-            .Single()
-            .SampleSize;
-    }
-
-    internal static int GetWarmupIterations(this Type type)
-    {
-        return type
-            .GetCustomAttributes(true)
-            .OfType<SailfishAttribute>()
-            .Single()
-            .NumWarmupIterations;
-    }
-
-    internal static bool SailfishTypeIsDisabled(this Type type)
-    {
-        return type
-            .GetCustomAttributes(true)
-            .OfType<SailfishAttribute>()
-            .Single()
-            .Disabled;
-    }
 
     public static List<MethodInfo> FindMethodsDecoratedWithAttribute<TAttribute>(this object obj)
         where TAttribute : Attribute

--- a/source/Sailfish/Extensions/Methods/TestCaseInstanceExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/TestCaseInstanceExtensionMethods.cs
@@ -1,6 +1,5 @@
 ﻿using Sailfish.Attributes;
 using Sailfish.Execution;
-using System;
 using System.Linq;
 using System.Reflection;
 

--- a/source/Tests.E2E.ExceptionHandling/Tests/TestsRunIfException.cs
+++ b/source/Tests.E2E.ExceptionHandling/Tests/TestsRunIfException.cs
@@ -1,0 +1,28 @@
+﻿using Sailfish.Attributes;
+
+namespace Tests.E2E.ExceptionHandling.Tests;
+
+[Sailfish(SampleSize = 1, NumWarmupIterations = 1, Disabled = false)]
+public class TestsRunIfException
+{
+    [SailfishMethod(Order = 1)]
+    public async Task WillItRun()
+    {
+        await Task.Yield();
+        Console.WriteLine("It Ran");
+    }
+
+    [SailfishMethod(Order = 2)]
+    public async Task ThisWillThrow()
+    {
+        await Task.Yield();
+        throw new Exception("OH No");
+    }
+
+    [SailfishMethod(Order = 3)]
+    public async Task ItHadBetterRun()
+    {
+        await Task.Yield();
+        Console.WriteLine("It also ran!");
+    }
+}

--- a/source/Tests.Library/E2EScenarios/FullE2EExceptionCases.cs
+++ b/source/Tests.Library/E2EScenarios/FullE2EExceptionCases.cs
@@ -213,4 +213,30 @@ public class FullE2EExceptionCases
             .Count(x => x is null)
             .ShouldBe(1);
     }
+
+    [Fact]
+    public async Task WhenOneTestCaseThrowsTheRemainingTestCasesStillExecute()
+    {
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(Some.RandomString())
+            .WithTestNames(nameof(TestsRunIfException))
+            .ProvidersFromAssembliesContaining(typeof(E2ETestExceptionHandlingProvider))
+            .TestsFromAssembliesContaining(typeof(E2ETestExceptionHandlingProvider))
+            .Build();
+        var result = await SailfishRunner.Run(runSettings);
+
+        result.IsValid.ShouldBeFalse();
+
+        result.Exceptions.ShouldNotBeNull();
+        result.Exceptions?.Count().ShouldBe(1);
+        result.ExecutionSummaries
+            .SelectMany(x => x.CompiledTestCaseResults.Select(c => c.PerformanceRunResult))
+            .Count(x => x is null)
+            .ShouldBe(1);
+
+        result.ExecutionSummaries
+            .SelectMany(x => x.CompiledTestCaseResults.Select(c => c.PerformanceRunResult))
+            .Count(x => x is not null)
+            .ShouldBe(2);
+    }
 }


### PR DESCRIPTION
## Description

Fixes: https://github.com/paulegradie/Sailfish/issues/146

Attempts to fix:
Fixes: https://github.com/paulegradie/Sailfish/issues/145

For Issues 145 - I haven't done thorough testing. If this doesn't resolve the issue, I'll look further into it and consider removing counts. The objective was to provide something of a 'progress bar' experience (without trying to impl some kind of a bar at this stage) - which we did find useful when following logs or running a console app locally (this is not intended to support the test adapter). 