### PR TITLE
Lower Microsoft.CodeAnalysis.Common to most common version with EF8 (4.5.0)

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/TestsRunIfException.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/TestsRunIfException.cs
@@ -8,10 +8,9 @@ namespace PerformanceTests.ExamplePerformanceTests;
 public class TestsRunIfException
 {
     [SailfishMethodSetup]
-    public async Task MethodSetupThrows()
+    public async Task MethodSetup()
     {
         await Task.Yield();
-        throw new Exception();
     }
     
     [SailfishMethod(Order = 1)]

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/LifecycleAttributeNames.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/LifecycleMethods/LifecycleAttributeNames.cs
@@ -2,19 +2,14 @@ namespace Sailfish.Analyzers.DiagnosticAnalyzers.LifecycleMethods;
 
 public class LifecycleAttributes
 {
-    public static readonly string[] Names;
-
-    static LifecycleAttributes()
-    {
-        Names = new[]
-        {
-            "SailfishGlobalSetup",
-            "SailfishGlobalTeardown",
-            "SailfishMethodSetup",
-            "SailfishMethodTeardown",
-            "SailfishIterationSetup",
-            "SailfishIterationTeardown",
-            "SailfishMethod"
-        };
-    }
+    public static readonly string[] Names =
+    [
+        "SailfishGlobalSetup",
+        "SailfishGlobalTeardown",
+        "SailfishMethodSetup",
+        "SailfishMethodTeardown",
+        "SailfishIterationSetup",
+        "SailfishIterationTeardown",
+        "SailfishMethod"
+    ];
 }

--- a/source/Sailfish.TestAdapter/Discovery/HashWrapper.cs
+++ b/source/Sailfish.TestAdapter/Discovery/HashWrapper.cs
@@ -6,12 +6,7 @@ namespace Sailfish.TestAdapter.Discovery;
 
 internal class HashWrapper : IHashAlgorithm
 {
-    private readonly HashAlgorithm hashAlgorithm;
-
-    public HashWrapper()
-    {
-        hashAlgorithm = SHA1.Create();
-    }
+    private readonly HashAlgorithm hashAlgorithm = SHA1.Create();
 
     public Guid GuidFromString(string data)
     {

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -34,7 +34,7 @@
 
         <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.8.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" />


### PR DESCRIPTION
## Description

Some widely used persistence frameworks (EF) out there unfortuantely use Microsoft.CodeAnalysis.Common=4.5.0. Sailfish also uses this library, except it uses 4.8.0. Since Sailfish doesn't require any critical dependencies from 4.8.0, I've decided to roll this back to 4.5.0 for better backwards compatibility. This is unlikely to change going forward.


In addition:
 - a bit of minor boy scouting