### PR TITLE
Use v4 Git Hub actions artifacts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,7 +70,7 @@ jobs:
           dotnet build ./source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj --configuration Release /p:Version=${{ needs.set_version.outputs.version }}
           dotnet build ./source/Sailfish.Analyzers/Sailfish.Analyzers.csproj --configuration Release /p:Version=${{ needs.set_version.outputs.version }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: built-binaries
           path: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,7 +70,7 @@ jobs:
           dotnet build ./source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj --configuration Release /p:Version=${{ needs.set_version.outputs.version }}
           dotnet build ./source/Sailfish.Analyzers/Sailfish.Analyzers.csproj --configuration Release /p:Version=${{ needs.set_version.outputs.version }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: built-binaries
           path: |
@@ -97,7 +97,7 @@ jobs:
           dotnet-version: 8.x.x
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: built-binaries
 
@@ -126,7 +126,7 @@ jobs:
           dotnet-version: 8.x.x
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: built-binaries
           path: source/

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: ["Sailfish", "Sailfish.TestAdapter", "Sailfish.Analyzers"]
+        project: ["Sailfish"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,7 +70,7 @@ jobs:
           dotnet build ./source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj --configuration Release /p:Version=${{ needs.set_version.outputs.version }}
           dotnet build ./source/Sailfish.Analyzers/Sailfish.Analyzers.csproj --configuration Release /p:Version=${{ needs.set_version.outputs.version }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           name: built-binaries
           path: |

--- a/.github/workflows/doc-website.yml
+++ b/.github/workflows/doc-website.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Static HTML export with Next.js
         run: npx --no-install next export
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./site/out
 

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -169,7 +169,7 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
                                 new CacheItem(providerPropertiesCacheKey,
                                     testCase.Instance.RetrievePropertiesAndFields()), new CacheItemPolicy()
                                 {
-                                    Priority = CacheItemPriority.NotRemovable
+                                    Priority = CacheItemPriority.NotRemovable // Otherwise we can find we can't re-hydrate the test class instance
                                 });
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## Description

An attempt to fix the issue seen here: https://github.com/paulegradie/Sailfish/pull/182#issuecomment-2408892298

https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/


## Results

The build step is now a matrix job of once, since it always built the three parts of sailfish and then tried to upload the same artifact three times. This doesn't work in artifact v4 which doesn't allow overriding of artifacts. 