### PR TITLE
Improve null reference error messaging

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/NullRefCheck.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/NullRefCheck.cs
@@ -1,0 +1,22 @@
+using Sailfish.Attributes;
+using System;
+using System.Threading.Tasks;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+public abstract class NullRefOnTheBase
+{
+    public NullThing? ThingINeed { get; set; }
+
+    public abstract record NullThing(object NotPresent);
+}
+
+[Sailfish]
+public class NullRefCheck : NullRefOnTheBase
+{
+    [SailfishMethod]
+    public async Task OopsNulRef()
+    {
+        Console.WriteLine(ThingINeed.NotPresent);
+    }
+}

--- a/source/Sailfish.TestAdapter/FrameworkHandlers/ExceptionNotificationHandler.cs
+++ b/source/Sailfish.TestAdapter/FrameworkHandlers/ExceptionNotificationHandler.cs
@@ -1,28 +1,37 @@
 ﻿using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Sailfish.Contracts.Private.ExecutionCallbackNotifications;
+using Sailfish.Logging;
 using Sailfish.TestAdapter.Execution;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sailfish.TestAdapter.FrameworkHandlers;
 
-internal class ExceptionNotificationHandler(IAdapterConsoleWriter consoleWriter) : INotificationHandler<ExceptionNotification>
+internal class ExceptionNotificationHandler(IAdapterConsoleWriter consoleWriter, ILogger logger)
+    : INotificationHandler<ExceptionNotification>
 {
-    private readonly IAdapterConsoleWriter consoleWriter = consoleWriter;
-
     public async Task Handle(ExceptionNotification notification, CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
 
+        logger.Log(LogLevel.Error, notification.Exception ?? new Exception("Undefined Exception"),
+            "Encountered exception during test case execution");
         if (notification.TestInstanceContainer is null)
         {
-            foreach (var testCase in notification.TestCaseGroup) consoleWriter.RecordEnd(testCase, TestOutcome.Failed);
+            foreach (var testCase in notification.TestCaseGroup)
+            {
+                consoleWriter.RecordEnd(testCase, TestOutcome.Failed);
+                consoleWriter.RecordResult(new TestResult(testCase));
+            }
         }
         else
         {
-            var currentTestCase = notification.TestInstanceContainer.GetTestCaseFromTestCaseGroupMatchingCurrentContainer(notification.TestCaseGroup.Cast<TestCase>());
+            var currentTestCase =
+                notification.TestInstanceContainer.GetTestCaseFromTestCaseGroupMatchingCurrentContainer(
+                    notification.TestCaseGroup.Cast<TestCase>());
             consoleWriter.RecordEnd(currentTestCase, TestOutcome.Failed);
             consoleWriter.RecordResult(new TestResult(currentTestCase));
         }

--- a/source/Sailfish.TestAdapter/TestExecutor.cs
+++ b/source/Sailfish.TestAdapter/TestExecutor.cs
@@ -88,7 +88,7 @@ public class TestExecutor : ITestExecutor
                 };
                 result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, ex.Message));
                 frameworkHandle.RecordResult(result);
-                frameworkHandle.RecordEnd(testCase, TestOutcome.None);
+                frameworkHandle.RecordEnd(testCase, TestOutcome.Skipped);
             }
         }
     }

--- a/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExceptionNotification.cs
+++ b/source/Sailfish/Contracts.Private/ExecutionCallbackNotifications/ExceptionNotification.cs
@@ -1,10 +1,12 @@
 ﻿using MediatR;
 using Sailfish.Execution;
+using System;
 using System.Collections.Generic;
 
 namespace Sailfish.Contracts.Private.ExecutionCallbackNotifications;
-internal class ExceptionNotification(TestInstanceContainer testInstanceContainer, IEnumerable<dynamic> testCaseGroup) : INotification
+internal class ExceptionNotification(TestInstanceContainer testInstanceContainer, IEnumerable<dynamic> testCaseGroup, Exception? exception) : INotification
 {
     public TestInstanceContainer? TestInstanceContainer { get; set; } = testInstanceContainer;
     public IEnumerable<dynamic> TestCaseGroup { get; set; } = testCaseGroup;
+    public Exception? Exception { get; } = exception;
 }

--- a/source/Sailfish/Extensions/Methods/InvocationReflectionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/InvocationReflectionExtensionMethods.cs
@@ -37,18 +37,20 @@ internal static class InvocationReflectionExtensionMethods
         var parameters = method.GetParameters().ToList();
         var arguments = new List<object> { };
         var errorMsg = $"The '{method.Name}' method in class '{instance.GetType().Name}' may only receive a single '{nameof(CancellationToken)}' parameter";
-        if (parameters.Count > 1)
+        switch (parameters.Count)
         {
-            throw new TestFormatException(errorMsg);
-        }
-        if (parameters.Count == 1)
-        {
-            var paramIsCancellationToken = parameters.Single().ParameterType == typeof(CancellationToken);
-            if (!paramIsCancellationToken)
-            {
+            case > 1:
                 throw new TestFormatException(errorMsg);
-            }
-            arguments.Add(cancellationToken);
+            case 1:
+                {
+                    var paramIsCancellationToken = parameters.Single().ParameterType == typeof(CancellationToken);
+                    if (!paramIsCancellationToken)
+                    {
+                        throw new TestFormatException(errorMsg);
+                    }
+                    arguments.Add(cancellationToken);
+                    break;
+                }
         }
 
         if (method.IsAsyncMethod())

--- a/source/Sailfish/Logging/DefaultLogger.cs
+++ b/source/Sailfish/Logging/DefaultLogger.cs
@@ -53,7 +53,7 @@ internal class DefaultLogger : ILogger
     {
         var lines = new List<string> { template, ex.Message };
         if (ex.StackTrace is not null)
-            lines.AddRange(ex.StackTrace.Split());
+            lines.Add(ex.StackTrace);
 
         if (ex.InnerException is not null)
         {
@@ -61,7 +61,7 @@ internal class DefaultLogger : ILogger
             if (innerExceptionMessage is not null) lines.Add(innerExceptionMessage);
 
             var innerStackTrace = ex.InnerException?.StackTrace;
-            if (innerStackTrace is not null) lines.AddRange(innerStackTrace.Split(Environment.NewLine));
+            if (innerStackTrace is not null) lines.Add(innerStackTrace);
         }
 
         JoinAndWriteLines(level, lines);


### PR DESCRIPTION
## Description

Null reference exceptions are a particularly cryptic issue - for example if you use a base class for a test and property on the base is null. The messaging around this isn't very good, so this PR introduces a slight improvement to make it more clear whats happening when debugging.