### PR TITLE
Add SailfishPreset and WithPreset to RunSettingsBuilder; propagate preset defaults for adaptive sampling and SailDiff

### DIFF
--- a/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
+++ b/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
@@ -79,15 +79,12 @@ public class SailDiffSettings
 
     private void ApplyPreset(SailfishPreset preset)
     {
-        var (alpha, testType) = preset switch
+        Alpha = preset switch
         {
-            SailfishPreset.LocalBaseline => (0.001, TestType.TwoSampleWilcoxonSignedRankTest),
-            SailfishPreset.CILowNoise => (0.0005, TestType.TwoSampleWilcoxonSignedRankTest),
-            SailfishPreset.ProductionNoisy => (0.01, TestType.WilcoxonRankSumTest),
+            SailfishPreset.Default => 0.001,
+            SailfishPreset.Tight => 0.0005,
+            SailfishPreset.Relaxed => 0.01,
             _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Unknown Sailfish preset.")
         };
-
-        Alpha = alpha;
-        TestType = testType;
     }
 }

--- a/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
+++ b/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
@@ -1,4 +1,7 @@
-﻿namespace Sailfish.Analysis.SailDiff;
+﻿using System;
+using Sailfish;
+
+namespace Sailfish.Analysis.SailDiff;
 
 /// <summary>
 ///     Settings to use with the regression tester.
@@ -30,6 +33,11 @@ public class SailDiffSettings
         TestType = testType;
         MaxDegreeOfParallelism = maxDegreeOfParallelism;
         DisableOrdering = disableOrdering;
+    }
+
+    public SailDiffSettings(SailfishPreset preset) : this()
+    {
+        ApplyPreset(preset);
     }
 
     public double Alpha { get; private set; }
@@ -67,5 +75,19 @@ public class SailDiffSettings
     public void SetDisableOrdering(bool disable)
     {
         DisableOrdering = disable;
+    }
+
+    private void ApplyPreset(SailfishPreset preset)
+    {
+        var (alpha, testType) = preset switch
+        {
+            SailfishPreset.LocalBaseline => (0.001, TestType.TwoSampleWilcoxonSignedRankTest),
+            SailfishPreset.CILowNoise => (0.0005, TestType.TwoSampleWilcoxonSignedRankTest),
+            SailfishPreset.ProductionNoisy => (0.01, TestType.WilcoxonRankSumTest),
+            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Unknown Sailfish preset.")
+        };
+
+        Alpha = alpha;
+        TestType = testType;
     }
 }

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -43,6 +43,8 @@ public interface IRunSettings
     // Global adaptive sampling overrides (null = no override)
     bool? GlobalUseAdaptiveSampling { get; }
     double? GlobalTargetCoefficientOfVariation { get; }
+    double? GlobalMaxConfidenceIntervalWidth { get; }
+    int? GlobalMinimumSampleSize { get; }
     int? GlobalMaximumSampleSize { get; }
 
         // Global outlier handling overrides (null = no override)

--- a/source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs
+++ b/source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs
@@ -42,6 +42,8 @@ internal class ClassExecutionSummaryCompiler : IClassExecutionSummaryCompiler
             _runSettings.NumWarmupIterationsOverride,
             _runSettings.GlobalUseAdaptiveSampling,
             _runSettings.GlobalTargetCoefficientOfVariation,
+            _runSettings.GlobalMaxConfidenceIntervalWidth,
+            _runSettings.GlobalMinimumSampleSize,
             _runSettings.GlobalMaximumSampleSize);
         return new ClassExecutionSummary(
             testClassResultGroup.TestClass,

--- a/source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs
+++ b/source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs
@@ -42,9 +42,9 @@ internal class ClassExecutionSummaryCompiler : IClassExecutionSummaryCompiler
             _runSettings.NumWarmupIterationsOverride,
             _runSettings.GlobalUseAdaptiveSampling,
             _runSettings.GlobalTargetCoefficientOfVariation,
+            _runSettings.GlobalMaximumSampleSize,
             _runSettings.GlobalMaxConfidenceIntervalWidth,
-            _runSettings.GlobalMinimumSampleSize,
-            _runSettings.GlobalMaximumSampleSize);
+            _runSettings.GlobalMinimumSampleSize);
         return new ClassExecutionSummary(
             testClassResultGroup.TestClass,
             executionSettings,

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -57,6 +57,8 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
                 _runSettings.NumWarmupIterationsOverride,
                 _runSettings.GlobalUseAdaptiveSampling,
                 _runSettings.GlobalTargetCoefficientOfVariation,
+                _runSettings.GlobalMaxConfidenceIntervalWidth,
+                _runSettings.GlobalMinimumSampleSize,
                 _runSettings.GlobalMaximumSampleSize,
                 _runSettings.GlobalUseConfigurableOutlierDetection,
                 _runSettings.GlobalOutlierStrategy);
