### PR TITLE
Introduce pattern for strongly typed complex SailfishVariables

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/BackwardCompatibilityDemo.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/BackwardCompatibilityDemo.cs
@@ -1,0 +1,130 @@
+﻿using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+/// <summary>
+/// Comprehensive demonstration showing ALL variable provider approaches working together:
+/// 1. Simple attribute-based variables (original system)
+/// 2. Type-based attribute variables (original system)  
+/// 3. Range-based attribute variables (original system)
+/// 4. New interface-based complex variables (new system)
+/// 
+/// This shows complete backward compatibility while adding new capabilities.
+/// </summary>
+[Sailfish(NumWarmupIterations = 1, SampleSize = 2)]
+public class BackwardCompatibilityDemo
+{
+    // 1. ORIGINAL: Simple attribute-based variables (still works exactly as before)
+    [SailfishVariable(10, 50, 100)]
+    public int SimpleNumbers { get; set; }
+
+    [SailfishVariable("Alpha", "Beta", "Gamma")]
+    public string SimpleStrings { get; set; } = null!;
+
+    // 2. ORIGINAL: Type-based attribute variables (still works exactly as before)
+    [SailfishVariable(typeof(CustomStringProvider))]
+    public string TypeBasedString { get; set; } = null!;
+
+    [SailfishVariable(typeof(CustomObjectProvider))]
+    public CustomObject TypeBasedObject { get; set; } = null!;
+
+    // 3. ORIGINAL: Range-based variables (still works exactly as before)
+    [SailfishRangeVariable(1, 5, 2)]
+    public int RangeNumbers { get; set; }
+
+    // 4. NEW: Interface-based complex variables (new feature)
+    public IComplexConfiguration ComplexConfig { get; set; } = null!;
+
+    [SailfishMethod]
+    public void DemoAllVariableTypes()
+    {
+        // All variable types work together seamlessly
+        Console.WriteLine($"Simple: {SimpleNumbers}, {SimpleStrings}");
+        Console.WriteLine($"Type-based: {TypeBasedString}, {TypeBasedObject.Name}");
+        Console.WriteLine($"Range: {RangeNumbers}");
+        Console.WriteLine($"Complex: {ComplexConfig.Algorithm}, {ComplexConfig.Settings.Count}");
+        
+        // Simulate some work
+        System.Threading.Thread.Sleep(1);
+    }
+}
+
+// ORIGINAL: Type-based providers (still work exactly as before)
+public class CustomStringProvider : ISailfishVariablesProvider<string>
+{
+    public IEnumerable<string> Variables()
+    {
+        return new[] { "Provider1", "Provider2", "Provider3" };
+    }
+}
+
+public class CustomObjectProvider : ISailfishVariablesProvider<CustomObject>
+{
+    public IEnumerable<CustomObject> Variables()
+    {
+        return new[]
+        {
+            new CustomObject("Object1", 100),
+            new CustomObject("Object2", 200),
+            new CustomObject("Object3", 300)
+        };
+    }
+}
+
+public record CustomObject(string Name, int Value) : IComparable
+{
+    public int CompareTo(object? obj)
+    {
+        if (obj is not CustomObject other) return 1;
+        return string.Compare(Name, other.Name, StringComparison.Ordinal);
+    }
+}
+
+// NEW: Interface-based complex variables
+public interface IComplexConfiguration : ISailfishComplexVariableProvider<ComplexConfiguration>
+{
+    string Algorithm { get; }
+    Dictionary<string, object> Settings { get; }
+    TimeSpan Timeout { get; }
+}
+
+public record ComplexConfiguration(
+    string Algorithm,
+    Dictionary<string, object> Settings,
+    TimeSpan Timeout) : IComplexConfiguration
+{
+    public int CompareTo(object? obj)
+    {
+        if (obj is not ComplexConfiguration other) return 1;
+        
+        var algorithmComparison = string.Compare(Algorithm, other.Algorithm, StringComparison.Ordinal);
+        if (algorithmComparison != 0) return algorithmComparison;
+        
+        return Timeout.CompareTo(other.Timeout);
+    }
+
+    public static IEnumerable<ComplexConfiguration> GetVariableInstances()
+    {
+        return new[]
+        {
+            new ComplexConfiguration(
+                "FastAlgorithm",
+                new Dictionary<string, object> { ["CacheSize"] = 1000, ["Parallel"] = true },
+                TimeSpan.FromSeconds(5)
+            ),
+            new ComplexConfiguration(
+                "AccurateAlgorithm", 
+                new Dictionary<string, object> { ["CacheSize"] = 5000, ["Parallel"] = false },
+                TimeSpan.FromSeconds(30)
+            ),
+            new ComplexConfiguration(
+                "BalancedAlgorithm",
+                new Dictionary<string, object> { ["CacheSize"] = 2500, ["Parallel"] = true },
+                TimeSpan.FromSeconds(15)
+            )
+        };
+    }
+}

