### PR TITLE
Add net10.0 to multi-targeting

### DIFF
--- a/.github/workflows/build-v3.0.yml
+++ b/.github/workflows/build-v3.0.yml
@@ -94,6 +94,7 @@ jobs:
           dotnet-version: |
             8.x.x
             9.x.x
+            10.x.x
 
       - name: Build Projects
         run: |
@@ -127,6 +128,7 @@ jobs:
           dotnet-version: |
             8.x.x
             9.x.x
+            10.x.x
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -159,6 +161,7 @@ jobs:
           dotnet-version: |
             8.x.x
             9.x.x
+            10.x.x
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/source/ConsoleAppDemo/ConsoleAppDemo.csproj
+++ b/source/ConsoleAppDemo/ConsoleAppDemo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/source/Demo.API/Demo.API.csproj
+++ b/source/Demo.API/Demo.API.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <RootNamespace>Demo.API</RootNamespace>
         <LangVersion>latest</LangVersion>

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
@@ -8,6 +8,7 @@
         <!-- Use version compatible with each target framework -->
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" Condition="'$(TargetFramework)' == 'net9.0'" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" Condition="'$(TargetFramework)' == 'net10.0'" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Octopus.Client" Version="15.2.2178" />
         <PackageReference Include="Serilog" Version="4.3.0"/>
@@ -28,6 +29,13 @@
     <Target Name="CopyTestAdapterNet9" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net9.0'">
         <ItemGroup>
             <TestAdapterFiles Include="$(MSBuildProjectDirectory)\..\Sailfish.TestAdapter\bin\$(Configuration)\net9.0\Sailfish.TestAdapter.dll" />
+        </ItemGroup>
+        <Copy SourceFiles="@(TestAdapterFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="false" />
+    </Target>
+
+    <Target Name="CopyTestAdapterNet10" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net10.0'">
+        <ItemGroup>
+            <TestAdapterFiles Include="$(MSBuildProjectDirectory)\..\Sailfish.TestAdapter\bin\$(Configuration)\net10.0\Sailfish.TestAdapter.dll" />
         </ItemGroup>
         <Copy SourceFiles="@(TestAdapterFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="false" />
     </Target>

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -9,7 +9,7 @@
             against your component or API - without with all the extra ceremony. Threerehere are a number of fateature
         </Description>
         <RootNamespace>Sailfish.TestAdapter</RootNamespace>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>

--- a/source/Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets
+++ b/source/Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets
@@ -12,12 +12,17 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)../lib/net10.0/Sailfish.TestAdapter.dll" Condition="'$(TargetFramework)' == 'net10.0' and Exists('$(MSBuildThisFileDirectory)../lib/net10.0/Sailfish.TestAdapter.dll')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
 
   <!-- Ensure the test adapter is available for test discovery -->
   <ItemGroup>
     <TestAdapterPath Include="$(MSBuildThisFileDirectory)../lib/net8.0/" Condition="'$(TargetFramework)' == 'net8.0'" />
     <TestAdapterPath Include="$(MSBuildThisFileDirectory)../lib/net9.0/" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <TestAdapterPath Include="$(MSBuildThisFileDirectory)../lib/net10.0/" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <!-- Copy ALL runtime dependencies to output directory -->

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -8,7 +8,7 @@
             against your component or API. The general intention is to provide a simple tool that teams can use to write straight forward
             tests that assess the speed of your code, without weighing you down with all the extra ceremony.
         </Description>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>

--- a/source/ScaleFishDemo/ScaleFishDemo.csproj
+++ b/source/ScaleFishDemo/ScaleFishDemo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/source/Tests.Analyzers/Tests.Analyzers.csproj
+++ b/source/Tests.Analyzers/Tests.Analyzers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/source/Tests.Common/Tests.Common.csproj
+++ b/source/Tests.Common/Tests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/source/Tests.E2E.ExceptionHandling/Tests.E2E.ExceptionHandling.csproj
+++ b/source/Tests.E2E.ExceptionHandling/Tests.E2E.ExceptionHandling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -11,6 +11,7 @@
         <!-- Use version compatible with each target framework -->
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" Condition="'$(TargetFramework)' == 'net9.0'" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" Condition="'$(TargetFramework)' == 'net10.0'" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
     </ItemGroup>
     <ItemGroup>