@@ -80,6 +82,8 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
                     _runSettings.NumWarmupIterationsOverride,
                     _runSettings.GlobalUseAdaptiveSampling,
                     _runSettings.GlobalTargetCoefficientOfVariation,
+                    _runSettings.GlobalMaxConfidenceIntervalWidth,
+                    _runSettings.GlobalMinimumSampleSize,
                     _runSettings.GlobalMaximumSampleSize,
                     _runSettings.GlobalUseConfigurableOutlierDetection,
                     _runSettings.GlobalOutlierStrategy);

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -57,11 +57,11 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
                 _runSettings.NumWarmupIterationsOverride,
                 _runSettings.GlobalUseAdaptiveSampling,
                 _runSettings.GlobalTargetCoefficientOfVariation,
-                _runSettings.GlobalMaxConfidenceIntervalWidth,
-                _runSettings.GlobalMinimumSampleSize,
                 _runSettings.GlobalMaximumSampleSize,
                 _runSettings.GlobalUseConfigurableOutlierDetection,
-                _runSettings.GlobalOutlierStrategy);
+                _runSettings.GlobalOutlierStrategy,
+                _runSettings.GlobalMaxConfidenceIntervalWidth,
+                _runSettings.GlobalMinimumSampleSize);
             var seed = TryParseSeed(_runSettings.Args);
             if (seed.HasValue) executionSettings.Seed = seed;
             yield return TestInstanceContainer.CreateTestInstance(instance, Method, [], [], disabled, executionSettings);
@@ -82,11 +82,11 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
                     _runSettings.NumWarmupIterationsOverride,
                     _runSettings.GlobalUseAdaptiveSampling,
                     _runSettings.GlobalTargetCoefficientOfVariation,
-                    _runSettings.GlobalMaxConfidenceIntervalWidth,
-                    _runSettings.GlobalMinimumSampleSize,
                     _runSettings.GlobalMaximumSampleSize,
                     _runSettings.GlobalUseConfigurableOutlierDetection,
-                    _runSettings.GlobalOutlierStrategy);
+                    _runSettings.GlobalOutlierStrategy,
+                    _runSettings.GlobalMaxConfidenceIntervalWidth,
+                    _runSettings.GlobalMinimumSampleSize);
                 var seed = TryParseSeed(_runSettings.Args);
                 if (seed.HasValue) executionSettings.Seed = seed;
                 yield return TestInstanceContainer.CreateTestInstance(instance, Method, propertyNames, variableValues, disabled, executionSettings);

--- a/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
@@ -56,6 +56,8 @@ internal static class ExecutionExtensionMethods
         int? globalNumWarmupIterations,
         bool? globalUseAdaptiveSampling,
         double? globalTargetCoefficientOfVariation,
+        double? globalMaxConfidenceIntervalWidth,
+        int? globalMinimumSampleSize,
         int? globalMaximumSampleSize)
     {
         var settings = type.RetrieveExecutionTestSettings(globalSampleSize, globalNumWarmupIterations);
@@ -67,6 +69,16 @@ internal static class ExecutionExtensionMethods
         if (globalTargetCoefficientOfVariation.HasValue)
         {
             settings.TargetCoefficientOfVariation = globalTargetCoefficientOfVariation.Value;
+        }
+
+        if (globalMaxConfidenceIntervalWidth.HasValue)
+        {
+            settings.MaxConfidenceIntervalWidth = globalMaxConfidenceIntervalWidth.Value;
+        }
+
+        if (globalMinimumSampleSize.HasValue)
+        {
+            settings.MinimumSampleSize = globalMinimumSampleSize.Value;
         }
 
         if (globalMaximumSampleSize.HasValue)
@@ -85,6 +97,8 @@ internal static class ExecutionExtensionMethods
             int? globalNumWarmupIterations,
             bool? globalUseAdaptiveSampling,
             double? globalTargetCoefficientOfVariation,
+            double? globalMaxConfidenceIntervalWidth,
+            int? globalMinimumSampleSize,
             int? globalMaximumSampleSize,
             bool? globalUseConfigurableOutlierDetection,
             OutlierStrategy? globalOutlierStrategy)