--- a/source/PerformanceTests/ExamplePerformanceTests/ComplexVariableProviderExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/ComplexVariableProviderExample.cs
@@ -1,0 +1,114 @@
+﻿using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+/// <summary>
+/// Example showing the new ISailfishComplexVariableProvider system working alongside
+/// traditional SailfishVariableAttribute for different types of test parameters
+/// </summary>
+[Sailfish(NumWarmupIterations = 1, SampleSize = 3)]
+public class ComplexVariableProviderExample
+{
+    // Traditional attribute-based variable for simple types
+    [SailfishVariable(10, 100, 1000)]
+    public int BufferSize { get; set; }
+
+    // New interface-based variable for complex objects
+    public ITestConfiguration Configuration { get; set; } = null!;
+
+    [SailfishMethod]
+    public void ProcessData()
+    {
+        // Simulate processing with different buffer sizes and configurations
+        var buffer = new byte[BufferSize];
+        
+        // Use the complex configuration object
+        var processingTime = Configuration.ProcessingDelay;
+        var algorithm = Configuration.Algorithm;
+        var settings = Configuration.Settings;
+        
+        // Simulate work
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = (byte)(i % 256);
+        }
+        
+        // Simulate algorithm-specific processing
+        if (algorithm == ProcessingAlgorithm.Fast)
+        {
+            Thread.Sleep(processingTime / 2);
+        }
+        else
+        {
+            Thread.Sleep(processingTime);
+        }
+    }
+}
+
+/// <summary>
+/// Interface for complex test configuration that implements ISailfishComplexVariableProvider
+/// This allows the property to serve dual purposes:
+/// 1. Hold the iteration data for the performance test
+/// 2. Provide instances of complex objects at runtime
+/// </summary>
+public interface ITestConfiguration : ISailfishComplexVariableProvider<TestConfiguration>
+{
+    ProcessingAlgorithm Algorithm { get; }
+    int ProcessingDelay { get; }
+    Dictionary<string, object> Settings { get; }
+}
+
+/// <summary>
+/// Implementation of the complex variable provider
+/// </summary>
+public record TestConfiguration(
+    ProcessingAlgorithm Algorithm,
+    int ProcessingDelay,
+    Dictionary<string, object> Settings) : ITestConfiguration
+{
+    public int CompareTo(object? obj)
+    {
+        if (obj is not TestConfiguration other) return 1;
+        
+        var algorithmComparison = Algorithm.CompareTo(other.Algorithm);
+        if (algorithmComparison != 0) return algorithmComparison;
+        
+        return ProcessingDelay.CompareTo(other.ProcessingDelay);
+    }
+
+    /// <summary>
+    /// Static method that provides the variable instances for testing
+    /// Each instance returned will result in a separate test execution
+    /// </summary>
+    public static IEnumerable<TestConfiguration> GetVariableInstances()
+    {
+        return new[]
+        {
+            new TestConfiguration(
+                ProcessingAlgorithm.Fast,
+                10,
+                new Dictionary<string, object> { ["CacheEnabled"] = true, ["MaxRetries"] = 3 }
+            ),
+            new TestConfiguration(
+                ProcessingAlgorithm.Thorough,
+                50,
+                new Dictionary<string, object> { ["CacheEnabled"] = false, ["MaxRetries"] = 5 }
+            ),
+            new TestConfiguration(
+                ProcessingAlgorithm.Balanced,
+                25,
+                new Dictionary<string, object> { ["CacheEnabled"] = true, ["MaxRetries"] = 2 }
+            )
+        };
+    }
+}
+
+public enum ProcessingAlgorithm
+{
+    Fast,
+    Balanced,
+    Thorough
+}

--- a/source/PerformanceTests/ExamplePerformanceTests/MigrationExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/MigrationExample.cs
@@ -1,0 +1,102 @@
+﻿using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+/// <summary>
+/// Example showing how to migrate from the old Type-based system to the new interface-based system
+/// </summary>
+
+// OLD WAY: Using SailfishVariableAttribute with Type parameter
+[Sailfish(NumWarmupIterations = 1, SampleSize = 2, Disabled = true)]
+public class OldWayExample
+{
+    [SailfishVariable(typeof(OldStyleProvider))]
+    public string TestValue { get; set; } = null!;
+
+    [SailfishMethod]
+    public void TestMethod()
+    {
+        Console.WriteLine($"Processing: {TestValue}");
+    }
+}
+
+// Old style provider - still works for backward compatibility
+public class OldStyleProvider : ISailfishVariablesProvider<string>
+{
+    public IEnumerable<string> Variables()
+    {
+        return new[] { "Value1", "Value2", "Value3" };
+    }
+}
+
+// NEW WAY: Using ISailfishComplexVariableProvider interface
+[Sailfish(NumWarmupIterations = 1, SampleSize = 2)]
+public class NewWayExample
+{
+    // Property type implements ISailfishComplexVariableProvider directly
+    public ITestData TestData { get; set; } = null!;
+
+    [SailfishMethod]
+    public void TestMethod()
+    {
+        Console.WriteLine($"Processing: {TestData.Name} with value {TestData.Value}");
+    }
+}
+
+// New style interface - cleaner and more type-safe
+public interface ITestData : ISailfishComplexVariableProvider<TestData>
+{
+    string Name { get; }
+    int Value { get; }
+}
+
+// Implementation provides the variable instances
+public record TestData(string Name, int Value) : ITestData
+{
+    public int CompareTo(object? obj)
+    {
+        if (obj is not TestData other) return 1;
+        
+        var nameComparison = string.Compare(Name, other.Name, StringComparison.Ordinal);
+        if (nameComparison != 0) return nameComparison;
+        
+        return Value.CompareTo(other.Value);
+    }
+
+    public static IEnumerable<TestData> GetVariableInstances()
+    {
+        return new[]
+        {
+            new TestData("Data1", 100),
+            new TestData("Data2", 200),
+            new TestData("Data3", 300)
+        };
+    }
+}
+
+/// <summary>
+/// Benefits of the new system:
+/// 
+/// 1. Type Safety: The property type directly implements the interface, providing compile-time type checking
+/// 2. Cleaner API: No need to pass Type parameters to attributes
+/// 3. Better IntelliSense: IDE can provide better code completion and navigation
+/// 4. Self-Documenting: The interface clearly shows what the property expects
+/// 5. Easier Testing: You can easily create test instances without reflection
+/// 6. Backward Compatible: Old attribute-based system continues to work
+/// 
+/// Migration Steps:
+/// 1. Create an interface that extends ISailfishComplexVariableProvider&lt;T&gt;
+/// 2. Define your data properties on the interface
+/// 3. Create a record/class that implements the interface
+/// 4. Implement CompareTo for ordering (required by IComparable)
+/// 5. Implement GetVariableInstances() to return your test data
+/// 6. Change your test property type to use the interface
+/// 7. Remove the [SailfishVariable(typeof(...))] attribute
+/// </summary>
+public static class MigrationGuide
+{
+    // This class exists only for documentation purposes
+}