--- a/source/Tests.E2E.TestSuite/Tests.E2E.TestSuite.csproj
+++ b/source/Tests.E2E.TestSuite/Tests.E2E.TestSuite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -11,6 +11,7 @@
         <!-- Use version compatible with each target framework -->
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" Condition="'$(TargetFramework)' == 'net9.0'" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" Condition="'$(TargetFramework)' == 'net10.0'" />
         <PackageReference Include="Sailfish.Analyzers" Version="2.0.360" />
         <PackageReference Include="Shouldly" Version="4.2.1"/>
     </ItemGroup>

--- a/source/Tests.Library/Tests.Library.csproj
+++ b/source/Tests.Library/Tests.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
@@ -14,6 +14,7 @@
         <!-- Use version compatible with each target framework -->
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" Condition="'$(TargetFramework)' == 'net9.0'" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" Condition="'$(TargetFramework)' == 'net10.0'" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/source/Tests.TestAdapter/Tests.TestAdapter.csproj
+++ b/source/Tests.TestAdapter/Tests.TestAdapter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>

--- a/source/Tests.TestAdapter/Utils/DllFinder.cs
+++ b/source/Tests.TestAdapter/Utils/DllFinder.cs
@@ -29,13 +29,13 @@ public static class DllFinder
             Substitute.For<IMessageLogger>(),
             path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"));
 
-        // Try to match current TFM from base directory first (e.g., net9.0, net8.0; Release or Debug)
+        // Try to match current TFM from base directory first (e.g., net10.0, net9.0, net8.0; Release or Debug)
         var baseDir = (AppContext.BaseDirectory ?? string.Empty).TrimEnd(Path.DirectorySeparatorChar);
         var preferred = allDlls.FirstOrDefault(p => baseDir.Length > 0 && p.StartsWith(baseDir));
         if (preferred is not null) return preferred;
 
         // Otherwise, attempt common TFMs in priority order under Release then Debug
-        var tfms = new[] { "net9.0", "net8.0" };
+        var tfms = new[] { "net10.0", "net9.0", "net8.0" };
         foreach (var tfm in tfms)
         {
             var rel = allDlls.FirstOrDefault(x => x.Contains(Path.Join("bin", "Release", tfm)));


### PR DESCRIPTION
## Description

Adds `net10.0` alongside `net8.0` and `net9.0` across the repo so consumers on .NET 10 can take a Sailfish/Sailfish.TestAdapter dependency without falling back to older TFMs.

Both .NET 8 (LTS through Nov 2026) and .NET 9 (STS) are retained so existing consumers are unaffected.

Fixes: https://github.com/paulegradie/Sailfish/issues/215

## Results

**Project changes**
- Bump `<TargetFrameworks>` to `net8.0;net9.0;net10.0` across 12 csproj files (analyzer stays on `netstandard2.0`)
- Add `Microsoft.AspNetCore.Mvc.Testing 10.0.7` conditional `PackageReference` rows in 4 test projects
- Add `net10.0` `<Content>` and `<TestAdapterPath>` entries to `Sailfish.TestAdapter/build/Sailfish.TestAdapter.targets` — the shipped NuGet asset that controls test discovery in downstream projects
- Add `CopyTestAdapterNet10` build target sibling in `PerformanceTests.csproj`
- Add `net10.0` to the TFM-priority array in `Tests.TestAdapter/Utils/DllFinder.cs`

**CI**
- Add `10.x.x` to all three `setup-dotnet` blocks in `.github/workflows/build-v3.0.yml`

**Local verification (net10.0)**
- `Tests.Library`: 1155 / 1155 passed
- `Tests.TestAdapter`: 544 / 544 passed
- `Tests.Analyzers`: 54 / 54 passed
- Only build warning: `NU1510` — `System.Collections.Specialized 4.3.0` in `Sailfish.csproj` is now redundant on .NET 10. Left for a follow-up.

net8.0 / net9.0 builds were not verified locally (SDKs not installed). CI will exercise both.

**Deferred (intentionally out of scope)**
- Bumping `Microsoft.Extensions.*` 9.0.7 → 10.0.x in `Sailfish.csproj`
- Removing the redundant `System.Collections.Specialized` reference
- Updating `AdaptiveSamplingQuickTest` (still pinned to `net8.0` with stale test SDKs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added .NET 10.0 as a supported target framework across all projects alongside .NET 8.0 and 9.0.
  * Expanded CI/CD workflows to build and validate against .NET 10.0.
  * Updated test and build infrastructure to support .NET 10.0 testing and deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->