@@ -94,6 +108,8 @@ internal static class ExecutionExtensionMethods
                 globalNumWarmupIterations,
                 globalUseAdaptiveSampling,
                 globalTargetCoefficientOfVariation,
+                globalMaxConfidenceIntervalWidth,
+                globalMinimumSampleSize,
                 globalMaximumSampleSize);
 
             if (globalUseConfigurableOutlierDetection.HasValue)

--- a/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
@@ -56,9 +56,9 @@ internal static class ExecutionExtensionMethods
         int? globalNumWarmupIterations,
         bool? globalUseAdaptiveSampling,
         double? globalTargetCoefficientOfVariation,
-        double? globalMaxConfidenceIntervalWidth,
-        int? globalMinimumSampleSize,
-        int? globalMaximumSampleSize)
+        int? globalMaximumSampleSize,
+        double? globalMaxConfidenceIntervalWidth = null,
+        int? globalMinimumSampleSize = null)
     {
         var settings = type.RetrieveExecutionTestSettings(globalSampleSize, globalNumWarmupIterations);
         if (globalUseAdaptiveSampling.HasValue)
@@ -97,20 +97,20 @@ internal static class ExecutionExtensionMethods
             int? globalNumWarmupIterations,
             bool? globalUseAdaptiveSampling,
             double? globalTargetCoefficientOfVariation,
-            double? globalMaxConfidenceIntervalWidth,
-            int? globalMinimumSampleSize,
             int? globalMaximumSampleSize,
             bool? globalUseConfigurableOutlierDetection,
-            OutlierStrategy? globalOutlierStrategy)
+            OutlierStrategy? globalOutlierStrategy,
+            double? globalMaxConfidenceIntervalWidth = null,
+            int? globalMinimumSampleSize = null)
         {
             var settings = type.RetrieveExecutionTestSettings(
                 globalSampleSize,
                 globalNumWarmupIterations,
                 globalUseAdaptiveSampling,
                 globalTargetCoefficientOfVariation,
+                globalMaximumSampleSize,
                 globalMaxConfidenceIntervalWidth,
-                globalMinimumSampleSize,
-                globalMaximumSampleSize);
+                globalMinimumSampleSize);
 
             if (globalUseConfigurableOutlierDetection.HasValue)
             {

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -36,6 +36,8 @@ internal class RunSettings : IRunSettings
         bool debug = false,
         bool? globalUseAdaptiveSampling = null,
         double? globalTargetCoefficientOfVariation = null,
+        double? globalMaxConfidenceIntervalWidth = null,
+        int? globalMinimumSampleSize = null,
         int? globalMaximumSampleSize = null,
         bool? globalUseConfigurableOutlierDetection = null,
         OutlierStrategy? globalOutlierStrategy = null,
@@ -64,6 +66,8 @@ internal class RunSettings : IRunSettings
         StreamTrackingUpdates = streamTrackingUpdates;
         GlobalUseAdaptiveSampling = globalUseAdaptiveSampling;
         GlobalTargetCoefficientOfVariation = globalTargetCoefficientOfVariation;
+        GlobalMaxConfidenceIntervalWidth = globalMaxConfidenceIntervalWidth;
+        GlobalMinimumSampleSize = globalMinimumSampleSize;
         GlobalMaximumSampleSize = globalMaximumSampleSize;
         GlobalUseConfigurableOutlierDetection = globalUseConfigurableOutlierDetection;
         GlobalOutlierStrategy = globalOutlierStrategy;
@@ -95,6 +99,8 @@ internal class RunSettings : IRunSettings
     public bool StreamTrackingUpdates { get; }
     public bool? GlobalUseAdaptiveSampling { get; }
     public double? GlobalTargetCoefficientOfVariation { get; }
+    public double? GlobalMaxConfidenceIntervalWidth { get; }
+    public int? GlobalMinimumSampleSize { get; }
     public int? GlobalMaximumSampleSize { get; }
     public bool? GlobalUseConfigurableOutlierDetection { get; }
     public OutlierStrategy? GlobalOutlierStrategy { get; }

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -10,6 +10,13 @@ using Sailfish.Presentation;
 
 namespace Sailfish;
 
+public enum SailfishPreset
+{
+    LocalBaseline,
+    CILowNoise,
+    ProductionNoisy
+}
+
 public class RunSettingsBuilder
 {
     private readonly OrderedDictionary _args = new();
@@ -48,6 +55,8 @@ public class RunSettingsBuilder
     private OutlierStrategy? _globalOutlierStrategy;
 
     private double? _globalTargetCoefficientOfVariation;
+    private double? _globalMaxConfidenceIntervalWidth;
+    private int? _globalMinimumSampleSize;
     private int? _globalMaximumSampleSize;
 
     public static RunSettingsBuilder CreateBuilder()
@@ -271,6 +280,15 @@ public class RunSettingsBuilder
         return this;
     }
 
+    /// <summary>
+    ///     Applies a preset for adaptive sampling and outlier handling defaults.
+    /// </summary>
+    public RunSettingsBuilder WithPreset(SailfishPreset preset)
+    {
+        ApplyPreset(preset);
+        return this;
+    }
+
         /// <summary>
         ///     Configures global outlier handling for the current run. When set, these values override per-class defaults.
         /// </summary>
@@ -315,6 +333,8 @@ public class RunSettingsBuilder
             _setDebug,
             _globalUseAdaptiveSampling,
             _globalTargetCoefficientOfVariation,
+            _globalMaxConfidenceIntervalWidth,
+            _globalMinimumSampleSize,
             _globalMaximumSampleSize,
             _globalUseConfigurableOutlierDetection,
             _globalOutlierStrategy,
@@ -322,4 +342,51 @@ public class RunSettingsBuilder
             _timerCalibration,
             seed: _seed);
     }