--- a/source/PerformanceTests/ExamplePerformanceTests/TestClass.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/TestClass.cs
@@ -1,0 +1,58 @@
+﻿using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+[Sailfish(NumWarmupIterations = 0)]
+public class StructuredObjectVariableExample
+{
+    public required ITestParams TestParams { get; set; }
+
+    [SailfishMethod]
+    public void TestMethod()
+    {
+        Console.WriteLine(TestParams.A);
+        Console.WriteLine(TestParams.B);
+        Console.WriteLine(TestParams.Inner.C);
+        Console.WriteLine(TestParams.Inner.D);
+    }
+}
+
+// user defines this interface and sets it as the property type
+public interface ITestParams : ISailfishComplexVariableProvider<TestParams>
+{
+    public int A { get; init; }
+    public string B { get; init; }
+    public InnerParam Inner { get; init; }
+}
+
+// user implements the provider interface
+public record TestParams(int A, string B, InnerParam Inner) : ITestParams
+{
+    public int CompareTo(object? obj)
+    {
+        if (obj is not TestParams other) return 1;
+
+        var aComparison = A.CompareTo(other.A);
+        if (aComparison != 0) return aComparison;
+
+        var bComparison = string.Compare(B, other.B, StringComparison.Ordinal);
+        if (bComparison != 0) return bComparison;
+
+        return Inner.C.CompareTo(other.Inner.C);
+    }
+
+    public static IEnumerable<TestParams> GetVariableInstances()
+    {
+        return
+        [
+            new TestParams(1, "A", new InnerParam(1.1, 1.2m)),
+            new TestParams(2, "B", new InnerParam(2.1, 2.2m)),
+            new TestParams(3, "C", new InnerParam(3.1, 3.2m))
+        ];
+    }
+}
+
+public record InnerParam(double C, decimal D);

--- a/source/Sailfish/Attributes/SailfishVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishVariableAttribute.cs
@@ -88,12 +88,12 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
             }
                 
             var method = instance.GetType().GetMethod("Variables");
-            if (method != null)
+            if (method == null)
             {
-                return (IEnumerable<object>) method.Invoke(instance, null);
+                throw new Exception($"Could not find Variables() method on type {variablesProvidingType}.");
             }
 
-            throw new Exception($"Could not find Variables() method on type {variablesProvidingType}.");
+            return (IEnumerable<object>) method.Invoke(instance, null);
         }
 
         throw new Exception($"Type {variablesProvidingType} does not implement {typeof(ISailfishVariablesProvider<>).FullName}.");

--- a/source/Sailfish/Attributes/SailfishVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishVariableAttribute.cs
@@ -1,8 +1,10 @@
+using Sailfish.Contracts.Public.Variables;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Sailfish.Exceptions;
+using System.Collections;
 
 namespace Sailfish.Attributes;
 
@@ -56,6 +58,15 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
     /// <returns>An enumerable of the variables.</returns>
     public IEnumerable<object> GetVariables()
     {
+        if (N.Count == 1 && N.First() is Type type)
+        {
+            if (typeof(ISailfishVariablesProvider).IsAssignableFrom(type))
+            {
+                var instance = (ISailfishVariablesProvider) Activator.CreateInstance(type);
+                return instance.Variables;
+            }
+
+        }
         return N.ToArray();
     }
 

--- a/source/Sailfish/Attributes/SailfishVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishVariableAttribute.cs
@@ -86,8 +86,8 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
             {
                 throw new Exception($"Could not construct instance of {variablesProvidingType}.");
             }
-                
-            var method = instance.GetType().GetMethod("Variables");
+            
+            var method = instance.GetType().GetMethod(nameof(ISailfishVariablesProvider<string>.Variables));
             if (method == null)
             {
                 throw new Exception($"Could not find Variables() method on type {variablesProvidingType}.");

--- a/source/Sailfish/Attributes/SailfishVariableAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishVariableAttribute.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Sailfish.Exceptions;
-using System.Collections;
-using System.Reflection;
 
 namespace Sailfish.Attributes;
 
@@ -27,7 +25,9 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
     /// <exception cref="SailfishException">Thrown when no values are provided.</exception>
     public SailfishVariableAttribute([MinLength(1)] params object[] n)
     {
-        if (n.Length == 0) throw new SailfishException($"No values were provided to the {nameof(SailfishVariableAttribute)} attribute.");
+        if (n.Length == 0)
+            throw new SailfishException(
+                $"No values were provided to the {nameof(SailfishVariableAttribute)} attribute.");
         N.AddRange(n);
     }
 
@@ -55,7 +55,7 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
     ///     Gets the list of values used as variables within the test.
     /// </summary>
     private List<object> N { get; } = new();
-    
+
     /// <summary>
     ///     
     /// </summary>
@@ -73,12 +73,14 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
         {
             return CollectVariablesFromVariablesProvider(variablesProvidingType);
         }
+
         return N.ToArray();
     }
 
     private static IEnumerable<object> CollectVariablesFromVariablesProvider(Type variablesProvidingType)
     {
-        if (variablesProvidingType.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ISailfishVariablesProvider<>)))
+        if (variablesProvidingType.GetInterfaces().Any(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ISailfishVariablesProvider<>)))
         {
             var instance = Activator.CreateInstance(variablesProvidingType);
 
@@ -86,17 +88,18 @@ public sealed class SailfishVariableAttribute : Attribute, ISailfishVariableAttr
             {
                 throw new Exception($"Could not construct instance of {variablesProvidingType}.");
             }
-            
+
             var method = instance.GetType().GetMethod(nameof(ISailfishVariablesProvider<string>.Variables));
             if (method == null)
             {
                 throw new Exception($"Could not find Variables() method on type {variablesProvidingType}.");
             }
 
-            return (IEnumerable<object>) method.Invoke(instance, null);
+            return (IEnumerable<object>)method.Invoke(instance, null);
         }
 
