### PR TITLE
Fix bug in which test instance props are lost

### DIFF
--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -167,7 +167,10 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
                         if (!testCase.Disabled)
                             memoryCache.Add(
                                 new CacheItem(providerPropertiesCacheKey,
-                                    testCase.Instance.RetrievePropertiesAndFields()), new CacheItemPolicy());
+                                    testCase.Instance.RetrievePropertiesAndFields()), new CacheItemPolicy()
+                                {
+                                    Priority = CacheItemPriority.NotRemovable
+                                });
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
## Description

Fixes (in theory): https://github.com/paulegradie/Sailfish/issues/180

Since now the item should never be dropped from the cache.

This is perhaps not ideal since now we have a memory leak, but it sure is better than tests failing because required fields of the test are missing.


## Results

<!-- The changes you ended up making -->