### PR TITLE
Fix running setup/tear down methods too many times

### DIFF
--- a/source/Sailfish/Extensions/Methods/ReflectionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/ReflectionExtensionMethods.cs
@@ -50,7 +50,7 @@ public static class ReflectionExtensionMethods
         var baseType = type.BaseType;
         while (baseType != null)
         {
-            var baseMethods = baseType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            var baseMethods = baseType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
                 .Where(method => method.GetCustomAttributes(typeof(TAttribute), true).Length > 0)
                 .OrderBy(m => m.Name)
                 .ToArray();

--- a/source/Tests.Library/ExtensionMethods/ReflectionExtensionMethodsTests.cs
+++ b/source/Tests.Library/ExtensionMethods/ReflectionExtensionMethodsTests.cs
@@ -1,0 +1,38 @@
+using Sailfish.Attributes;
+using Sailfish.Extensions.Methods;
+using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests.Library.ExtensionMethods;
+
+public class ReflectionExtensionMethodsTests
+{
+    [Fact]
+    public void WhenExtendingABaseClass_WhereOnlyTheBaseClassHasTheSailfishGlobalSetupAttribute_ThenOnlyOneMethodWillBeFound()
+    {
+        var methods = new ExtendsBaseExample().FindMethodsDecoratedWithAttribute<SailfishGlobalSetupAttribute>();
+        methods.Count.ShouldBe(1);
+    }
+    
+    [Fact]
+    public void WhenExtendingAClassThatExtendsTheBaseClass_WhereOnlyTheBaseClassHasTheSailfishGlobalSetupAttribute_ThenOnlyOneMethodWillBeFound()
+    {
+        var methods = new ExtendsExtendsBaseExample().FindMethodsDecoratedWithAttribute<SailfishGlobalSetupAttribute>();
+        methods.Count.ShouldBe(1);
+    }
+
+    public class BaseExample
+    {
+        [SailfishGlobalSetup]
+        public async Task EnforcedGlobalSetup(CancellationToken cancellationToken)
+        {
+        }
+    }
+
+    public class ExtendsBaseExample : BaseExample;
+    
+    public class ExtendsExtendsBaseExample : ExtendsBaseExample;
+
+}


### PR DESCRIPTION
## Description

Previously Sailfish would run the same method multiple times when base classes are involved. Now it does not.

Fixes: https://github.com/paulegradie/Sailfish/issues/190

## Results

<!-- The changes you ended up making -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method discovery in inheritance scenarios to ensure only methods declared directly on each class are considered, preventing duplicate results when searching for decorated methods.

* **Tests**
  * Added new tests to verify correct behavior of method discovery with class inheritance, ensuring only one decorated method is found even in extended class hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->