-        throw new Exception($"Type {variablesProvidingType} does not implement {typeof(ISailfishVariablesProvider<>).FullName}.");
+        throw new Exception(
+            $"Type {variablesProvidingType} does not implement {typeof(ISailfishVariablesProvider<>).FullName}.");
     }
 
     /// <summary>

--- a/source/Sailfish/Contracts.Public/Variables/ISailfishComplexVariableProvider.cs
+++ b/source/Sailfish/Contracts.Public/Variables/ISailfishComplexVariableProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sailfish.Contracts.Public.Variables;
+
+/// <summary>
+/// Interface for providing complex object instances to Sailfish performance tests.
+/// This interface allows properties to serve dual purposes:
+/// 1. Hold the iteration data for the performance test
+/// 2. Provide instances of complex objects at runtime
+/// 
+/// This system works alongside the existing SailfishVariableAttribute system
+/// and provides a cleaner alternative to passing Types to constructors.
+/// </summary>
+/// <typeparam name="T">The type that implements this interface and will be used as test variables</typeparam>
+public interface ISailfishComplexVariableProvider<T> : IComparable
+    where T : ISailfishComplexVariableProvider<T>, IComparable
+{
+    /// <summary>
+    /// Returns a collection of instances of type T that will be used to create test iterations.
+    /// Each instance returned will result in a separate test execution where the test class
+    /// property will be set to that instance.
+    /// </summary>
+    /// <returns>An enumerable collection of T instances</returns>
+    static abstract IEnumerable<T> GetVariableInstances();
+}

--- a/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
+++ b/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Sailfish.Contracts.Public.Variables;
 
-public interface ISailfishVariablesProvider<out T> where T : IComparable
+public interface ISailfishVariablesProvider<T> where T : IComparable
 {
     public IEnumerable<T> Variables();
 }

--- a/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
+++ b/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
@@ -3,7 +3,26 @@ using System.Collections.Generic;
 
 namespace Sailfish.Contracts.Public.Variables;
 
-public interface ISailfishVariablesProvider<T> where T : IComparable
+/// <summary>
+/// Base interface for variable providers. This interface is used for type checking
+/// but does not define any methods. Use ISailfishVariablesProvider&lt;T&gt; for actual implementation.
+/// </summary>
+public interface ISailfishVariablesProvider
 {
-    public IEnumerable<T> Variables();
+}
+
+/// <summary>
+/// Generic interface for providing variables to Sailfish performance tests.
+/// Implement this interface to provide a collection of values for a specific type.
+/// </summary>
+/// <typeparam name="T">The type of variables this provider will supply</typeparam>
+public interface ISailfishVariablesProvider<T> : ISailfishVariablesProvider
+    where T : IComparable
+{
+    /// <summary>
+    /// Returns a collection of variables of type T that will be used to create test iterations.
+    /// Each value returned will result in a separate test execution.
+    /// </summary>
+    /// <returns>An enumerable collection of variables</returns>
+    IEnumerable<T> Variables();
 }

--- a/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
+++ b/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Sailfish.Contracts.Public.Variables;
+
+public interface ISailfishVariablesProvider
+{
+    public IEnumerable<object> Variables { get; }
+}

--- a/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
+++ b/source/Sailfish/Contracts.Public/Variables/ISailfishVariablesProvider.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Collections.Generic;
 
 namespace Sailfish.Contracts.Public.Variables;
 
-public interface ISailfishVariablesProvider
+public interface ISailfishVariablesProvider<out T> where T : IComparable
 {
-    public IEnumerable<object> Variables { get; }
+    public IEnumerable<T> Variables();
 }