+
+    private void ApplyPreset(SailfishPreset preset)
+    {
+        var settings = GetPresetExecutionDefaults(preset);
+        _globalUseAdaptiveSampling = true;
+        _globalTargetCoefficientOfVariation = settings.TargetCoefficientOfVariation;
+        _globalMaxConfidenceIntervalWidth = settings.MaxConfidenceIntervalWidth;
+        _globalMinimumSampleSize = settings.MinimumSampleSize;
+        _globalMaximumSampleSize = settings.MaximumSampleSize;
+        _globalUseConfigurableOutlierDetection = true;
+        _globalOutlierStrategy = settings.OutlierStrategy;
+
+        _sdSettings ??= new SailDiffSettings(preset);
+    }
+
+    private static PresetExecutionDefaults GetPresetExecutionDefaults(SailfishPreset preset)
+    {
+        return preset switch
+        {
+            SailfishPreset.LocalBaseline => new PresetExecutionDefaults(
+                targetCoefficientOfVariation: 0.05,
+                maxConfidenceIntervalWidth: 0.20,
+                minimumSampleSize: 10,
+                maximumSampleSize: 1000,
+                outlierStrategy: OutlierStrategy.RemoveUpper),
+            SailfishPreset.CILowNoise => new PresetExecutionDefaults(
+                targetCoefficientOfVariation: 0.02,
+                maxConfidenceIntervalWidth: 0.10,
+                minimumSampleSize: 30,
+                maximumSampleSize: 2000,
+                outlierStrategy: OutlierStrategy.RemoveAll),
+            SailfishPreset.ProductionNoisy => new PresetExecutionDefaults(
+                targetCoefficientOfVariation: 0.10,
+                maxConfidenceIntervalWidth: 0.30,
+                minimumSampleSize: 10,
+                maximumSampleSize: 5000,
+                outlierStrategy: OutlierStrategy.Adaptive),
+            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Unknown Sailfish preset.")
+        };
+    }
+
+    private sealed record PresetExecutionDefaults(
+        double TargetCoefficientOfVariation,
+        double MaxConfidenceIntervalWidth,
+        int MinimumSampleSize,
+        int MaximumSampleSize,
+        OutlierStrategy OutlierStrategy);
 }

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -10,13 +10,6 @@ using Sailfish.Presentation;
 
 namespace Sailfish;
 
-public enum SailfishPreset
-{
-    LocalBaseline,
-    CILowNoise,
-    ProductionNoisy
-}
-
 public class RunSettingsBuilder
 {
     private readonly OrderedDictionary _args = new();
@@ -281,7 +274,10 @@ public class RunSettingsBuilder
     }
 
     /// <summary>
