### PR TITLE
Attempt to improve auto-release notes

### DIFF
--- a/.github/workflows/build-v2.1.yml
+++ b/.github/workflows/build-v2.1.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Download NuGet packages
         uses: actions/download-artifact@v4
         with:
-          name: built-binaries
+          name: nuget-packages   # ← must match upload step
           path: ./packages/
 
       - name: Find NuGet packages
@@ -224,7 +224,7 @@ jobs:
           # Create a list of package files for the release
           PACKAGES=""
           for pkg in Sailfish Sailfish.TestAdapter Sailfish.Analyzers; do
-            PKG_FILE="./${pkg}.${{ needs.set_version.outputs.version }}.nupkg"
+            PKG_FILE="./packages/${pkg}.${{ needs.set_version.outputs.version }}.nupkg"
             if [ -f "$PKG_FILE" ]; then
               PACKAGES="$PACKAGES $PKG_FILE"
               echo "Found package: $PKG_FILE"

--- a/.github/workflows/build-v2.1.yml
+++ b/.github/workflows/build-v2.1.yml
@@ -199,6 +199,123 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: dotnet nuget push ${{matrix.project}}.${{ needs.set_version.outputs.version }}.nupkg --source https://www.nuget.org --api-key ${{secrets.NUGET_API_KEY}} --skip-duplicate
 