--- a/source/Sailfish/Execution/IVariableProvider.cs
+++ b/source/Sailfish/Execution/IVariableProvider.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Attributes;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+/// Interface for providing variables to Sailfish tests, supporting both attribute-based and interface-based variable providers
+/// </summary>
+internal interface IVariableProvider
+{
+    /// <summary>
+    /// Gets the variables for test execution
+    /// </summary>
+    /// <returns>An enumerable of variable values</returns>
+    IEnumerable<object> GetVariables();
+
+    /// <summary>
+    /// Indicates if this variable provider should be used for complexity estimation (ScaleFish)
+    /// </summary>
+    /// <returns>True if this should be used for complexity estimation</returns>
+    bool IsScaleFishVariable();
+}
+
+/// <summary>
+/// Variable provider for attribute-based variables (SailfishVariableAttribute, SailfishRangeVariableAttribute)
+/// </summary>
+internal class AttributeVariableProvider : IVariableProvider
+{
+    private readonly ISailfishVariableAttribute attribute;
+
+    public AttributeVariableProvider(ISailfishVariableAttribute attribute)
+    {
+        this.attribute = attribute;
+    }
+
+    public IEnumerable<object> GetVariables()
+    {
+        return attribute.GetVariables();
+    }
+
+    public bool IsScaleFishVariable()
+    {
+        return attribute.IsScaleFishVariable();
+    }
+}
+
+/// <summary>
+/// Variable provider for interface-based complex variables (ISailfishComplexVariableProvider)
+/// </summary>
+internal class ComplexVariableProvider : IVariableProvider
+{
+    private readonly System.Type propertyType;
+
+    public ComplexVariableProvider(System.Type propertyType)
+    {
+        this.propertyType = propertyType;
+    }
+
+    public IEnumerable<object> GetVariables()
+    {
+        return GetComplexVariables(propertyType);
+    }
+
+    public bool IsScaleFishVariable()
+    {
+        // Complex variables are not used for complexity estimation by default
+        // This could be extended in the future if needed
+        return false;
+    }
+
+    private static IEnumerable<object> GetComplexVariables(System.Type propertyType)
+    {
+        // Find the concrete implementation type that implements ISailfishComplexVariableProvider<T>
+        var complexInterface = propertyType.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType &&
+                                i.GetGenericTypeDefinition() == typeof(Contracts.Public.Variables.ISailfishComplexVariableProvider<>));
+
+        if (complexInterface == null)
+        {
+            throw new System.Exception($"Type {propertyType} does not implement ISailfishComplexVariableProvider<T>.");
+        }
+
+        // Get the generic argument (the concrete type T)
+        var concreteType = complexInterface.GetGenericArguments()[0];
+
+        // Find the GetVariableInstances method on the concrete type
+        var method = concreteType.GetMethod("GetVariableInstances",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+
+        if (method == null)
+        {
+            throw new System.Exception($"Could not find GetVariableInstances() method on type {concreteType}.");
+        }
+
+        var result = method.Invoke(null, null);
+        if (result is not System.Collections.IEnumerable variables)
+        {
+            throw new System.Exception($"GetVariableInstances() method on type {concreteType} did not return IEnumerable.");
+        }
+
+        return variables.Cast<object>();
+    }
+}

--- a/source/Tests.E2E.TestSuite/Discoverable/NonSystemTypeVariablesFromMethodTest.cs
+++ b/source/Tests.E2E.TestSuite/Discoverable/NonSystemTypeVariablesFromMethodTest.cs
@@ -1,0 +1,92 @@
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+
+namespace Tests.E2E.TestSuite.Discoverable;
+
+[Sailfish(SampleSize = 1, NumWarmupIterations = 1, Disabled = Constants.Disabled)]
+public class NonSystemTypeVariablesFromMethodTest
+{
+    [SailfishVariable(typeof(NonSystemTypeVariableProvider))]
+    public MyNonSystemType MyNonSystemType { get; set; }
+
+    public static AsyncLocal<List<MyNonSystemType>> CaptureStringVariablesForTestingThisTest = new();
+
+    [SailfishMethod]
+    public void Run()
+    {
+        if (CaptureStringVariablesForTestingThisTest.Value is not null)
+        {
+            CaptureStringVariablesForTestingThisTest.Value.Add(MyNonSystemType);
+        }
+    }
+}
+
+public class MyNonSystemType(string myString, int myInt) : IComparable
+{
+    public string MyString { get; } = myString;
+    public int MyInt { get; } = myInt;
+
+    /// <summary>
+    /// Sailfish uses this to define the order the variables are tested in.
+    /// By setting this to 0, the order defined in the method that supplies the variables
+    /// will define the order in which the tests are run.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public int CompareTo(object? obj) => 0;
+
+    /// <summary>
+    /// The ToString value is what is displayed in the IDE UI and other places in Sailfish.
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
+    {
+        return $"MyString: {MyString}, MyInt: {MyInt}";
+    }
+
+    /// <summary>
+    /// Overriding Equals is required so sailfish can ensure we have distinct test runs.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((MyNonSystemType)obj);
+    }
+    
+    protected bool Equals(MyNonSystemType other) => MyString == other.MyString && MyInt == other.MyInt;
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(MyString, MyInt);
+    }
+}
+
+public class NonSystemTypeVariableProvider : ISailfishVariablesProvider<MyNonSystemType>
+{
+    public IEnumerable<MyNonSystemType> Variables()
+    {
+        // Sailfish will execute tests in the order below since the CompareTo method above always
+        // returns 0
+        return
+        [
+            new MyNonSystemType("Foo", 1337),
+            new MyNonSystemType("Bar", 42)
+        ];
+    }
+}

--- a/source/Tests.E2E.TestSuite/Discoverable/StringVariablesFromMethodTest.cs
+++ b/source/Tests.E2E.TestSuite/Discoverable/StringVariablesFromMethodTest.cs
@@ -1,0 +1,29 @@
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+
+namespace Tests.E2E.TestSuite.Discoverable;
+
+[Sailfish(SampleSize = 1, NumWarmupIterations = 1, Disabled = Constants.Disabled)]
+public class StringVariablesFromMethodTest
+{
+    [SailfishVariable(typeof(StringVariablesProvider))]
+    public string MyString { get; set; }
+
+    public static AsyncLocal<List<string>> StringVariables = new();
+    [SailfishMethod]
+    public void Run()
+    {
+        if (StringVariables.Value is not null)
+        {
+            StringVariables.Value.Add(MyString);
+        }
+    }
+}
+
+public class StringVariablesProvider : ISailfishVariablesProvider<string>
+{
+    public IEnumerable<string> Variables()
+    {
+        return ["Z", "A", "B"];
+    }
+}

