### PR TITLE
Pg/dont use modules internally

### DIFF
--- a/source/Sailfish.TestAdapter/Execution/TestAdapterRegistrations.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterRegistrations.cs
@@ -5,15 +5,21 @@ using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
 using Sailfish.Logging;
+using Sailfish.Registration;
 using Sailfish.TestAdapter.FrameworkHandlers;
 
 namespace Sailfish.TestAdapter.Execution;
 
-internal class TestAdapterModule(IFrameworkHandle? frameworkHandle) : Module
+internal class TestAdapterRegistrations : IProvideAdditionalRegistrations
 {
-    private readonly IFrameworkHandle? frameworkHandle = frameworkHandle;
+    private readonly IFrameworkHandle? frameworkHandle;
 
-    protected override void Load(ContainerBuilder builder)
+    public TestAdapterRegistrations(IFrameworkHandle? frameworkHandle)
+    {
+        this.frameworkHandle = frameworkHandle;
+    }
+
+    public void Load(ContainerBuilder builder)
     {
         if (frameworkHandle is not null) builder.RegisterInstance(frameworkHandle).As<IFrameworkHandle>();
 
@@ -26,11 +32,12 @@ internal class TestAdapterModule(IFrameworkHandle? frameworkHandle) : Module
         builder.RegisterType<AdapterScaleFish>().As<IAdapterScaleFish>();
         builder.RegisterType<TestCaseCountPrinter>().As<ITestCaseCountPrinter>().SingleInstance();
 
-        builder.RegisterType<ExecutionStartingNotificationHandler>().As<INotificationHandler<ExecutionStartingNotification>>();
-        builder.RegisterType<ExecutionCompletedNotificationHandler>().As<INotificationHandler<ExecutionCompletedNotification>>();
-        builder.RegisterType<ExecutionDisabledNotificationHandler>().As<INotificationHandler<ExecutionDisabledNotification>>();
+        builder.RegisterType<ExecutionStartingNotificationHandler>()
+            .As<INotificationHandler<ExecutionStartingNotification>>();
+        builder.RegisterType<ExecutionCompletedNotificationHandler>()
+            .As<INotificationHandler<ExecutionCompletedNotification>>();
+        builder.RegisterType<ExecutionDisabledNotificationHandler>()
+            .As<INotificationHandler<ExecutionDisabledNotification>>();
         builder.RegisterType<ExceptionNotificationHandler>().As<INotificationHandler<ExceptionNotification>>();
-
-
     }
 }

