### PR TITLE
StatisticalTestComputer misses results

### DIFF
--- a/source/Sailfish/Analysis/SailDiff/StatisticalTestComputer.cs
+++ b/source/Sailfish/Analysis/SailDiff/StatisticalTestComputer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Sailfish.Contracts.Public;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Extensions.Methods;
+using System.Collections.Concurrent;
 
 namespace Sailfish.Analysis.SailDiff;
 
@@ -35,7 +36,7 @@ public class StatisticalTestComputer(IStatisticalTestExecutor statisticalTestExe
             .Select(x => new TestCaseId(x.DisplayName))
             .GroupBy(x => x.DisplayName)
             .Select(x => x.First());
-        var results = new List<SailDiffResult>();
+        var results = new ConcurrentBag<SailDiffResult>();
         Parallel.ForEach(
             testCaseIdGroups,
             new ParallelOptions
@@ -67,10 +68,7 @@ public class StatisticalTestComputer(IStatisticalTestExecutor statisticalTestExe
                     afterCompiled.AggregatedRawExecutionResults,
                     settings);
 
-                lock (result)
-                {
-                    results.Add(new SailDiffResult(testCaseId, result));
-                }
+                results.Add(new SailDiffResult(testCaseId, result));
             });
 
         if (settings.DisableOrdering || results.Count > 60) return [.. results];


### PR DESCRIPTION
This method sometimes missed results. This occurs because it's not locking the colelction that's being modified. This changes the collection to a ConcurrentBag as used elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and performance when running statistical tests in parallel by ensuring thread-safe result collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->