--- a/source/Tests.E2E.TestSuite/Discoverable/StringVariablesFromMethodTest.cs
+++ b/source/Tests.E2E.TestSuite/Discoverable/StringVariablesFromMethodTest.cs
@@ -9,13 +9,14 @@ public class StringVariablesFromMethodTest
     [SailfishVariable(typeof(StringVariablesProvider))]
     public string MyString { get; set; }
 
-    public static AsyncLocal<List<string>> StringVariables = new();
+    public static AsyncLocal<List<string>> CaptureStringVariablesForTestingThisTest = new();
+    
     [SailfishMethod]
     public void Run()
     {
-        if (StringVariables.Value is not null)
+        if (CaptureStringVariablesForTestingThisTest.Value is not null)
         {
-            StringVariables.Value.Add(MyString);
+            CaptureStringVariablesForTestingThisTest.Value.Add(MyString);
         }
     }
 }

--- a/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
+++ b/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
 using Sailfish.Exceptions;
 using Shouldly;
 using Xunit;
@@ -61,5 +62,17 @@ public class SailfishAttributeTests
     public void SailfishVariableAttributeShouldThrowWhenScaleFishAndNLessThanThree()
     {
         Should.Throw<SailfishException>(() => new SailfishVariableAttribute(true, 1, 2));
+    }
+    
+    [Fact]
+    public void SailfishVariableAttributeCanBeConfiguredFromMethod()
+    {
+        var atty = new SailfishVariableAttribute(typeof(TestVariablesSupplier));
+        atty.GetVariables().Cast<string>().ToList().ShouldBeEquivalentTo(new List<string>() { "A", "B", "C" });
+    }
+
+    public class TestVariablesSupplier : ISailfishVariablesProvider
+    {
+        public IEnumerable<object> Variables => ["A", "B", "C"];
     }
 }

--- a/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
+++ b/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
@@ -68,7 +68,7 @@ public class SailfishAttributeTests
     public void SailfishVariableAttributeCanBeConfiguredFromMethod()
     {
         var atty = new SailfishVariableAttribute(typeof(TestVariablesSupplier));
-        atty.GetVariables().Cast<string>().ToList().ShouldBeEquivalentTo(new List<string>() { "A", "B", "C" });
+        atty.GetVariables().Cast<string>().ToList().ShouldBeEquivalentTo(new List<string> { "A", "B", "C" });
     }
 
     public class TestVariablesSupplier : ISailfishVariablesProvider<string>

--- a/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
+++ b/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
@@ -4,6 +4,7 @@ using Sailfish.Attributes;
 using Sailfish.Contracts.Public.Variables;
 using Sailfish.Exceptions;
 using Shouldly;
+using Tests.E2E.TestSuite.Discoverable;
 using Xunit;
 
 namespace Tests.Library.AttributeCollection;

--- a/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
+++ b/source/Tests.Library/AttributeCollection/SailfishAttributeTests.cs
@@ -71,8 +71,8 @@ public class SailfishAttributeTests
         atty.GetVariables().Cast<string>().ToList().ShouldBeEquivalentTo(new List<string>() { "A", "B", "C" });
     }
 
-    public class TestVariablesSupplier : ISailfishVariablesProvider
+    public class TestVariablesSupplier : ISailfishVariablesProvider<string>
     {
-        public IEnumerable<object> Variables => ["A", "B", "C"];
+        public IEnumerable<string> Variables() => ["A", "B", "C"];
     }
 }

--- a/source/Tests.Library/AttributeCollection/WhenSettingIterationVariableAttributes.cs
+++ b/source/Tests.Library/AttributeCollection/WhenSettingIterationVariableAttributes.cs
@@ -48,7 +48,7 @@ public class WhenSettingSailfishAttributes
         propName.ShouldBe(nameof(testClass.MyValues));
 
         var variableSet = variables[propName];
-        variableSet.OrderedVariables.ShouldBe(new object[] { new TestClassWithVariableSupplyingMethod.MySpecialType("A"), new TestClassWithVariableSupplyingMethod.MySpecialType("B"), new TestClassWithVariableSupplyingMethod.MySpecialType("C") });
+        variableSet.OrderedVariables.ShouldBe(new object[] { new MySpecialType("A"), new MySpecialType("B"), new MySpecialType("C") });
     }
 }
 
@@ -61,45 +61,45 @@ public class TestClass
 public class TestClassWithVariableSupplyingMethod
 {
     [SailfishVariable(typeof(MyVariables))]
-    public MySpecialType MyValues { get; set; }
+    public MySpecialType? MyValues { get; set; }
+}
 
-    public class MyVariables : ISailfishVariablesProvider
+public class MyVariables : ISailfishVariablesProvider<MySpecialType>
+{
+    public IEnumerable<MySpecialType> Variables() => [new MySpecialType("A"), new MySpecialType("B"), new MySpecialType("C")];
+}
+
+public class MySpecialType : IComparable
+{
+    public string Value { get; set; }
+
+    public MySpecialType(string value)
     {
-        public IEnumerable<object> Variables => [new MySpecialType("A"), new MySpecialType("B"), new MySpecialType("C")];
+        this.Value = value;
     }
 
-    public class MySpecialType : IComparable
+    public override bool Equals(object? obj)
     {
-        public string Value { get; set; }
-
-        public MySpecialType(string value)
+        if (obj is null)
         {
-            this.Value = value;
+            return false;
         }
 
-        public override bool Equals(object? obj)
+        if (ReferenceEquals(this, obj))
         {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            if (obj.GetType() != GetType())
-            {
-                return false;
-            }
-
-            return Equals((MySpecialType)obj);
+            return true;
         }
 
-        public int CompareTo(object? obj)
+        if (obj.GetType() != GetType())
         {
-            return 0;
+            return false;
         }
+
+        return Equals((MySpecialType)obj);
+    }
+
+    public int CompareTo(object? obj)
+    {
+        return 0;
     }
 }