--- a/source/Sailfish.TestAdapter/TestExecutor.cs
+++ b/source/Sailfish.TestAdapter/TestExecutor.cs
@@ -61,7 +61,7 @@ public class TestExecutor : ITestExecutor
         {
             var runSettings = AdapterRunSettingsLoader.LoadAdapterRunSettings();
             var builder = new ContainerBuilder();
-            builder.RegisterSailfishTypes(runSettings, new TestAdapterModule(frameworkHandle));
+            builder.RegisterSailfishTypes(runSettings, new TestAdapterRegistrations(frameworkHandle));
 
             var refTestType = RetrieveReferenceTypeForTestProject(testCases);
             SailfishTypeRegistrationUtility.InvokeRegistrationProviderCallbackMain(

--- a/source/Sailfish/DefaultHandlers/Sailfish/TestCaseCompletedNotificationHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/TestCaseCompletedNotificationHandler.cs
@@ -13,11 +13,18 @@ using System.Threading.Tasks;
 
 namespace Sailfish.DefaultHandlers.Sailfish;
 
-public class SailfishUpdateTrackingDataNotificationHandler(ITrackingFileSerialization trackingFileSerialization, IRunSettings runSettings, ILogger logger) : INotificationHandler<TestCaseCompletedNotification>
+public class TestCaseCompletedNotificationHandler : INotificationHandler<TestCaseCompletedNotification>
 {
-    private readonly ILogger logger = logger;
-    private readonly IRunSettings runSettings = runSettings;
-    private readonly ITrackingFileSerialization trackingFileSerialization = trackingFileSerialization;
+    private readonly ILogger logger;
+    private readonly IRunSettings runSettings;
+    private readonly ITrackingFileSerialization trackingFileSerialization;
+
+    public TestCaseCompletedNotificationHandler(ITrackingFileSerialization trackingFileSerialization, IRunSettings runSettings, ILogger logger)
+    {
+        this.logger = logger;
+        this.runSettings = runSettings;
+        this.trackingFileSerialization = trackingFileSerialization;
+    }
 
     public async Task Handle(TestCaseCompletedNotification notification, CancellationToken cancellationToken)
     {

--- a/source/Sailfish/Registration/AssemblyRegistrationExtensionMethods.cs
+++ b/source/Sailfish/Registration/AssemblyRegistrationExtensionMethods.cs
@@ -5,9 +5,20 @@ namespace Sailfish.Registration;
 
 public static class AssemblyRegistrationExtensionMethods
 {
-    public static void RegisterSailfishTypes(this ContainerBuilder builder, IRunSettings runSettings, params Module[] additionalModules)
+    public static void RegisterSailfishTypes(this ContainerBuilder builder, IRunSettings runSettings)
     {
-        builder.RegisterModule(new SailfishModule(runSettings));
-        foreach (var additionalModule in additionalModules) builder.RegisterModule(additionalModule);
+        new SailfishModuleRegistrations(runSettings).Load(builder);
+    }
+
+    internal static void RegisterSailfishTypes(
+        this ContainerBuilder builder,
+        IRunSettings runSettings,
+        params IProvideAdditionalRegistrations[] additionalModules)
+    {
+        builder.RegisterSailfishTypes(runSettings);
+        foreach (var additionalModule in additionalModules)
+        {
+            additionalModule.Load(builder);
+        }
     }
 }

--- a/source/Sailfish/Registration/IProvideAdditionalRegistrations.cs
+++ b/source/Sailfish/Registration/IProvideAdditionalRegistrations.cs
@@ -1,0 +1,8 @@
+using Autofac;
+
+namespace Sailfish.Registration;
+
+public interface IProvideAdditionalRegistrations
+{
+    void Load(ContainerBuilder builder);
+}

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -23,23 +23,26 @@ using Sailfish.Presentation.Markdown;
 
 namespace Sailfish.Registration;
 
-public class SailfishModule(IRunSettings runSettings) : Module
+internal class SailfishModuleRegistrations : IProvideAdditionalRegistrations
 {
-    private readonly IRunSettings runSettings = runSettings;
+    private readonly IRunSettings runSettings;
 
-    protected override void Load(ContainerBuilder builder)
+    public SailfishModuleRegistrations(IRunSettings runSettings)
     {
-        base.Load(builder);
+        this.runSettings = runSettings;
+    }
 
+    public void Load(ContainerBuilder builder)
+    {
         builder.RegisterInstance(
             runSettings.DisableLogging
                 ? new SilentLogger()
                 : runSettings.CustomLogger ?? new DefaultLogger(runSettings.MinimumLogLevel)).As<ILogger>();
-        builder.RegisterMediatR(MediatRConfigurationBuilder.Create(typeof(SailfishModule).Assembly).Build());
-        builder.RegisterAssemblyTypes(typeof(SailfishModule).Assembly)
+        builder.RegisterMediatR(MediatRConfigurationBuilder.Create(typeof(SailfishModuleRegistrations).Assembly).Build());
+        builder.RegisterAssemblyTypes(typeof(SailfishModuleRegistrations).Assembly)
             .AsClosedTypesOf(typeof(INotificationHandler<>))
             .AsImplementedInterfaces();
-        builder.RegisterAssemblyTypes(typeof(SailfishModule).Assembly)
+        builder.RegisterAssemblyTypes(typeof(SailfishModuleRegistrations).Assembly)
             .AsClosedTypesOf(typeof(IRequestHandler<,>))
             .AsImplementedInterfaces();
 

--- a/source/Tests.TestAdapter/TestExecutionFixture.cs
+++ b/source/Tests.TestAdapter/TestExecutionFixture.cs
@@ -28,7 +28,7 @@ public class TestExecutionFixture
     {
         frameworkHandle = Substitute.For<IFrameworkHandle>();
         builder = new ContainerBuilder();
-        builder.RegisterSailfishTypes(Substitute.For<IRunSettings>(), new TestAdapterModule(frameworkHandle));
+        builder.RegisterSailfishTypes(Substitute.For<IRunSettings>(), new TestAdapterRegistrations(frameworkHandle));
         builder.RegisterInstance(RunSettingsBuilder.CreateBuilder().DisableOverheadEstimation().Build());
         var projectDll = DllFinder.FindThisProjectsDllRecursively();
         testCases = TestDiscovery.DiscoverTests(new[] { projectDll }, Substitute.For<IMessageLogger>()).ToList();


### PR DESCRIPTION
## Description

Extending Autofacs `Module` class internally in Sailfish is dangerious since clients will typically performance assembly scanning to discover modules. This PR removes these extensions and replaces them with an interface implementation that is used internally.
