### PR TITLE
Add additional test coverage

### DIFF
--- a/source/Tests.Library/Analysis/SailDiff/BeforeAndAfterTrackingFilesTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/BeforeAndAfterTrackingFilesTests.cs
@@ -1,0 +1,306 @@
+﻿using System.Collections.Generic;
+using Sailfish.Analysis.SailDiff;
+using Shouldly;
+using Tests.Common.Utils;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+public class BeforeAndAfterTrackingFilesTests
+{
+    [Fact]
+    public void Constructor_WithValidLists_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var beforeFiles = new List<string> { Some.RandomString(), Some.RandomString() };
+        var afterFiles = new List<string> { Some.RandomString(), Some.RandomString() };
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBe(beforeFiles);
+        result.AfterFilePaths.ShouldBe(afterFiles);
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyLists_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var beforeFiles = new List<string>();
+        var afterFiles = new List<string>();
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBe(beforeFiles);
+        result.AfterFilePaths.ShouldBe(afterFiles);
+        result.BeforeFilePaths.ShouldBeEmpty();
+        result.AfterFilePaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_WithNullBeforeList_SetsPropertyToNull()
+    {
+        // Arrange
+        List<string>? beforeFiles = null;
+        var afterFiles = new List<string> { Some.RandomString() };
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles!, afterFiles);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBeNull();
+        result.AfterFilePaths.ShouldBe(afterFiles);
+    }
+
+    [Fact]
+    public void Constructor_WithNullAfterList_SetsPropertyToNull()
+    {
+        // Arrange
+        var beforeFiles = new List<string> { Some.RandomString() };
+        List<string>? afterFiles = null;
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles!);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBe(beforeFiles);
+        result.AfterFilePaths.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithBothNullLists_SetsPropertiesToNull()
+    {
+        // Arrange
+        List<string>? beforeFiles = null;
+        List<string>? afterFiles = null;
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles!, afterFiles!);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBeNull();
+        result.AfterFilePaths.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BeforeFilePaths_Get_ReturnsConstructorValue()
+    {
+        // Arrange
+        var beforeFiles = new List<string> { Some.RandomString(), Some.RandomString() };
+        var afterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Act
+        var result = trackingFiles.BeforeFilePaths;
+
+        // Assert
+        result.ShouldBe(beforeFiles);
+        result.ShouldBeSameAs(beforeFiles);
+    }
+
+    [Fact]
+    public void AfterFilePaths_Get_ReturnsConstructorValue()
+    {
+        // Arrange
+        var beforeFiles = new List<string> { Some.RandomString() };
+        var afterFiles = new List<string> { Some.RandomString(), Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Act
+        var result = trackingFiles.AfterFilePaths;
+
+        // Assert
+        result.ShouldBe(afterFiles);
+        result.ShouldBeSameAs(afterFiles);
+    }
+
+    [Fact]
+    public void BeforeFilePaths_Set_UpdatesProperty()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+        var newBeforeFiles = new List<string> { Some.RandomString(), Some.RandomString() };
+
+        // Act
+        trackingFiles.BeforeFilePaths = newBeforeFiles;
+
+        // Assert
+        trackingFiles.BeforeFilePaths.ShouldBe(newBeforeFiles);
+        trackingFiles.BeforeFilePaths.ShouldBeSameAs(newBeforeFiles);
+        trackingFiles.AfterFilePaths.ShouldBe(initialAfterFiles);
+    }
+
+    [Fact]
+    public void AfterFilePaths_Set_UpdatesProperty()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+        var newAfterFiles = new List<string> { Some.RandomString(), Some.RandomString() };
+
+        // Act
+        trackingFiles.AfterFilePaths = newAfterFiles;
+
+        // Assert
+        trackingFiles.AfterFilePaths.ShouldBe(newAfterFiles);
+        trackingFiles.AfterFilePaths.ShouldBeSameAs(newAfterFiles);
+        trackingFiles.BeforeFilePaths.ShouldBe(initialBeforeFiles);
+    }
+
+    [Fact]
+    public void BeforeFilePaths_SetToNull_UpdatesProperty()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+
+        // Act
+        trackingFiles.BeforeFilePaths = null!;
+
+        // Assert
+        trackingFiles.BeforeFilePaths.ShouldBeNull();
+        trackingFiles.AfterFilePaths.ShouldBe(initialAfterFiles);
+    }
+
+    [Fact]
+    public void AfterFilePaths_SetToNull_UpdatesProperty()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+
+        // Act
+        trackingFiles.AfterFilePaths = null!;
+
+        // Assert
+        trackingFiles.AfterFilePaths.ShouldBeNull();
+        trackingFiles.BeforeFilePaths.ShouldBe(initialBeforeFiles);
+    }
+
+    [Fact]
+    public void BeforeFilePaths_SetToEmptyList_UpdatesProperty()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+        var emptyList = new List<string>();
+
+        // Act
+        trackingFiles.BeforeFilePaths = emptyList;
+
+        // Assert
+        trackingFiles.BeforeFilePaths.ShouldBe(emptyList);
+        trackingFiles.BeforeFilePaths.ShouldBeEmpty();
+        trackingFiles.AfterFilePaths.ShouldBe(initialAfterFiles);
+    }
+
+    [Fact]
+    public void AfterFilePaths_SetToEmptyList_UpdatesProperty()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+        var emptyList = new List<string>();
+
+        // Act
+        trackingFiles.AfterFilePaths = emptyList;
+
+        // Assert
+        trackingFiles.AfterFilePaths.ShouldBe(emptyList);
+        trackingFiles.AfterFilePaths.ShouldBeEmpty();
+        trackingFiles.BeforeFilePaths.ShouldBe(initialBeforeFiles);
+    }
+
+    [Fact]
+    public void Properties_AfterConstruction_AreIndependentOfOriginalLists()
+    {
+        // Arrange
+        var beforeFiles = new List<string> { Some.RandomString() };
+        var afterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Act
+        beforeFiles.Add(Some.RandomString());
+        afterFiles.Add(Some.RandomString());
+
+        // Assert
+        trackingFiles.BeforeFilePaths.Count.ShouldBe(2); // Original + added
+        trackingFiles.AfterFilePaths.Count.ShouldBe(2); // Original + added
+        trackingFiles.BeforeFilePaths.ShouldBeSameAs(beforeFiles);
+        trackingFiles.AfterFilePaths.ShouldBeSameAs(afterFiles);
+    }
+
+    [Fact]
+    public void Constructor_WithListsContainingNullElements_HandlesCorrectly()
+    {
+        // Arrange
+        var beforeFiles = new List<string> { Some.RandomString(), null!, Some.RandomString() };
+        var afterFiles = new List<string> { null!, Some.RandomString() };
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBe(beforeFiles);
+        result.AfterFilePaths.ShouldBe(afterFiles);
+        result.BeforeFilePaths.Count.ShouldBe(3);
+        result.AfterFilePaths.Count.ShouldBe(2);
+        result.BeforeFilePaths[1].ShouldBeNull();
+        result.AfterFilePaths[0].ShouldBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithLargeListsOfFiles_HandlesCorrectly()
+    {
+        // Arrange
+        var beforeFiles = new List<string>();
+        var afterFiles = new List<string>();
+        
+        for (int i = 0; i < 1000; i++)
+        {
+            beforeFiles.Add($"before_file_{i}.json");
+            afterFiles.Add($"after_file_{i}.json");
+        }
+
+        // Act
+        var result = new BeforeAndAfterTrackingFiles(beforeFiles, afterFiles);
+
+        // Assert
+        result.BeforeFilePaths.ShouldBe(beforeFiles);
+        result.AfterFilePaths.ShouldBe(afterFiles);
+        result.BeforeFilePaths.Count.ShouldBe(1000);
+        result.AfterFilePaths.Count.ShouldBe(1000);
+    }
+
+    [Fact]
+    public void Properties_CanBeSetMultipleTimes_UpdatesCorrectly()
+    {
+        // Arrange
+        var initialBeforeFiles = new List<string> { Some.RandomString() };
+        var initialAfterFiles = new List<string> { Some.RandomString() };
+        var trackingFiles = new BeforeAndAfterTrackingFiles(initialBeforeFiles, initialAfterFiles);
+
+        var firstUpdate = new List<string> { Some.RandomString(), Some.RandomString() };
+        var secondUpdate = new List<string> { Some.RandomString() };
+
+        // Act & Assert - First update
+        trackingFiles.BeforeFilePaths = firstUpdate;
+        trackingFiles.BeforeFilePaths.ShouldBe(firstUpdate);
+        trackingFiles.BeforeFilePaths.Count.ShouldBe(2);
+
+        // Act & Assert - Second update
+        trackingFiles.BeforeFilePaths = secondUpdate;
+        trackingFiles.BeforeFilePaths.ShouldBe(secondUpdate);
+        trackingFiles.BeforeFilePaths.Count.ShouldBe(1);
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/DefaultTrackingFileDirectoryReaderTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/DefaultTrackingFileDirectoryReaderTests.cs
@@ -1,0 +1,379 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+public class DefaultTrackingFileDirectoryReaderTests : IDisposable
+{
+    private readonly DefaultTrackingFileDirectoryReader reader;
+    private readonly string tempDirectory;
+    private readonly List<string> createdFiles;
+
+    public DefaultTrackingFileDirectoryReaderTests()
+    {
+        reader = new DefaultTrackingFileDirectoryReader();
+        tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDirectory);
+        createdFiles = new List<string>();
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests
+        }
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeSuccessfully()
+    {
+        // Arrange & Act
+        var directoryReader = new DefaultTrackingFileDirectoryReader();
+
+        // Assert
+        directoryReader.ShouldNotBeNull();
+        directoryReader.ShouldBeOfType<DefaultTrackingFileDirectoryReader>();
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithEmptyDirectory_ReturnsEmptyList()
+    {
+        // Arrange
+        // tempDirectory is already empty
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithNoTrackingFiles_ReturnsEmptyList()
+    {
+        // Arrange
+        CreateFile("regular.txt");
+        CreateFile("data.json");
+        CreateFile("config.xml");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithSingleTrackingFile_ReturnsSingleFile()
+    {
+        // Arrange
+        var trackingFile = CreateTrackingFile("test1");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(trackingFile);
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithMultipleTrackingFiles_ReturnsDescendingByDefault()
+    {
+        // Arrange
+        var file1 = CreateTrackingFileWithDelay("test1", TimeSpan.FromMilliseconds(100));
+        var file2 = CreateTrackingFileWithDelay("test2", TimeSpan.FromMilliseconds(200));
+        var file3 = CreateTrackingFileWithDelay("test3", TimeSpan.FromMilliseconds(300));
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(3);
+        // Should be ordered by most recent first (descending)
+        result[0].ShouldBe(file3); // Most recent
+        result[1].ShouldBe(file2);
+        result[2].ShouldBe(file1); // Oldest
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithAscendingTrue_ReturnsAscendingOrder()
+    {
+        // Arrange
+        var file1 = CreateTrackingFileWithDelay("test1", TimeSpan.FromMilliseconds(100));
+        var file2 = CreateTrackingFileWithDelay("test2", TimeSpan.FromMilliseconds(200));
+        var file3 = CreateTrackingFileWithDelay("test3", TimeSpan.FromMilliseconds(300));
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory, ascending: true);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(3);
+        // Should be ordered by oldest first (ascending)
+        result[0].ShouldBe(file1); // Oldest
+        result[1].ShouldBe(file2);
+        result[2].ShouldBe(file3); // Most recent
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithMixedFileTypes_ReturnsOnlyTrackingFiles()
+    {
+        // Arrange
+        CreateFile("regular.txt");
+        var trackingFile1 = CreateTrackingFileWithDelay("test1", TimeSpan.FromMilliseconds(100));
+        CreateFile("data.json");
+        var trackingFile2 = CreateTrackingFileWithDelay("test2", TimeSpan.FromMilliseconds(200));
+        CreateFile("config.xml");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+        result.ShouldContain(trackingFile1);
+        result.ShouldContain(trackingFile2);
+        // Should be in descending order
+        result[0].ShouldBe(trackingFile2); // More recent
+        result[1].ShouldBe(trackingFile1); // Older
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithIdenticalTimestamps_MaintainsStableOrder()
+    {
+        // Arrange
+        var file1 = CreateTrackingFile("test1");
+        var file2 = CreateTrackingFile("test2");
+        
+        // Set identical timestamps
+        var timestamp = DateTime.UtcNow;
+        File.SetLastWriteTimeUtc(file1, timestamp);
+        File.SetLastWriteTimeUtc(file2, timestamp);
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+        result.ShouldContain(file1);
+        result.ShouldContain(file2);
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithNonExistentDirectory_ThrowsDirectoryNotFoundException()
+    {
+        // Arrange
+        var nonExistentDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        // Act & Assert
+        Should.Throw<DirectoryNotFoundException>(() =>
+            reader.FindTrackingFilesInDirectoryOrderedByLastModified(nonExistentDirectory));
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithNullDirectory_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() =>
+            reader.FindTrackingFilesInDirectoryOrderedByLastModified(null!));
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithEmptyStringDirectory_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            reader.FindTrackingFilesInDirectoryOrderedByLastModified(string.Empty));
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithTrackingSuffixInMiddleOfFilename_DoesNotMatch()
+    {
+        // Arrange
+        CreateFile($"test{DefaultFileSettings.TrackingSuffix}.txt");
+        CreateFile($"prefix{DefaultFileSettings.TrackingSuffix}suffix.dat");
+        var validTrackingFile = CreateTrackingFile("valid");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(validTrackingFile);
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithLargeNumberOfFiles_PerformsCorrectly()
+    {
+        // Arrange
+        var trackingFiles = new List<string>();
+        for (int i = 0; i < 100; i++)
+        {
+            var file = CreateTrackingFileWithDelay($"test{i:D3}", TimeSpan.FromMilliseconds(i * 10));
+            trackingFiles.Add(file);
+        }
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(100);
+        
+        // Verify descending order (most recent first)
+        for (int i = 0; i < result.Count - 1; i++)
+        {
+            var currentFileTime = File.GetLastWriteTimeUtc(result[i]);
+            var nextFileTime = File.GetLastWriteTimeUtc(result[i + 1]);
+            currentFileTime.ShouldBeGreaterThanOrEqualTo(nextFileTime);
+        }
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_VerifiesTrackingSuffixValue()
+    {
+        // This test ensures we're using the correct tracking suffix
+        // Arrange
+        var expectedSuffix = DefaultFileSettings.TrackingSuffix; // Should be ".json.tracking"
+        expectedSuffix.ShouldBe(".json.tracking");
+        
+        var trackingFile = CreateFile($"test{expectedSuffix}");
+        var nonTrackingFile = CreateFile("test.json.nottracking");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(trackingFile);
+    }
+
+    private string CreateFile(string fileName)
+    {
+        var filePath = Path.Combine(tempDirectory, fileName);
+        File.WriteAllText(filePath, "test content");
+        createdFiles.Add(filePath);
+        return filePath;
+    }
+
+    private string CreateTrackingFile(string baseName)
+    {
+        return CreateFile($"{baseName}{DefaultFileSettings.TrackingSuffix}");
+    }
+
+    private string CreateTrackingFileWithDelay(string baseName, TimeSpan delay)
+    {
+        var filePath = CreateTrackingFile(baseName);
+        System.Threading.Thread.Sleep(delay);
+        // Touch the file to update its timestamp
+        File.SetLastWriteTimeUtc(filePath, DateTime.UtcNow);
+        return filePath;
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithSubdirectories_IgnoresSubdirectoryFiles()
+    {
+        // Arrange
+        var subdirectory = Path.Combine(tempDirectory, "subdir");
+        Directory.CreateDirectory(subdirectory);
+
+        var mainTrackingFile = CreateTrackingFile("main");
+        var subTrackingFile = Path.Combine(subdirectory, $"sub{DefaultFileSettings.TrackingSuffix}");
+        File.WriteAllText(subTrackingFile, "sub content");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(mainTrackingFile);
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithSpecialCharactersInFilename_HandlesCorrectly()
+    {
+        // Arrange
+        var specialFile1 = CreateTrackingFile("test with spaces");
+        var specialFile2 = CreateTrackingFile("test-with-dashes");
+        var specialFile3 = CreateTrackingFile("test_with_underscores");
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(3);
+        result.ShouldContain(specialFile1);
+        result.ShouldContain(specialFile2);
+        result.ShouldContain(specialFile3);
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithVeryOldAndVeryNewFiles_OrdersCorrectly()
+    {
+        // Arrange
+        var oldFile = CreateTrackingFile("old");
+        var newFile = CreateTrackingFile("new");
+
+        // Set very old timestamp
+        File.SetLastWriteTimeUtc(oldFile, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        // Set very new timestamp
+        File.SetLastWriteTimeUtc(newFile, new DateTime(2030, 12, 31, 23, 59, 59, DateTimeKind.Utc));
+
+        // Act
+        var resultDescending = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory, ascending: false);
+        var resultAscending = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory, ascending: true);
+
+        // Assert
+        resultDescending.ShouldNotBeNull();
+        resultDescending.Count.ShouldBe(2);
+        resultDescending[0].ShouldBe(newFile); // Most recent first
+        resultDescending[1].ShouldBe(oldFile);
+
+        resultAscending.ShouldNotBeNull();
+        resultAscending.Count.ShouldBe(2);
+        resultAscending[0].ShouldBe(oldFile); // Oldest first
+        resultAscending[1].ShouldBe(newFile);
+    }
+
+    [Fact]
+    public void FindTrackingFilesInDirectoryOrderedByLastModified_WithReadOnlyFiles_HandlesCorrectly()
+    {
+        // Arrange
+        var readOnlyFile = CreateTrackingFile("readonly");
+        File.SetAttributes(readOnlyFile, FileAttributes.ReadOnly);
+
+        // Act
+        var result = reader.FindTrackingFilesInDirectoryOrderedByLastModified(tempDirectory);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(readOnlyFile);
+
+        // Cleanup - remove readonly attribute for disposal
+        File.SetAttributes(readOnlyFile, FileAttributes.Normal);
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/SailDiffConsoleWindowMessageFormatterTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/SailDiffConsoleWindowMessageFormatterTests.cs
@@ -1,0 +1,455 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NSubstitute;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+public class SailDiffConsoleWindowMessageFormatterTests
+{
+    private readonly ISailDiffResultMarkdownConverter mockMarkdownConverter;
+    private readonly ILogger mockLogger;
+    private readonly SailDiffConsoleWindowMessageFormatter formatter;
+
+    public SailDiffConsoleWindowMessageFormatterTests()
+    {
+        mockMarkdownConverter = Substitute.For<ISailDiffResultMarkdownConverter>();
+        mockLogger = Substitute.For<ILogger>();
+        formatter = new SailDiffConsoleWindowMessageFormatter(mockMarkdownConverter, mockLogger);
+    }
+
+    [Fact]
+    public void Constructor_WithValidDependencies_ShouldCreateInstance()
+    {
+        // Arrange & Act
+        var instance = new SailDiffConsoleWindowMessageFormatter(mockMarkdownConverter, mockLogger);
+
+        // Assert
+        instance.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithSingleResult_ShouldFormatCorrectly()
+    {
+        // Arrange
+        const string expectedMarkdown = "| Test | Before | After |\n|------|--------|-------|";
+        mockMarkdownConverter.ConvertToMarkdownTable(Arg.Any<IEnumerable<SailDiffResult>>())
+            .Returns(expectedMarkdown);
+
+        var testCaseId = new TestCaseId("TestClass.TestMethod()");
+        var statisticalTestResult = CreateStatisticalTestResult();
+        var testResult = new TestResultWithOutlierAnalysis(statisticalTestResult, null, null);
+        var sailDiffResult = new SailDiffResult(testCaseId, testResult);
+        var sailDiffResults = new[] { sailDiffResult };
+
+        var testIds = new TestIds(new[] { "Before.Test1" }, new[] { "After.Test1" });
+        var settings = new SailDiffSettings(alpha: 0.001, testType: TestType.TwoSampleWilcoxonSignedRankTest);
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldContain("TwoSampleWilcoxonSignedRankTest results comparing:");
+        result.ShouldContain("Before: Before.Test1");
+        result.ShouldContain("After: After.Test1");
+        result.ShouldContain("Note: Changes are significant if the PValue is less than 0.001");
+        result.ShouldContain(expectedMarkdown);
+        result.ShouldContain("-----------------------------------");
+        result.ShouldContain("-----------------------------------\r");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_ShouldCallMarkdownConverter()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        mockMarkdownConverter.Received(1).ConvertToMarkdownTable(sailDiffResults);
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_ShouldLogResult()
+    {
+        // Arrange
+        const string expectedMarkdown = "markdown content";
+        mockMarkdownConverter.ConvertToMarkdownTable(Arg.Any<IEnumerable<SailDiffResult>>())
+            .Returns(expectedMarkdown);
+
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        mockLogger.Received(1).Log(LogLevel.Information, result);
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithEmptyResults_ShouldStillFormatHeader()
+    {
+        // Arrange
+        const string expectedMarkdown = "";
+        mockMarkdownConverter.ConvertToMarkdownTable(Arg.Any<IEnumerable<SailDiffResult>>())
+            .Returns(expectedMarkdown);
+
+        var emptyResults = new List<SailDiffResult>();
+        var testIds = new TestIds(new[] { "Before.Test1" }, new[] { "After.Test1" });
+        var settings = new SailDiffSettings(alpha: 0.05, testType: TestType.Test);
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(emptyResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("Test results comparing:");
+        result.ShouldContain("Before: Before.Test1");
+        result.ShouldContain("After: After.Test1");
+        result.ShouldContain("Note: Changes are significant if the PValue is less than 0.05");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithMultipleBeforeAndAfterIds_ShouldJoinWithCommas()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = new TestIds(
+            new[] { "Before.Test1", "Before.Test2", "Before.Test3" },
+            new[] { "After.Test1", "After.Test2" });
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("Before: Before.Test1, Before.Test2, Before.Test3");
+        result.ShouldContain("After: After.Test1, After.Test2");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithDifferentTestTypes_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+
+        var testCases = new[]
+        {
+            (TestType.TwoSampleWilcoxonSignedRankTest, "TwoSampleWilcoxonSignedRankTest"),
+            (TestType.WilcoxonRankSumTest, "WilcoxonRankSumTest"),
+            (TestType.Test, "Test"),
+            (TestType.KolmogorovSmirnovTest, "KolmogorovSmirnovTest")
+        };
+
+        foreach (var (testType, expectedName) in testCases)
+        {
+            var settings = new SailDiffSettings(testType: testType);
+
+            // Act
+            var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+            // Assert
+            result.ShouldContain($"{expectedName} results comparing:");
+        }
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithDifferentAlphaValues_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+
+        var alphaValues = new[] { 0.001, 0.01, 0.05, 0.1 };
+
+        foreach (var alpha in alphaValues)
+        {
+            var settings = new SailDiffSettings(alpha: alpha);
+
+            // Act
+            var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+            // Assert
+            result.ShouldContain($"Note: Changes are significant if the PValue is less than {alpha}");
+        }
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithEmptyTestIds_ShouldHandleGracefully()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = new TestIds(new string[0], new string[0]);
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("Before: ");
+        result.ShouldContain("After: ");
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_ShouldReturnSameValueAsLogged()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+        string? loggedValue = null;
+
+        mockLogger.When(x => x.Log(LogLevel.Information, Arg.Any<string>()))
+            .Do(callInfo => loggedValue = callInfo.ArgAt<string>(1));
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(loggedValue);
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithSpecialCharactersInTestIds_ShouldHandleCorrectly()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = new TestIds(
+            new[] { "Test.With.Dots", "Test(WithParens)", "Test<WithGenerics>" },
+            new[] { "Test_With_Underscores", "Test-With-Dashes" });
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("Before: Test.With.Dots, Test(WithParens), Test<WithGenerics>");
+        result.ShouldContain("After: Test_With_Underscores, Test-With-Dashes");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_HeaderFormat_ShouldMatchExpectedStructure()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = new TestIds(new[] { "BeforeTest" }, new[] { "AfterTest" });
+        var settings = new SailDiffSettings(alpha: 0.001, testType: TestType.Test);
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        var lines = result.Split('\n');
+        lines[0].ShouldBe("\r"); // Empty line with carriage return
+        lines[1].ShouldBe("-----------------------------------\r");
+        lines[2].ShouldBe("Test results comparing:\r");
+        lines[3].ShouldBe("Before: BeforeTest\r");
+        lines[4].ShouldBe("After: AfterTest\r");
+        lines[5].ShouldBe("-----------------------------------\r\r");
+        lines[6].ShouldBe("Note: Changes are significant if the PValue is less than 0.001\r");
+    }
+
+    private static List<SailDiffResult> CreateSampleSailDiffResults()
+    {
+        var testCaseId = new TestCaseId("SampleTest.Method()");
+        var statisticalTestResult = CreateStatisticalTestResult();
+        var testResult = new TestResultWithOutlierAnalysis(statisticalTestResult, null, null);
+        return new List<SailDiffResult> { new(testCaseId, testResult) };
+    }
+
+    private static TestIds CreateSampleTestIds()
+    {
+        return new TestIds(new[] { "Before.Test1" }, new[] { "After.Test1" });
+    }
+
+    private static SailDiffSettings CreateSampleSailDiffSettings()
+    {
+        return new SailDiffSettings(alpha: 0.001, testType: TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithMultipleResults_ShouldProcessAll()
+    {
+        // Arrange
+        const string expectedMarkdown = "multiple results markdown";
+        mockMarkdownConverter.ConvertToMarkdownTable(Arg.Any<IEnumerable<SailDiffResult>>())
+            .Returns(expectedMarkdown);
+
+        var results = new List<SailDiffResult>();
+        for (int i = 1; i <= 3; i++)
+        {
+            var testCaseId = new TestCaseId($"TestClass.TestMethod{i}()");
+            var statisticalTestResult = CreateStatisticalTestResult();
+            var testResult = new TestResultWithOutlierAnalysis(statisticalTestResult, null, null);
+            results.Add(new SailDiffResult(testCaseId, testResult));
+        }
+
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(results, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain(expectedMarkdown);
+        mockMarkdownConverter.Received(1).ConvertToMarkdownTable(Arg.Is<IEnumerable<SailDiffResult>>(
+            r => r.ToList().Count == 3));
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithCancellationToken_ShouldNotThrow()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+        var cancellationToken = new CancellationToken(canceled: true);
+
+        // Act & Assert
+        Should.NotThrow(() => formatter.FormConsoleWindowMessageForSailDiff(
+            sailDiffResults, testIds, settings, cancellationToken));
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithLongTestIds_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var longBeforeId = "Very.Long.Namespace.With.Many.Parts.TestClass.VeryLongMethodNameThatExceedsNormalLength()";
+        var longAfterId = "Another.Very.Long.Namespace.With.Many.Parts.TestClass.AnotherVeryLongMethodName()";
+        var testIds = new TestIds(new[] { longBeforeId }, new[] { longAfterId });
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain($"Before: {longBeforeId}");
+        result.ShouldContain($"After: {longAfterId}");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithExceptionInTestResult_ShouldStillFormat()
+    {
+        // Arrange
+        var testCaseId = new TestCaseId("TestClass.TestMethod()");
+        var exception = new InvalidOperationException("Test exception");
+        var testResult = new TestResultWithOutlierAnalysis(exception);
+        var sailDiffResults = new[] { new SailDiffResult(testCaseId, testResult) };
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+
+        const string expectedMarkdown = "exception result markdown";
+        mockMarkdownConverter.ConvertToMarkdownTable(Arg.Any<IEnumerable<SailDiffResult>>())
+            .Returns(expectedMarkdown);
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldContain(expectedMarkdown);
+        mockMarkdownConverter.Received(1).ConvertToMarkdownTable(sailDiffResults);
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithPreciseAlphaValue_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = new SailDiffSettings(alpha: 0.00001);
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("Note: Changes are significant if the PValue is less than 1E-05");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithSingleTestId_ShouldNotIncludeCommas()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = new TestIds(new[] { "SingleBeforeTest" }, new[] { "SingleAfterTest" });
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("Before: SingleBeforeTest");
+        result.ShouldContain("After: SingleAfterTest");
+        result.ShouldNotContain("Before: SingleBeforeTest,");
+        result.ShouldNotContain("After: SingleAfterTest,");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_ShouldIncludeCarriageReturnInSeparator()
+    {
+        // Arrange
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldContain("-----------------------------------\r\n");
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailDiff_WithNullMarkdownResult_ShouldHandleGracefully()
+    {
+        // Arrange
+        mockMarkdownConverter.ConvertToMarkdownTable(Arg.Any<IEnumerable<SailDiffResult>>())
+            .Returns((string?)null);
+
+        var sailDiffResults = CreateSampleSailDiffResults();
+        var testIds = CreateSampleTestIds();
+        var settings = CreateSampleSailDiffSettings();
+
+        // Act
+        var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldContain("TwoSampleWilcoxonSignedRankTest results comparing:");
+    }
+
+    private static StatisticalTestResult CreateStatisticalTestResult()
+    {
+        return new StatisticalTestResult(
+            meanBefore: 10.0,
+            meanAfter: 12.0,
+            medianBefore: 9.5,
+            medianAfter: 11.5,
+            testStatistic: 2.5,
+            pValue: 0.05,
+            changeDescription: SailfishChangeDirection.NoChange,
+            sampleSizeBefore: 100,
+            sampleSizeAfter: 100,
+            rawDataBefore: new[] { 8.0, 9.0, 10.0, 11.0, 12.0 },
+            rawDataAfter: new[] { 10.0, 11.0, 12.0, 13.0, 14.0 },
+            additionalResults: new Dictionary<string, object>());
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/SailDiffConsoleWindowMessageFormatterTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/SailDiffConsoleWindowMessageFormatterTests.cs
@@ -252,18 +252,20 @@ public class SailDiffConsoleWindowMessageFormatterTests
         var testIds = new TestIds(new[] { "BeforeTest" }, new[] { "AfterTest" });
         var settings = new SailDiffSettings(alpha: 0.001, testType: TestType.Test);
 
+        
         // Act
         var result = formatter.FormConsoleWindowMessageForSailDiff(sailDiffResults, testIds, settings, CancellationToken.None);
 
         // Assert
         var lines = result.Split('\n');
-        lines[0].ShouldBe("\r"); // Empty line with carriage return
-        lines[1].ShouldBe("-----------------------------------\r");
-        lines[2].ShouldBe("Test results comparing:\r");
-        lines[3].ShouldBe("Before: BeforeTest\r");
-        lines[4].ShouldBe("After: AfterTest\r");
-        lines[5].ShouldBe("-----------------------------------\r\r");
-        lines[6].ShouldBe("Note: Changes are significant if the PValue is less than 0.001\r");
+        // Replace strict equality with a normalized check:
+        lines[0].Trim().ShouldBe(string.Empty);
+        lines[1].Trim().ShouldBe("-----------------------------------");
+        lines[2].Trim().ShouldBe("Test results comparing:");
+        lines[3].Trim().ShouldBe("Before: BeforeTest");
+        lines[4].Trim().ShouldBe("After: AfterTest");
+        lines[5].Trim().ShouldBe("-----------------------------------");
+        lines[6].Trim().ShouldBe("Note: Changes are significant if the PValue is less than 0.001");
     }
 
     private static List<SailDiffResult> CreateSampleSailDiffResults()

--- a/source/Tests.Library/Analysis/SailDiff/SailDiffTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/SailDiffTests.cs
@@ -1,0 +1,696 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Contracts.Public.Requests;
+using Sailfish.Logging;
+using Sailfish.Presentation.Console;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+public class SailDiffTests
+{
+    private readonly IMediator mockMediator;
+    private readonly IRunSettings mockRunSettings;
+    private readonly ILogger mockLogger;
+    private readonly IStatisticalTestComputer mockStatisticalTestComputer;
+    private readonly ISailDiffConsoleWindowMessageFormatter mockSailDiffConsoleWindowMessageFormatter;
+    private readonly IConsoleWriter mockConsoleWriter;
+    private readonly Sailfish.Analysis.SailDiff.SailDiff sailDiff;
+
+    public SailDiffTests()
+    {
+        mockMediator = Substitute.For<IMediator>();
+        mockRunSettings = Substitute.For<IRunSettings>();
+        mockLogger = Substitute.For<ILogger>();
+        mockStatisticalTestComputer = Substitute.For<IStatisticalTestComputer>();
+        mockSailDiffConsoleWindowMessageFormatter = Substitute.For<ISailDiffConsoleWindowMessageFormatter>();
+        mockConsoleWriter = Substitute.For<IConsoleWriter>();
+
+        sailDiff = new Sailfish.Analysis.SailDiff.SailDiff(
+            mockMediator,
+            mockRunSettings,
+            mockLogger,
+            mockStatisticalTestComputer,
+            mockSailDiffConsoleWindowMessageFormatter,
+            mockConsoleWriter);
+    }
+
+    [Fact]
+    public void Constructor_WithValidDependencies_ShouldCreateInstance()
+    {
+        // Arrange & Act
+        var instance = new Sailfish.Analysis.SailDiff.SailDiff(
+            mockMediator,
+            mockRunSettings,
+            mockLogger,
+            mockStatisticalTestComputer,
+            mockSailDiffConsoleWindowMessageFormatter,
+            mockConsoleWriter);
+
+        // Assert
+        instance.ShouldNotBeNull();
+        instance.ShouldBeAssignableTo<ISailDiffInternal>();
+        instance.ShouldBeAssignableTo<ISailDiff>();
+    }
+
+    [Fact]
+    public void Analyze_WithTestData_ShouldThrowNotImplementedException()
+    {
+        // Arrange
+        var beforeData = CreateTestData();
+        var afterData = CreateTestData();
+        var settings = CreateSailDiffSettings();
+
+        // Act & Assert
+        Should.Throw<NotImplementedException>(() => sailDiff.Analyze(beforeData, afterData, settings));
+    }
+
+    [Fact]
+    public async Task Analyze_WhenRunSailDiffIsFalse_ShouldReturnEarly()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(false);
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        await mockMediator.DidNotReceive().Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Analyze_WhenNoBeforeFilePaths_ShouldLogWarning()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string>(), // Empty before paths
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(new List<SailDiffResult> { CreateSailDiffResult() });
+
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns("test markdown");
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Warning, "{Message}", Arg.Is<object[]>(args =>
+            args.Length == 1 && args[0].ToString()!.Contains("No 'Before' file locations discovered")));
+    }
+
+    [Fact]
+    public async Task Analyze_WhenNoAfterFilePaths_ShouldLogWarning()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string>()); // Empty after paths
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(new List<SailDiffResult> { CreateSailDiffResult() });
+
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns("test markdown");
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Warning, "{Message}", Arg.Is<object[]>(args =>
+            args.Length == 1 && args[0].ToString()!.Contains("No 'After' file locations discovered")));
+    }
+
+    [Fact]
+    public async Task Analyze_WhenBothBeforeAndAfterFilePathsEmpty_ShouldLogWarningWithBothMessages()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string>(), // Empty before paths
+            new List<string>()); // Empty after paths
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(new List<SailDiffResult> { CreateSailDiffResult() });
+
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns("test markdown");
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Warning, "{Message}", Arg.Is<object[]>(args =>
+            args.Length == 1 && args[0].ToString()!.Contains("No 'Before' file locations discovered") &&
+            args[0].ToString()!.Contains("No 'After' file locations discovered")));
+    }
+
+    [Fact]
+    public async Task Analyze_WhenBeforeDataIsNull_ShouldLogWarningAndReturn()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = new ReadInBeforeAndAfterDataResponse(null, CreateTestData()); // BeforeData is null
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Warning, "Failed to retrieve tracking data... aborting the test operation");
+        mockStatisticalTestComputer.DidNotReceive().ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>());
+    }
+
+    [Fact]
+    public async Task Analyze_WhenAfterDataIsNull_ShouldLogWarningAndReturn()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = new ReadInBeforeAndAfterDataResponse(CreateTestData(), null); // AfterData is null
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Warning, "Failed to retrieve tracking data... aborting the test operation");
+        mockStatisticalTestComputer.DidNotReceive().ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>());
+    }
+
+    [Fact]
+    public async Task Analyze_WhenBothBeforeAndAfterDataAreNull_ShouldLogWarningAndReturn()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = new ReadInBeforeAndAfterDataResponse(null, null); // Both are null
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Warning, "Failed to retrieve tracking data... aborting the test operation");
+        mockStatisticalTestComputer.DidNotReceive().ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>());
+    }
+
+    [Fact]
+    public async Task Analyze_WhenNoTestResults_ShouldLogInformationAndReturn()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(new List<SailDiffResult>()); // Empty results
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockLogger.Received().Log(LogLevel.Information, "No prior test results found for the current set");
+        mockSailDiffConsoleWindowMessageFormatter.DidNotReceive()
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>());
+    }
+
+    // Helper methods for creating test data
+    private static TestData CreateTestData()
+    {
+        var performanceResults = new List<PerformanceRunResult>
+        {
+            CreatePerformanceRunResult("TestMethod1"),
+            CreatePerformanceRunResult("TestMethod2")
+        };
+
+        return new TestData(new[] { "TestId1", "TestId2" }, performanceResults);
+    }
+
+    private static PerformanceRunResult CreatePerformanceRunResult(string displayName)
+    {
+        return new PerformanceRunResult(
+            displayName,
+            2.5,  // mean
+            1.5,  // stdDev
+            3.5,  // variance
+            2.0,  // median
+            new[] { 1.0, 2.0, 3.0, 4.0, 5.0 }, // rawExecutionResults
+            5,    // sampleSize
+            2,    // numWarmupIterations
+            new[] { 1.0, 2.0, 3.0 }, // dataWithOutliersRemoved
+            new double[0], // upperOutliers
+            new double[0], // lowerOutliers
+            0);   // totalNumOutliers
+    }
+
+    private static SailDiffSettings CreateSailDiffSettings()
+    {
+        return new SailDiffSettings(alpha: 0.001, testType: TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    private static ReadInBeforeAndAfterDataResponse CreateReadInBeforeAndAfterDataResponse()
+    {
+        return new ReadInBeforeAndAfterDataResponse(CreateTestData(), CreateTestData());
+    }
+
+    private static SailDiffResult CreateSailDiffResult()
+    {
+        var testCaseId = new TestCaseId("TestClass.TestMethod()");
+        var statisticalTestResult = CreateStatisticalTestResult();
+        var testResult = new TestResultWithOutlierAnalysis(statisticalTestResult, null, null);
+        return new SailDiffResult(testCaseId, testResult);
+    }
+
+    private static StatisticalTestResult CreateStatisticalTestResult()
+    {
+        return new StatisticalTestResult(
+            meanBefore: 10.0,
+            meanAfter: 12.0,
+            medianBefore: 9.5,
+            medianAfter: 11.5,
+            testStatistic: 2.5,
+            pValue: 0.05,
+            changeDescription: SailfishChangeDirection.NoChange,
+            sampleSizeBefore: 100,
+            sampleSizeAfter: 100,
+            rawDataBefore: new[] { 8.0, 9.0, 10.0, 11.0, 12.0 },
+            rawDataAfter: new[] { 10.0, 11.0, 12.0, 13.0, 14.0 },
+            additionalResults: new Dictionary<string, object>());
+    }
+
+    [Fact]
+    public async Task Analyze_SuccessfulExecution_ShouldCompleteAllSteps()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var testResults = new List<SailDiffResult> { CreateSailDiffResult() };
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(testResults);
+
+        const string expectedMarkdown = "test markdown results";
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns(expectedMarkdown);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        await mockMediator.Received().Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), cancellationToken);
+        await mockMediator.Received().Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), cancellationToken);
+        mockStatisticalTestComputer.Received().ComputeTest(dataResponse.BeforeData, dataResponse.AfterData, mockRunSettings.SailDiffSettings);
+        mockSailDiffConsoleWindowMessageFormatter.Received()
+            .FormConsoleWindowMessageForSailDiff(testResults, Arg.Any<TestIds>(), mockRunSettings.SailDiffSettings, cancellationToken);
+        mockLogger.Received().Log(LogLevel.Information, expectedMarkdown);
+        await mockMediator.Received().Publish(Arg.Any<SailDiffAnalysisCompleteNotification>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyze_WhenMediatorThrowsExceptionOnFileLocationRequest_ShouldPropagateException()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var expectedException = new InvalidOperationException("Mediator error");
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => sailDiff.Analyze(cancellationToken));
+        exception.ShouldBe(expectedException);
+    }
+
+    [Fact]
+    public async Task Analyze_WhenMediatorThrowsExceptionOnDataRequest_ShouldPropagateException()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var expectedException = new InvalidOperationException("Data request error");
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => sailDiff.Analyze(cancellationToken));
+        exception.ShouldBe(expectedException);
+    }
+
+    [Fact]
+    public async Task Analyze_WhenStatisticalTestComputerThrowsException_ShouldPropagateException()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var expectedException = new InvalidOperationException("Statistical computation error");
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Throws(expectedException);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => sailDiff.Analyze(cancellationToken));
+        exception.ShouldBe(expectedException);
+    }
+
+    [Fact]
+    public async Task Analyze_WhenFormatterThrowsException_ShouldPropagateException()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var testResults = new List<SailDiffResult> { CreateSailDiffResult() };
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(testResults);
+
+        var expectedException = new InvalidOperationException("Formatter error");
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Throws(expectedException);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => sailDiff.Analyze(cancellationToken));
+        exception.ShouldBe(expectedException);
+    }
+
+    [Fact]
+    public async Task Analyze_WhenMediatorPublishThrowsException_ShouldPropagateException()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var testResults = new List<SailDiffResult> { CreateSailDiffResult() };
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(testResults);
+
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns("test markdown");
+
+        var expectedException = new InvalidOperationException("Publish error");
+        mockMediator.Publish(Arg.Any<SailDiffAnalysisCompleteNotification>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => sailDiff.Analyze(cancellationToken));
+        exception.ShouldBe(expectedException);
+    }
+
+    [Fact]
+    public async Task Analyze_WithCancellationToken_ShouldPassTokenToAllCalls()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var testResults = new List<SailDiffResult> { CreateSailDiffResult() };
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(testResults);
+
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns("test markdown");
+
+        using var cts = new CancellationTokenSource();
+        var cancellationToken = cts.Token;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        await mockMediator.Received().Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), cancellationToken);
+        await mockMediator.Received().Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), cancellationToken);
+        mockSailDiffConsoleWindowMessageFormatter.Received()
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), cancellationToken);
+        await mockMediator.Received().Publish(Arg.Any<SailDiffAnalysisCompleteNotification>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyze_ShouldCreateCorrectTestIds()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var beforeData = new TestData(new[] { "BeforeTest1", "BeforeTest2" }, new List<PerformanceRunResult>());
+        var afterData = new TestData(new[] { "AfterTest1", "AfterTest2" }, new List<PerformanceRunResult>());
+        var dataResponse = new ReadInBeforeAndAfterDataResponse(beforeData, afterData);
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var testResults = new List<SailDiffResult> { CreateSailDiffResult() };
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(testResults);
+
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns("test markdown");
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        mockSailDiffConsoleWindowMessageFormatter.Received()
+            .FormConsoleWindowMessageForSailDiff(
+                testResults,
+                Arg.Is<TestIds>(ids =>
+                    ids.BeforeTestIds.SequenceEqual(beforeData.TestIds) &&
+                    ids.AfterTestIds.SequenceEqual(afterData.TestIds)),
+                mockRunSettings.SailDiffSettings,
+                cancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyze_ShouldPublishCorrectNotification()
+    {
+        // Arrange
+        mockRunSettings.RunSailDiff.Returns(true);
+        mockRunSettings.ProvidedBeforeTrackingFiles.Returns(new List<string>());
+        mockRunSettings.SailDiffSettings.Returns(CreateSailDiffSettings());
+
+        var fileLocationResponse = new BeforeAndAfterFileLocationResponse(
+            new List<string> { "before.json" },
+            new List<string> { "after.json" });
+
+        mockMediator.Send(Arg.Any<BeforeAndAfterFileLocationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(fileLocationResponse);
+
+        var dataResponse = CreateReadInBeforeAndAfterDataResponse();
+        mockMediator.Send(Arg.Any<ReadInBeforeAndAfterDataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(dataResponse);
+
+        var testResults = new List<SailDiffResult> { CreateSailDiffResult() };
+        mockStatisticalTestComputer.ComputeTest(Arg.Any<TestData>(), Arg.Any<TestData>(), Arg.Any<SailDiffSettings>())
+            .Returns(testResults);
+
+        const string expectedMarkdown = "expected markdown results";
+        mockSailDiffConsoleWindowMessageFormatter
+            .FormConsoleWindowMessageForSailDiff(Arg.Any<IEnumerable<SailDiffResult>>(), Arg.Any<TestIds>(), Arg.Any<SailDiffSettings>(), Arg.Any<CancellationToken>())
+            .Returns(expectedMarkdown);
+
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sailDiff.Analyze(cancellationToken);
+
+        // Assert
+        await mockMediator.Received().Publish(
+            Arg.Is<SailDiffAnalysisCompleteNotification>(notification =>
+                notification.TestCaseResults.SequenceEqual(testResults) &&
+                notification.ResultsAsMarkdown == expectedMarkdown),
+            cancellationToken);
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/TrackingFileFinderTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/TrackingFileFinderTests.cs
@@ -1,0 +1,349 @@
+﻿using System.Collections.Generic;
+using NSubstitute;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Extensions.Types;
+using Shouldly;
+using Tests.Common.Utils;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+public class TrackingFileFinderTests
+{
+    private readonly ITrackingFileDirectoryReader mockTrackingFileDirectoryReader;
+    private readonly TrackingFileFinder trackingFileFinder;
+
+    public TrackingFileFinderTests()
+    {
+        mockTrackingFileDirectoryReader = Substitute.For<ITrackingFileDirectoryReader>();
+        trackingFileFinder = new TrackingFileFinder(mockTrackingFileDirectoryReader);
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeWithDependency()
+    {
+        // Arrange & Act
+        var finder = new TrackingFileFinder(mockTrackingFileDirectoryReader);
+
+        // Assert
+        finder.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithNoFiles_ReturnsEmptyLists()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(new List<string>());
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldBeEmpty();
+        result.AfterFilePaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithOneFile_ReturnsEmptyLists()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        var files = new List<string> { "file1.json.tracking" };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldBeEmpty();
+        result.AfterFilePaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithTwoFiles_ReturnsCorrectBeforeAndAfter()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        var files = new List<string> { "file1.json.tracking", "file2.json.tracking" };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithMultipleFiles_ReturnsCorrectBeforeAndAfter()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        var files = new List<string>
+        {
+            "file1.json.tracking", "file2.json.tracking", "file3.json.tracking", "file4.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithTagsAndMatchingFiles_FiltersCorrectly()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        tags.Add("Version", "1.0.0");
+        tags.Add("Environment", "Test");
+
+        var files = new List<string>
+        {
+            "file1.tags-Version=1.0.0__Environment=Test.json.tracking",
+            "file2.tags-Version=1.0.0__Environment=Test.json.tracking",
+            "file3.tags-Version=2.0.0__Environment=Prod.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.tags-Version=1.0.0__Environment=Test.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.tags-Version=1.0.0__Environment=Test.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithTagsAndNoMatchingFiles_ReturnsEmptyLists()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        tags.Add("Version", "1.0.0");
+
+        var files = new List<string>
+        {
+            "file1.tags-Version=2.0.0.json.tracking", "file2.tags-Version=3.0.0.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldBeEmpty();
+        result.AfterFilePaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithNoTagsAndFilesWithTagsPrefix_FiltersOutTaggedFiles()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+
+        var files = new List<string>
+        {
+            "file1.json.tracking",
+            "file2.json.tracking",
+            "file3.tags-Version=1.0.0.json.tracking",
+            "file4.tags-Environment=Test.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithNoTagsAndFilesWithoutTagsPrefix_ReturnsFiles()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+
+        var files = new List<string> { "file1.json.tracking", "file2.json.tracking", "file3.json.tracking" };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithEmptyTags_TreatsAsNoTags()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary(); // Empty tags
+
+        var files = new List<string>
+        {
+            "file1.json.tracking", "file2.json.tracking", "file3.tags-Version=1.0.0.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithSingleTagAndMatchingFiles_FiltersCorrectly()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        tags.Add("Version", "1.0.0");
+
+        var files = new List<string>
+        {
+            "file1.tags-Version=1.0.0.json.tracking",
+            "file2.tags-Version=1.0.0.json.tracking",
+            "file3.tags-Version=2.0.0.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldContain("file2.tags-Version=1.0.0.json.tracking");
+        result.AfterFilePaths.ShouldContain("file1.tags-Version=1.0.0.json.tracking");
+        result.BeforeFilePaths.Count.ShouldBe(1);
+        result.AfterFilePaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_WithTagsAndOnlyOneMatchingFile_ReturnsEmptyLists()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+        tags.Add("Version", "1.0.0");
+
+        var files = new List<string>
+        {
+            "file1.tags-Version=1.0.0.json.tracking",
+            "file2.tags-Version=2.0.0.json.tracking",
+            "file3.tags-Version=3.0.0.json.tracking"
+        };
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(files);
+
+        // Act
+        var result = trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.BeforeFilePaths.ShouldBeEmpty();
+        result.AfterFilePaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetBeforeAndAfterTrackingFiles_VerifyDirectoryParameterPassedToReader()
+    {
+        // Arrange
+        var directory = Some.RandomString();
+        var beforeTarget = Some.RandomString();
+        var tags = new OrderedDictionary();
+
+        mockTrackingFileDirectoryReader
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory)
+            .Returns(new List<string>());
+
+        // Act
+        trackingFileFinder.GetBeforeAndAfterTrackingFiles(directory, beforeTarget, tags);
+
+        // Assert
+        mockTrackingFileDirectoryReader
+            .Received(1)
+            .FindTrackingFilesInDirectoryOrderedByLastModified(directory);
+    }
+}


### PR DESCRIPTION
## Description
Add more test coverage - to get to 80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for SailDiff analysis components, including tracking file handling, console message formatting, analysis execution, and directory reading.
  * Tests cover scenarios such as empty or malformed data, formatting outputs, dependency interactions, error handling, file ordering, filtering by tags, and correct partitioning of tracking files.
  * Enhanced validation of SailDiff features and improved reliability through extensive test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->