--- a/source/Tests.Library/E2EScenarios/SuccessCases/FullRuns.cs
+++ b/source/Tests.Library/E2EScenarios/SuccessCases/FullRuns.cs
@@ -51,7 +51,7 @@ public class FullRuns
         var result = await SailfishRunner.Run(runSettings);
 
         result.IsValid.ShouldBe(true);
-        result.ExecutionSummaries.Count().ShouldBe(15);
+        result.ExecutionSummaries.Count().ShouldBe(16);
     }
 
     [Fact]

--- a/source/Tests.Library/E2EScenarios/SuccessCases/FullRuns.cs
+++ b/source/Tests.Library/E2EScenarios/SuccessCases/FullRuns.cs
@@ -50,8 +50,9 @@ public class FullRuns
 
         var result = await SailfishRunner.Run(runSettings);
 
+        result.Exceptions.ShouldBeEmpty();
         result.IsValid.ShouldBe(true);
-        result.ExecutionSummaries.Count().ShouldBe(16);
+        result.ExecutionSummaries.Count().ShouldBe(17);
     }
 
     [Fact]

--- a/source/Tests.Library/E2EScenarios/SuccessCases/NonSystemTypeVariablesFromMethodTestTest.cs
+++ b/source/Tests.Library/E2EScenarios/SuccessCases/NonSystemTypeVariablesFromMethodTestTest.cs
@@ -10,19 +10,19 @@ using Xunit;
 
 namespace Tests.Library.E2EScenarios.SuccessCases;
 
-public class StringVariablesFromMethodTestTest
+public class NonSystemTypeVariablesFromMethodTestTest
 {
     [Fact]
-    public async Task StringVariablesCanBeSuppliedFromAMethod()
+    public async Task NonSystemVariablesCanBeSuppliedFromAMethod()
     {
         // Will hold the variables the perf tests where executed with
-        var testVariables = new List<string>();
-        StringVariablesFromMethodTest.CaptureStringVariablesForTestingThisTest.Value = testVariables;
+        var testVariables = new List<MyNonSystemType>();
+        NonSystemTypeVariablesFromMethodTest.CaptureStringVariablesForTestingThisTest.Value = testVariables;
         var runSettings = RunSettingsBuilder.CreateBuilder()
             .WithLocalOutputDirectory(Some.RandomString())
             .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
             .TestsFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
-            .WithTestNames(nameof(StringVariablesFromMethodTest))
+            .WithTestNames(nameof(NonSystemTypeVariablesFromMethodTest))
             .DisableOverheadEstimation()
             .WithAnalysisDisabledGlobally()
             .Build();
@@ -31,10 +31,16 @@ public class StringVariablesFromMethodTestTest
 
         result.IsValid.ShouldBe(true);
         result.ExecutionSummaries.Count().ShouldBe(1);
-        
-        
+
+
         // The variables should be processed in their natural order
-        // We have each variable twice since we have warm ups
-        testVariables.ShouldBeEquivalentTo(new List<string>{"A", "A", "B", "B", "Z", "Z"});
+        // We have each variable twice since we have warm-ups
+        testVariables.ShouldBeEquivalentTo(new List<MyNonSystemType>
+        {
+            new("Foo", 1337), 
+            new("Foo", 1337), 
+            new("Bar", 42),
+            new("Bar", 42)
+        });
     }
 }

--- a/source/Tests.Library/E2EScenarios/SuccessCases/StringVariablesFromMethodTestTest.cs
+++ b/source/Tests.Library/E2EScenarios/SuccessCases/StringVariablesFromMethodTestTest.cs
@@ -17,7 +17,7 @@ public class StringVariablesFromMethodTestTest
     {
         // Will hold the variables the perf tests where executed with
         var testVariables = new List<string>();
-        StringVariablesFromMethodTest.StringVariables.Value = testVariables;
+        StringVariablesFromMethodTest.CaptureStringVariablesForTestingThisTest.Value = testVariables;
         var runSettings = RunSettingsBuilder.CreateBuilder()
             .WithLocalOutputDirectory(Some.RandomString())
             .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))

--- a/source/Tests.Library/E2EScenarios/SuccessCases/StringVariablesFromMethodTestTest.cs
+++ b/source/Tests.Library/E2EScenarios/SuccessCases/StringVariablesFromMethodTestTest.cs
@@ -1,0 +1,40 @@
+using Sailfish;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.Common.Utils;
+using Tests.E2E.TestSuite;
+using Tests.E2E.TestSuite.Discoverable;
+using Xunit;
+
+namespace Tests.Library.E2EScenarios.SuccessCases;
+
+public class StringVariablesFromMethodTestTest
+{
+    [Fact]
+    public async Task AFullTestRunOfTheDemoShouldFindAllTests()
+    {
+        // Will hold the variables the perf tests where executed with
+        var testVariables = new List<string>();
+        StringVariablesFromMethodTest.StringVariables.Value = testVariables;
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(Some.RandomString())
+            .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .TestsFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .WithTestNames(nameof(StringVariablesFromMethodTest))
+            .DisableOverheadEstimation()
+            .WithAnalysisDisabledGlobally()
+            .Build();
+
+        var result = await SailfishRunner.Run(runSettings);
+
+        result.IsValid.ShouldBe(true);
+        result.ExecutionSummaries.Count().ShouldBe(1);
+        
+        
+        // The variables should be processed in their natural order
+        // We have each variable twice since we have warm ups
+        testVariables.ShouldBeEquivalentTo(new List<string>{"A", "A", "B", "B", "Z", "Z"});
+    }
+}