+  create_release:
+    name: Create GitHub Release
+    needs: [pack, set_version]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v4
+        with:
+          name: built-binaries
+          path: ./packages/
+
+      - name: Find NuGet packages
+        id: find_packages
+        run: |
+          echo "Finding .nupkg files..."
+          find . -name "*.nupkg" -type f
+
+          # Create a list of package files for the release
+          PACKAGES=""
+          for pkg in Sailfish Sailfish.TestAdapter Sailfish.Analyzers; do
+            PKG_FILE="./${pkg}.${{ needs.set_version.outputs.version }}.nupkg"
+            if [ -f "$PKG_FILE" ]; then
+              PACKAGES="$PACKAGES $PKG_FILE"
+              echo "Found package: $PKG_FILE"
+            else
+              echo "Warning: Package not found: $PKG_FILE"
+            fi
+          done
+
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+
+      - name: Check for manual release notes
+        id: check_release_notes
+        run: |
+          # Check if there's a RELEASE_NOTES.md file in the repo root
+          if [ -f "RELEASE_NOTES.md" ]; then
+            echo "manual_notes=true" >> $GITHUB_OUTPUT
+            echo "Found manual release notes file"
+          else
+            echo "manual_notes=false" >> $GITHUB_OUTPUT
+            echo "No manual release notes found, will generate from commits"
+          fi
+
+      - name: Generate Release Notes from Commits
+        if: steps.check_release_notes.outputs.manual_notes == 'false'
+        id: auto_release_notes
+        run: |
+          VERSION="${{ needs.set_version.outputs.version }}"
+
+          # Get commits since last release
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMITS=$(git log ${LAST_TAG}..HEAD --oneline --no-merges)
+          else
+            # If no previous tags, get last 10 commits
+            COMMITS=$(git log -10 --oneline --no-merges)
+          fi
+
+          # Create release notes
+          cat > release_notes.md << EOF
+          ## What's Changed in v${VERSION}
+
+          ### Commits in this release:
+          ${COMMITS}
+
+          ### NuGet Packages
+          - [Sailfish v${VERSION}](https://www.nuget.org/packages/Sailfish/${VERSION})
+          - [Sailfish.TestAdapter v${VERSION}](https://www.nuget.org/packages/Sailfish.TestAdapter/${VERSION})
+          - [Sailfish.Analyzers v${VERSION}](https://www.nuget.org/packages/Sailfish.Analyzers/${VERSION})
+
+          **Full Changelog**: https://github.com/paulegradie/Sailfish/compare/${LAST_TAG}...v${VERSION}
+          EOF
+
+          echo "Auto-generated release notes:"
+          cat release_notes.md
+
+      - name: Prepare Manual Release Notes
+        if: steps.check_release_notes.outputs.manual_notes == 'true'
+        id: manual_release_notes
+        run: |
+          VERSION="${{ needs.set_version.outputs.version }}"
+
+          # Replace placeholder version in manual notes
+          sed "s/NEXT_VERSION/${VERSION}/g" RELEASE_NOTES.md > release_notes.md
+
+          # Add NuGet package links at the end
+          cat >> release_notes.md << EOF
+
+          ### NuGet Packages
+          - [Sailfish v${VERSION}](https://www.nuget.org/packages/Sailfish/${VERSION})
+          - [Sailfish.TestAdapter v${VERSION}](https://www.nuget.org/packages/Sailfish.TestAdapter/${VERSION})
+          - [Sailfish.Analyzers v${VERSION}](https://www.nuget.org/packages/Sailfish.Analyzers/${VERSION})
+          EOF
+
+          echo "Manual release notes prepared:"
+          cat release_notes.md
+
+          # Clean up the manual notes file after use
+          rm RELEASE_NOTES.md
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.set_version.outputs.version }}
+          name: Sailfish v${{ needs.set_version.outputs.version }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+          files: ${{ steps.find_packages.outputs.packages }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   sonar:
     name: Sonar Code Quality Check
     needs: [set_version, build]

--- a/.github/workflows/build-v2.1.yml
+++ b/.github/workflows/build-v2.1.yml
@@ -305,7 +305,8 @@ jobs:
           rm RELEASE_NOTES.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.set_version.outputs.version }}
           name: Sailfish v${{ needs.set_version.outputs.version }}

--- a/.github/workflows/build-v2.1.yml
+++ b/.github/workflows/build-v2.1.yml
@@ -274,9 +274,8 @@ jobs:
           - [Sailfish.TestAdapter v${VERSION}](https://www.nuget.org/packages/Sailfish.TestAdapter/${VERSION})
           - [Sailfish.Analyzers v${VERSION}](https://www.nuget.org/packages/Sailfish.Analyzers/${VERSION})
 
-          **Full Changelog**: https://github.com/paulegradie/Sailfish/compare/${LAST_TAG}...v${VERSION}
+          ${LAST_TAG:+**Full Changelog**: https://github.com/paulegradie/Sailfish/compare/${LAST_TAG}...v${VERSION}}
           EOF
-
           echo "Auto-generated release notes:"
           cat release_notes.md
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,31 @@
+﻿## What's Changed in vNEXT_VERSION
+
+- **New Feature**: Transitioned to GitHub Releases for better release management
+    - **Automated Release Creation**: CI/CD pipeline now automatically creates GitHub releases
+    - **Flexible Release Notes**: Support for both manual and auto-generated release notes
+    - **NuGet Package Integration**: Packages are automatically attached to releases
+    - **Better Discoverability**: Releases are prominently displayed on the GitHub repository
+
+- **Documentation Update**: Updated release notes page to redirect to GitHub Releases
+    - **Historical Archive**: Previous release notes preserved for reference
+    - **Clear Migration Path**: Users directed to new location for current releases
+
+- **Developer Experience**: Simplified release workflow eliminates version number lag
+    - **Write During Development**: Create release notes without knowing final version number
+    - **Automatic Version Replacement**: `NEXT_VERSION` placeholder replaced with actual version
+    - **Clean Repository**: Release notes file automatically cleaned up after use
+
+### Migration Benefits
+
+This change solves the version lag problem where release notes had to be updated in follow-up PRs after seeing the final version number. Now you can:
+
+1. Write release notes during feature development
+2. Use `NEXT_VERSION` as a placeholder
+3. Commit and push - the CI/CD pipeline handles the rest
+4. No more follow-up PRs needed!
+
+### For Users
+
+- Visit [GitHub Releases](https://github.com/paulegradie/Sailfish/releases) for the latest release information
+- Subscribe to release notifications on GitHub to stay updated
+- Download NuGet packages directly from release pages

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,52 @@
+﻿# Release Notes Template
+
+When you want to create a release with custom release notes, copy this file to `RELEASE_NOTES.md` in the repository root and edit it with your release notes.
+
+The CI/CD pipeline will:
+1. Check for the existence of `RELEASE_NOTES.md`
+2. If found, use it as the release notes (replacing `NEXT_VERSION` with the actual version)
+3. If not found, auto-generate release notes from recent commits
+4. Automatically add NuGet package links
+5. Clean up the `RELEASE_NOTES.md` file after creating the release
+
+## Template Format:
+
+```markdown
+## What's Changed in vNEXT_VERSION
+
+- **Major Feature**: **Enhanced Complex Variables System** - Improved support for complex object variables using modern provider patterns
+    - **Interface-Based Approach**: `ISailfishVariables<TType, TProvider>` pattern for explicit data contracts
+    - **Class-Based Approach**: `SailfishVariables<T, TProvider>` class for simplified syntax without custom interfaces
+    - **Provider Pattern**: Clean separation of data types from variable generation logic through `ISailfishVariablesProvider<T>` interface
+    - **Type Safety**: Enhanced type safety, IntelliSense support, and compile-time checking for complex variable scenarios
+    - **Mixed Usage**: Support for combining simple attribute-based variables with complex variables in the same test class
+
+- **Breaking Change**: Deprecated .NET 6 support - now supports .NET 8 and .NET 9 only
+- **Framework Upgrades**: Updated all projects to target .NET 8.0 and .NET 9.0 for improved performance and latest features
+- **Bug Fix**: Fixed critical issue where subsequent test cases would fail to execute if an earlier test case threw an exception
+
+### Technical Details
+- Improved memory management and performance optimizations
+- Enhanced error handling and logging capabilities
+- Better IDE integration and developer experience
+
+### Migration Guide
+For users upgrading from previous versions:
+1. Update your project to target .NET 8 or .NET 9
+2. Review any breaking changes listed above
+3. Test your existing Sailfish tests to ensure compatibility
+```
+
+## Usage Instructions:
+
+1. **For releases with detailed notes**: Copy this template to `RELEASE_NOTES.md`, edit with your content, commit and push
+2. **For simple releases**: Don't create `RELEASE_NOTES.md` - the system will auto-generate from commits
+3. **Version placeholder**: Use `NEXT_VERSION` in your notes - it will be replaced with the actual version number
+
+## Benefits:
+
+- ✅ Write release notes during development without knowing the final version number
+- ✅ No more follow-up PRs to update version numbers
+- ✅ Automatic fallback to commit-based notes for quick releases
+- ✅ NuGet package links automatically added
+- ✅ Clean repository (release notes file is removed after use)

--- a/RELEASE_WORKFLOW.md
+++ b/RELEASE_WORKFLOW.md
@@ -1,0 +1,126 @@
+﻿# Release Workflow Documentation
+
+## Overview
+
+Sailfish uses an automated release workflow that creates GitHub releases with proper versioning and release notes. This eliminates the version lag problem where you had to update release notes in follow-up PRs.
+
+## Versioning Strategy
+
+- **Major.Minor**: Embedded in workflow filename (e.g., `build-v2.1.yml` → `2.1`)
+- **Patch**: GitHub run number (auto-incrementing)
+- **Final Version**: `2.1.{run_number}` (e.g., `2.1.45`)
+- **PR Versions**: `2.1.{run_number}-pull-request`
+
+## Release Notes Options
+
+### Option 1: Manual Release Notes (Recommended for major releases)
+
+1. **Create release notes during development**:
+   ```bash
+   # Copy the template
+   cp RELEASE_NOTES_TEMPLATE.md RELEASE_NOTES.md
+   
+   # Edit with your release notes
+   # Use NEXT_VERSION as placeholder for version number
+   ```
+
+2. **Example content**:
+   ```markdown
+   ## What's Changed in vNEXT_VERSION
+   
+   - **Major Feature**: New complex variables system
+   - **Breaking Change**: Deprecated .NET 6 support
+   - **Bug Fix**: Fixed critical test execution issue
+   ```
+
+3. **Commit and push**:
+   ```bash
+   git add RELEASE_NOTES.md
+   git commit -m "Add release notes for next version"
+   git push
+   ```
+
+4. **Automatic processing**:
+   - CI/CD detects `RELEASE_NOTES.md`
+   - Replaces `NEXT_VERSION` with actual version
+   - Creates GitHub release
+   - Attaches NuGet packages
+   - Cleans up the release notes file
+
+### Option 2: Auto-Generated Release Notes (For quick releases)
+
+1. **Don't create `RELEASE_NOTES.md`**
+2. **Push your changes**
+3. **CI/CD automatically**:
+   - Generates release notes from recent commits
+   - Creates GitHub release
+   - Attaches NuGet packages
+
+## Workflow Triggers
+
+### Main Branch (Production Releases)
+- **Trigger**: Push to `main` branch
+- **Version**: `2.1.{run_number}`
+- **Actions**: Build → Test → Pack → Create Release → Push to NuGet
+
+### Pull Requests (Development Builds)
+- **Trigger**: PR opened/updated
+- **Version**: `2.1.{run_number}-pull-request`
+- **Actions**: Build → Test → Pack (no release creation)
+
+## Benefits
+
+✅ **No Version Lag**: Write release notes during development  
+✅ **Automatic Versioning**: No manual version number management  
+✅ **GitHub Integration**: Releases prominently displayed  
+✅ **Asset Management**: NuGet packages attached to releases  
+✅ **Flexible**: Choose manual or auto-generated notes  
+✅ **Clean Repository**: Release notes file auto-cleaned  
+
+## Migration from Old System
+
+1. **Historical notes**: Preserved in documentation website as archive
+2. **Current releases**: Now on GitHub Releases page
+3. **User communication**: Documentation updated with redirect
+4. **Workflow**: Developers use new `RELEASE_NOTES.md` approach
+
+## Examples
+
+### Major Release with Detailed Notes
+```bash
+# Create detailed release notes
+cp RELEASE_NOTES_TEMPLATE.md RELEASE_NOTES.md
+# Edit with comprehensive changes
+git add RELEASE_NOTES.md
+git commit -m "feat: major complex variables system overhaul"
+git push
+```
+
+### Quick Bug Fix Release
+```bash
+# Just push the fix - auto-generated notes
+git add .
+git commit -m "fix: resolve test execution issue"
+git push
+```
+
+## Troubleshooting
+
+### Release Not Created
+- Check if running on `main` branch
+- Verify `pack` job succeeded
+- Check GitHub Actions logs
+
+### Wrong Version Number
+- Verify workflow filename contains correct major.minor
+- Check `set_version` job output
+
+### Missing NuGet Packages
+- Verify `pack` job created `.nupkg` files
+- Check `find_packages` step output
+
+## Future Enhancements
+
+- **Changelog Generation**: Automatic changelog from release notes
+- **Release Notifications**: Slack/Discord integration
+- **Semantic Versioning**: Automatic major/minor bumps based on commit messages

--- a/site/src/pages/docs/4/releasenotes.md
+++ b/site/src/pages/docs/4/releasenotes.md
@@ -2,6 +2,30 @@
 title: Release Notes
 ---
 
+## Current Release Notes
+
+Release notes have been moved to [GitHub Releases](https://github.com/paulegradie/Sailfish/releases) for better integration with the development workflow.
+
+**[📋 View All Releases →](https://github.com/paulegradie/Sailfish/releases)**
+
+### Why the Move?
+
+- **Real-time updates**: Release notes are now automatically generated when new versions are published
+- **Better GitHub integration**: Releases are prominently displayed on the repository page
+- **Automatic linking**: Direct links to commits, pull requests, and contributors
+- **Asset management**: NuGet packages are directly attached to each release
+- **Notifications**: Subscribe to release notifications on GitHub
+
+### Latest Releases
+
+For the most up-to-date release information, please visit the [GitHub Releases page](https://github.com/paulegradie/Sailfish/releases).
+
+---
+
+## Historical Release Notes (Archive)
+
+The following release notes are archived for reference. For current releases, see the GitHub Releases page above.
+
 - 2.1.33
     - **Major Feature**: **Enhanced Complex Variables System** - Improved support for complex object variables using
       modern provider patterns


### PR DESCRIPTION
## Description

I'm trying to get things set up so that I don't need to keep managing release note versioning manually. W'ere going to remove these from the site and just manage them in git


## Results

Automations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated creation of GitHub Releases with attached NuGet packages and integrated release notes, supporting both manual and auto-generated notes.
  * Added support for writing release notes in advance using a template with automatic version replacement.

* **Documentation**
  * Introduced a detailed release workflow guide outlining versioning, release triggers, and benefits of the new process.
  * Added a release notes template with usage instructions for creating custom release notes.
  * Updated release notes pages to direct users to GitHub Releases for the latest information and clarified the archival status of historical notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->