-    ///     Applies a preset for adaptive sampling and outlier handling defaults.
+    ///     Seeds adaptive-sampling, outlier-handling, and SailDiff defaults from a named preset.
+    ///     Composition is order-insensitive: any explicit <c>WithGlobalX</c> or <see cref="WithSailDiff(SailDiffSettings)"/>
+    ///     call wins over the preset, regardless of whether it is invoked before or after <c>WithPreset</c>.
+    ///     <c>WithPreset</c> does not enable SailDiff by itself — call <see cref="WithSailDiff()"/> separately.
     /// </summary>
     public RunSettingsBuilder WithPreset(SailfishPreset preset)
     {
@@ -346,13 +342,13 @@ public class RunSettingsBuilder
     private void ApplyPreset(SailfishPreset preset)
     {
         var settings = GetPresetExecutionDefaults(preset);
-        _globalUseAdaptiveSampling = true;
-        _globalTargetCoefficientOfVariation = settings.TargetCoefficientOfVariation;
-        _globalMaxConfidenceIntervalWidth = settings.MaxConfidenceIntervalWidth;
-        _globalMinimumSampleSize = settings.MinimumSampleSize;
-        _globalMaximumSampleSize = settings.MaximumSampleSize;
-        _globalUseConfigurableOutlierDetection = true;
-        _globalOutlierStrategy = settings.OutlierStrategy;
+        _globalUseAdaptiveSampling ??= true;
+        _globalTargetCoefficientOfVariation ??= settings.TargetCoefficientOfVariation;
+        _globalMaxConfidenceIntervalWidth ??= settings.MaxConfidenceIntervalWidth;
+        _globalMinimumSampleSize ??= settings.MinimumSampleSize;
+        _globalMaximumSampleSize ??= settings.MaximumSampleSize;
+        _globalUseConfigurableOutlierDetection ??= true;
+        _globalOutlierStrategy ??= settings.OutlierStrategy;
 
         _sdSettings ??= new SailDiffSettings(preset);
     }
@@ -361,24 +357,24 @@ public class RunSettingsBuilder
     {
         return preset switch
         {
-            SailfishPreset.LocalBaseline => new PresetExecutionDefaults(
-                targetCoefficientOfVariation: 0.05,
-                maxConfidenceIntervalWidth: 0.20,
-                minimumSampleSize: 10,
-                maximumSampleSize: 1000,
-                outlierStrategy: OutlierStrategy.RemoveUpper),
-            SailfishPreset.CILowNoise => new PresetExecutionDefaults(
-                targetCoefficientOfVariation: 0.02,
-                maxConfidenceIntervalWidth: 0.10,
-                minimumSampleSize: 30,
-                maximumSampleSize: 2000,
-                outlierStrategy: OutlierStrategy.RemoveAll),
-            SailfishPreset.ProductionNoisy => new PresetExecutionDefaults(
-                targetCoefficientOfVariation: 0.10,
-                maxConfidenceIntervalWidth: 0.30,
-                minimumSampleSize: 10,
-                maximumSampleSize: 5000,
-                outlierStrategy: OutlierStrategy.Adaptive),
+            SailfishPreset.Default => new PresetExecutionDefaults(
+                TargetCoefficientOfVariation: 0.05,
+                MaxConfidenceIntervalWidth: 0.20,
+                MinimumSampleSize: 10,
+                MaximumSampleSize: 1000,
+                OutlierStrategy: OutlierStrategy.RemoveUpper),
+            SailfishPreset.Tight => new PresetExecutionDefaults(
+                TargetCoefficientOfVariation: 0.03,
+                MaxConfidenceIntervalWidth: 0.12,
+                MinimumSampleSize: 50,
+                MaximumSampleSize: 2000,
+                OutlierStrategy: OutlierStrategy.RemoveUpper),
+            SailfishPreset.Relaxed => new PresetExecutionDefaults(
+                TargetCoefficientOfVariation: 0.10,
+                MaxConfidenceIntervalWidth: 0.30,
+                MinimumSampleSize: 10,
+                MaximumSampleSize: 1000,
+                OutlierStrategy: OutlierStrategy.Adaptive),
             _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Unknown Sailfish preset.")
         };
     }

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -52,6 +52,10 @@ public class RunSettingsBuilder
     private int? _globalMinimumSampleSize;
     private int? _globalMaximumSampleSize;
 
+    // Selected preset. Applied at Build() so that any explicit WithX call
+    // wins and a later WithPreset call replaces an earlier one.
+    private SailfishPreset? _preset;
+
     public static RunSettingsBuilder CreateBuilder()
     {
         return new RunSettingsBuilder();
@@ -275,13 +279,16 @@ public class RunSettingsBuilder
 
     /// <summary>
     ///     Seeds adaptive-sampling, outlier-handling, and SailDiff defaults from a named preset.
-    ///     Composition is order-insensitive: any explicit <c>WithGlobalX</c> or <see cref="WithSailDiff(SailDiffSettings)"/>
-    ///     call wins over the preset, regardless of whether it is invoked before or after <c>WithPreset</c>.
+    ///     The preset is applied at <see cref="Build"/>, so:
+    ///     <list type="bullet">
+    ///         <item>Any explicit <c>WithGlobalX</c> or <see cref="WithSailDiff(SailDiffSettings)"/> call wins over the preset, regardless of call order.</item>
+    ///         <item>If <c>WithPreset</c> is called more than once, the last call wins (no silent divergence between execution and SailDiff settings).</item>
+    ///     </list>
     ///     <c>WithPreset</c> does not enable SailDiff by itself — call <see cref="WithSailDiff()"/> separately.
     /// </summary>
     public RunSettingsBuilder WithPreset(SailfishPreset preset)
     {
-        ApplyPreset(preset);
+        _preset = preset;
         return this;
     }
 
@@ -305,6 +312,7 @@ public class RunSettingsBuilder
 
     public IRunSettings Build()
     {
+        if (_preset.HasValue) ApplyPreset(_preset.Value);
         return new RunSettings(
             _names,
             _localOutputDir ?? DefaultFileSettings.DefaultOutputDirectory,

--- a/source/Sailfish/SailfishPreset.cs
+++ b/source/Sailfish/SailfishPreset.cs
@@ -1,0 +1,27 @@
+namespace Sailfish;
+
+/// <summary>
+/// Pre-tuned measurement policies applied via <see cref="RunSettingsBuilder.WithPreset"/>.
+/// Presets seed adaptive sampling, outlier handling, and SailDiff defaults; any subsequent
+/// explicit <c>WithX</c> call on the builder overrides the preset value for that field.
+/// </summary>
+public enum SailfishPreset
+{
+    /// <summary>
+    /// Sensible defaults for local development and most CI runs. Matches Sailfish's built-in attribute defaults.
+    /// CV 0.05, CI 0.20, MinN 10, MaxN 1000, OutlierStrategy.RemoveUpper, SailDiff alpha 0.001.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Tighter convergence for release gates and baseline verification where small regressions matter.
+    /// CV 0.03, CI 0.12, MinN 50, MaxN 2000, OutlierStrategy.RemoveUpper, SailDiff alpha 0.0005.
+    /// </summary>
+    Tight,
+
+    /// <summary>
+    /// Looser convergence for shared or noisy CI hosts where predictable completion time matters more than micro-changes.
+    /// CV 0.10, CI 0.30, MinN 10, MaxN 1000, OutlierStrategy.Adaptive, SailDiff alpha 0.01.
+    /// </summary>
+    Relaxed
+}

--- a/source/Tests.Library/RunSettingsBuilder_PresetTests.cs
+++ b/source/Tests.Library/RunSettingsBuilder_PresetTests.cs
@@ -138,6 +138,24 @@ public class RunSettingsBuilderPresetTests
     }
 
     [Fact]
+    public void WithPreset_CalledTwice_LastCallWins()
+    {
+        // Regression for codex review #r2787896254: previously the first preset stuck
+        // because ApplyPreset eagerly used ??=. Now preset is applied at Build() so
+        // a later WithPreset call cleanly replaces an earlier one for BOTH execution
+        // settings and SailDiff settings — no silent divergence.
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithPreset(SailfishPreset.Default)
+            .WithPreset(SailfishPreset.Relaxed)
+            .Build();
+
+        settings.GlobalTargetCoefficientOfVariation.ShouldBe(0.10);
+        settings.GlobalMaxConfidenceIntervalWidth.ShouldBe(0.30);
+        settings.GlobalOutlierStrategy.ShouldBe(OutlierStrategy.Adaptive);
+        settings.SailDiffSettings.Alpha.ShouldBe(0.01);
+    }
+
+    [Fact]
     public void SailDiffSettings_PresetConstructor_Default_SetsAlpha()
     {
         var s = new SailDiffSettings(SailfishPreset.Default);

--- a/source/Tests.Library/RunSettingsBuilder_PresetTests.cs
+++ b/source/Tests.Library/RunSettingsBuilder_PresetTests.cs
@@ -1,0 +1,163 @@
+using Sailfish;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library;
+
+public class RunSettingsBuilderPresetTests
+{
+    [Fact]
+    public void WithPreset_ReturnsSameBuilder()
+    {
+        var builder = RunSettingsBuilder.CreateBuilder();
+
+        var result = builder.WithPreset(SailfishPreset.Default);
+
+        result.ShouldBeSameAs(builder);
+    }
+
+    [Fact]
+    public void WithPreset_Default_PopulatesAllGlobalSettings()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithPreset(SailfishPreset.Default)
+            .Build();
+
+        settings.GlobalUseAdaptiveSampling.ShouldBe(true);
+        settings.GlobalTargetCoefficientOfVariation.ShouldBe(0.05);
+        settings.GlobalMaxConfidenceIntervalWidth.ShouldBe(0.20);
+        settings.GlobalMinimumSampleSize.ShouldBe(10);
+        settings.GlobalMaximumSampleSize.ShouldBe(1000);
+        settings.GlobalUseConfigurableOutlierDetection.ShouldBe(true);
+        settings.GlobalOutlierStrategy.ShouldBe(OutlierStrategy.RemoveUpper);
+        settings.SailDiffSettings.Alpha.ShouldBe(0.001);
+        settings.SailDiffSettings.TestType.ShouldBe(TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    [Fact]
+    public void WithPreset_Tight_PopulatesAllGlobalSettings()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithPreset(SailfishPreset.Tight)
+            .Build();
+
+        settings.GlobalUseAdaptiveSampling.ShouldBe(true);
+        settings.GlobalTargetCoefficientOfVariation.ShouldBe(0.03);
+        settings.GlobalMaxConfidenceIntervalWidth.ShouldBe(0.12);
+        settings.GlobalMinimumSampleSize.ShouldBe(50);
+        settings.GlobalMaximumSampleSize.ShouldBe(2000);
+        settings.GlobalUseConfigurableOutlierDetection.ShouldBe(true);
+        settings.GlobalOutlierStrategy.ShouldBe(OutlierStrategy.RemoveUpper);
+        settings.SailDiffSettings.Alpha.ShouldBe(0.0005);
+        settings.SailDiffSettings.TestType.ShouldBe(TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    [Fact]
+    public void WithPreset_Relaxed_PopulatesAllGlobalSettings()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithPreset(SailfishPreset.Relaxed)
+            .Build();
+
+        settings.GlobalUseAdaptiveSampling.ShouldBe(true);
+        settings.GlobalTargetCoefficientOfVariation.ShouldBe(0.10);
+        settings.GlobalMaxConfidenceIntervalWidth.ShouldBe(0.30);
+        settings.GlobalMinimumSampleSize.ShouldBe(10);
+        settings.GlobalMaximumSampleSize.ShouldBe(1000);
+        settings.GlobalUseConfigurableOutlierDetection.ShouldBe(true);
+        settings.GlobalOutlierStrategy.ShouldBe(OutlierStrategy.Adaptive);
+        settings.SailDiffSettings.Alpha.ShouldBe(0.01);
+        settings.SailDiffSettings.TestType.ShouldBe(TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    [Fact]
+    public void WithPreset_DoesNotEnableSailDiff()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithPreset(SailfishPreset.Default)
+            .Build();
+
+        settings.RunSailDiff.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WithPreset_Then_WithGlobalAdaptiveSampling_ExplicitCallWins()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithPreset(SailfishPreset.Tight)
+            .WithGlobalAdaptiveSampling(targetCoefficientOfVariation: 0.07, maximumSampleSize: 500)
+            .Build();
+
+        settings.GlobalTargetCoefficientOfVariation.ShouldBe(0.07);
+        settings.GlobalMaximumSampleSize.ShouldBe(500);
+        // Fields not touched by WithGlobalAdaptiveSampling keep preset values.
+        settings.GlobalMaxConfidenceIntervalWidth.ShouldBe(0.12);
+        settings.GlobalMinimumSampleSize.ShouldBe(50);
+    }
+
+    [Fact]
+    public void WithGlobalAdaptiveSampling_Then_WithPreset_ExplicitCallWins()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithGlobalAdaptiveSampling(targetCoefficientOfVariation: 0.07, maximumSampleSize: 500)
+            .WithPreset(SailfishPreset.Tight)
+            .Build();
+
+        settings.GlobalTargetCoefficientOfVariation.ShouldBe(0.07);
+        settings.GlobalMaximumSampleSize.ShouldBe(500);
+        // Fields not touched by WithGlobalAdaptiveSampling pick up preset values.
+        settings.GlobalMaxConfidenceIntervalWidth.ShouldBe(0.12);
+        settings.GlobalMinimumSampleSize.ShouldBe(50);
+    }
+
+    [Fact]
+    public void WithGlobalOutlierHandling_Before_WithPreset_ExplicitCallWins()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithGlobalOutlierHandling(useConfigurable: true, OutlierStrategy.DontRemove)
+            .WithPreset(SailfishPreset.Default)
+            .Build();
+
+        settings.GlobalOutlierStrategy.ShouldBe(OutlierStrategy.DontRemove);
+    }
+
+    [Fact]
+    public void WithSailDiff_Before_WithPreset_CustomSailDiffSurvives()
+    {
+        var custom = new SailDiffSettings(alpha: 0.05, round: 7);
+
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithSailDiff(custom)
+            .WithPreset(SailfishPreset.Default)
+            .Build();
+
+        settings.SailDiffSettings.ShouldBeSameAs(custom);
+        settings.SailDiffSettings.Alpha.ShouldBe(0.05);
+    }
+
+    [Fact]
+    public void SailDiffSettings_PresetConstructor_Default_SetsAlpha()
+    {
+        var s = new SailDiffSettings(SailfishPreset.Default);
+        s.Alpha.ShouldBe(0.001);
+        s.TestType.ShouldBe(TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    [Fact]
+    public void SailDiffSettings_PresetConstructor_Tight_SetsAlpha()
+    {
+        var s = new SailDiffSettings(SailfishPreset.Tight);
+        s.Alpha.ShouldBe(0.0005);
+        s.TestType.ShouldBe(TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+
+    [Fact]
+    public void SailDiffSettings_PresetConstructor_Relaxed_SetsAlpha()
+    {
+        var s = new SailDiffSettings(SailfishPreset.Relaxed);
+        s.Alpha.ShouldBe(0.01);
+        s.TestType.ShouldBe(TestType.TwoSampleWilcoxonSignedRankTest);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide easy, opinionated presets to configure adaptive-sampling and outlier-handling defaults across a run.
- Allow SailDiff settings (alpha/test type) to be derived from the same preset so regression testing behavior matches sampling choices.

### Description
- Added the `SailfishPreset` enum with `LocalBaseline`, `CILowNoise`, and `ProductionNoisy` and implemented `RunSettingsBuilder.WithPreset(SailfishPreset)` which applies preset defaults via a private `ApplyPreset` helper and `PresetExecutionDefaults` record.
- Wired preset values into global overrides by adding `GlobalMaxConfidenceIntervalWidth` and `GlobalMinimumSampleSize` to `IRunSettings` and `RunSettings`, and included those fields in the `RunSettingsBuilder.Build()` call.
- Propagated the new global overrides through execution settings resolution by updating `ExecutionExtensionMethods.RetrieveExecutionTestSettings`, `TestInstanceContainerProvider`, and `ClassExecutionSummaryCompiler` so `ExecutionSettings` respects preset/override values (target CV, CI width, min/max sample sizes, and outlier strategy).
- Extended `SailDiffSettings` with a constructor `SailDiffSettings(SailfishPreset)` and an `ApplyPreset` implementation to derive `Alpha` and `TestType` from the chosen preset; existing constructors remain so default behavior is unchanged when no preset is specified.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d1cc8908832cb89412ac0709a0ae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preset configurations to quickly apply common testing scenarios (LocalBaseline, CILowNoise, ProductionNoisy).
  * Added two new global settings options: maximum confidence interval width and minimum sample size, enabling more granular control over statistical analysis parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->