--- a/source/Tests.Library/Execution/WhenUsingComplexVariableProviders.cs
+++ b/source/Tests.Library/Execution/WhenUsingComplexVariableProviders.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Variables;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Execution;
+
+public class WhenUsingComplexVariableProviders
+{
+    [Fact]
+    public void ComplexVariableProvider_ShouldReturnCorrectVariables()
+    {
+        // Arrange
+        var provider = new ComplexVariableProvider(typeof(TestComplexVariable));
+
+        // Act
+        var variables = provider.GetVariables().ToList();
+
+        // Assert
+        variables.ShouldNotBeEmpty();
+        variables.Count.ShouldBe(3);
+        variables.ShouldAllBe(v => v is TestComplexVariable);
+        
+        var typedVariables = variables.Cast<TestComplexVariable>().ToList();
+        typedVariables.ShouldContain(v => v.Name == "Test1" && v.Value == 1);
+        typedVariables.ShouldContain(v => v.Name == "Test2" && v.Value == 2);
+        typedVariables.ShouldContain(v => v.Name == "Test3" && v.Value == 3);
+    }
+
+    [Fact]
+    public void ComplexVariableProvider_ShouldNotBeScaleFishVariable()
+    {
+        // Arrange
+        var provider = new ComplexVariableProvider(typeof(TestComplexVariable));
+
+        // Act & Assert
+        provider.IsScaleFishVariable().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IterationVariableRetriever_ShouldHandleBothAttributeAndComplexVariables()
+    {
+        // Arrange
+        var retriever = new IterationVariableRetriever();
+
+        // Act
+        var variables = retriever.RetrieveIterationVariables(typeof(MixedVariableTestClass));
+
+        // Assert
+        variables.ShouldNotBeEmpty();
+        variables.Count.ShouldBe(2);
+        
+        // Should have both attribute-based and complex variables
+        variables.ShouldContainKey("SimpleValue");
+        variables.ShouldContainKey("ComplexValue");
+        
+        // Check simple variable
+        var simpleVar = variables["SimpleValue"];
+        simpleVar.OrderedVariables.ShouldContain(1);
+        simpleVar.OrderedVariables.ShouldContain(2);
+        simpleVar.OrderedVariables.ShouldContain(3);
+        
+        // Check complex variable
+        var complexVar = variables["ComplexValue"];
+        complexVar.OrderedVariables.Count().ShouldBe(3);
+        complexVar.OrderedVariables.ShouldAllBe(v => v is TestComplexVariable);
+    }
+
+    [Fact]
+    public void AttributeDiscoveryExtensions_ShouldDetectComplexVariableProperties()
+    {
+        // Arrange
+        var type = typeof(MixedVariableTestClass);
+
+        // Act
+        var complexProperties = type.CollectAllSailfishComplexVariableProperties();
+        var allProperties = type.CollectAllVariableProperties();
+
+        // Assert
+        complexProperties.Count.ShouldBe(1);
+        complexProperties.Single().Name.ShouldBe("ComplexValue");
+        
+        allProperties.Count.ShouldBe(2);
+        allProperties.ShouldContain(p => p.Name == "SimpleValue");
+        allProperties.ShouldContain(p => p.Name == "ComplexValue");
+    }
+
+    [Fact]
+    public void TypeExtensions_ShouldCorrectlyIdentifyComplexVariableProvider()
+    {
+        // Act & Assert
+        typeof(TestComplexVariable).ImplementsISailfishComplexVariableProvider().ShouldBeTrue();
+        typeof(string).ImplementsISailfishComplexVariableProvider().ShouldBeFalse();
+        typeof(int).ImplementsISailfishComplexVariableProvider().ShouldBeFalse();
+    }
+}
+
+// Test classes for the unit tests
+public class MixedVariableTestClass
+{
+    [SailfishVariable(1, 2, 3)]
+    public int SimpleValue { get; set; }
+
+    public ITestComplexVariable ComplexValue { get; set; } = null!;
+}
+
+public interface ITestComplexVariable : ISailfishComplexVariableProvider<TestComplexVariable>
+{
+    string Name { get; }
+    int Value { get; }
+}
+
+public record TestComplexVariable(string Name, int Value) : ITestComplexVariable
+{
+    public int CompareTo(object? obj)
+    {
+        if (obj is not TestComplexVariable other) return 1;
+        
+        var nameComparison = string.Compare(Name, other.Name, StringComparison.Ordinal);
+        if (nameComparison != 0) return nameComparison;
+        
+        return Value.CompareTo(other.Value);
+    }
+
+    public static IEnumerable<TestComplexVariable> GetVariableInstances()
+    {
+        return new[]
+        {
+            new TestComplexVariable("Test1", 1),
+            new TestComplexVariable("Test2", 2),
+            new TestComplexVariable("Test3", 3)
+        };
+    }
+}


### PR DESCRIPTION
## Description

This introduces a way to provide ccomplex variables that can't otherwise be provided via the SailfishVariableAttribute.

Note _ this is base off of https://github.com/paulegradie/Sailfish/pull/194 - however there are a bunch of merge conflicts that may screw up the impl as I resolve them so I'm puttin gthis up separately for exposure.


## Results

Tests work, new feature is backwards compatible