### PR TITLE
Fix the TestAdapter for .net9 - attempt 1

### DIFF
--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <PackageId>Sailfish.TestAdapter</PackageId>
-        <Version>0.0.0</Version>
+        <Version>0.0.1-local</Version>
         <Authors>Paul E. Gradie</Authors>
         <Description>
             Sailfish is a produtiocction friendly performace test suite for owriinting organized performance tests

--- a/source/Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets
+++ b/source/Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets
@@ -40,7 +40,8 @@
                                         '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'System.Collections.Specialized' or
                                         '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'System.Diagnostics.DiagnosticSource'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <TargetPath>%(Filename)%(Extension)</TargetPath>
+        <TargetPath Condition="'%(RuntimeCopyLocalItems.TargetPath)' != ''">%(RuntimeCopyLocalItems.TargetPath)</TargetPath>
+        <TargetPath Condition="'%(RuntimeCopyLocalItems.TargetPath)' == ''">%(Filename)%(Extension)</TargetPath>
       </ContentWithTargetPath>
     </ItemGroup>
   </Target>

--- a/source/Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets
+++ b/source/Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets
@@ -20,4 +20,29 @@
     <TestAdapterPath Include="$(MSBuildThisFileDirectory)../lib/net9.0/" Condition="'$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
+  <!-- Copy all Sailfish runtime dependencies to output directory -->
+  <Target Name="CopySailfishDependencies" AfterTargets="ResolvePackageAssets">
+    <ItemGroup>
+      <!-- Copy all runtime assemblies from packages that Sailfish depends on -->
+      <ContentWithTargetPath Include="@(RuntimeCopyLocalItems)"
+        Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Sailfish' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Autofac' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'MediatR' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'MediatR.Extensions.Autofac.DependencyInjection' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'CsvHelper' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'MathNet.Numerics' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Perfolizer' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'System.Linq.Async' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Microsoft.Extensions.Configuration' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Microsoft.Extensions.Configuration.Json' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Microsoft.Extensions.DependencyInjection.Abstractions' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'System.Runtime.Caching' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'System.Collections.Specialized' or
+                                        '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'System.Diagnostics.DiagnosticSource'">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </ContentWithTargetPath>
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Description

I'm finding the package doesn't function correctly in .net9. Not sure if this is the version of .net or Sailfish. So I'll try a few things and whichever works will stick for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.1-local pre-release.
  * Build updated to introduce a consolidated runtime dependency copy step, ensuring relevant runtime assemblies are copied to the output for improved distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->