### PR TITLE
Fix codecov reporting: flag matrix uploads and wait for all jobs

### DIFF
--- a/.github/workflows/build-v3.0.yml
+++ b/.github/workflows/build-v3.0.yml
@@ -144,6 +144,12 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: paulegradie/Sailfish
+          # Flag each matrix job so codecov merges the parallel uploads
+          # by-file instead of letting the last upload win.
+          flags: ${{ matrix.project }}
+          name: ${{ matrix.project }}
+          # Don't fail the whole job on a transient codecov outage.
+          fail_ci_if_error: false
 
   pack:
     name: Nuget Package Test

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,10 @@
 codecov:
   notify:
     require_ci_to_pass: yes
-    after_n_builds: 1
+    # We have 3 parallel matrix jobs (Tests.Library, Tests.TestAdapter,
+    # Tests.Analyzers). Wait for all three uploads before computing the
+    # verdict; otherwise the badge reflects whichever job finished first.
+    after_n_builds: 3
 
 coverage:
   status:
@@ -40,13 +43,17 @@ parsers:
       method: no
       macro: no
 
+# Per-matrix-job flags. Each flag corresponds to a parallel test job in
+# .github/workflows/build-v3.0.yml. carryforward keeps the last known
+# coverage for a flag if its job fails or is skipped on a given commit,
+# so the badge stays stable.
 flags:
-  unittest: # Define a flag for unit tests
-    paths:
-      - "tests/unit"
-  integration: # Define a flag for integration tests
-    paths:
-      - "tests/integration"
+  Tests.Library:
+    carryforward: true
+  Tests.TestAdapter:
+    carryforward: true
+  Tests.Analyzers:
+    carryforward: true
 
 # Ignore files and directories that should not be included in coverage
 ignore:
@@ -54,7 +61,12 @@ ignore:
   - "vendor/*"
   - "docs/*"
   - "**/*.md"
-  - "**/*Tests.*" # Ignore any project with 'Tests.' in its name
+  - "source/Tests.*/**" # Ignore any project with 'Tests.' in its name
+  - "source/Demo.API/**"
+  - "source/ConsoleAppDemo/**"
+  - "source/ScaleFishDemo/**"
+  - "source/PerformanceTests/**"
+  - "source/AdaptiveSamplingQuickTest/**"
 
 # Settings for custom coverage reporting
 yaml:

--- a/source/Tests.Library/Execution/OperationsPerInvokeTunerTests.cs
+++ b/source/Tests.Library/Execution/OperationsPerInvokeTunerTests.cs
@@ -19,8 +19,12 @@ public class OperationsPerInvokeTunerTests
     [Fact]
     public async Task Tune_FastRelativeToTarget_IncreasesOPI()
     {
-        // Arrange: per-op ~10ms, target 30ms -> expect OPI >= 2
-        var instance = new DelayWork(10);
+        // Arrange: per-op ~5ms, target 100ms -> expect OPI >= 2.
+        // Headroom is intentionally wide (~20:1) so the assertion stays
+        // robust against jittery CI runners (e.g. multi-tenant vCPUs)
+        // where observed per-op time can drift several-fold above its
+        // nominal value.
+        var instance = new DelayWork(5);
         var method = typeof(DelayWork).GetMethod(nameof(DelayWork.Run))!;
         var settings = new ExecutionSettings { OperationsPerInvoke = 1, NumWarmupIterations = 0, SampleSize = 3 };
         var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
@@ -28,7 +32,7 @@ public class OperationsPerInvokeTunerTests
         var tuner = new OperationsPerInvokeTuner();
 
         // Act
-        var tuned = await tuner.TuneAsync(container, TimeSpan.FromMilliseconds(30), _logger, CancellationToken.None);
+        var tuned = await tuner.TuneAsync(container, TimeSpan.FromMilliseconds(100), _logger, CancellationToken.None);
 
         // Assert
         tuned.ShouldBeGreaterThanOrEqualTo(2);


### PR DESCRIPTION
## Description

The codecov badge has been showing ~46% on main, but locally — merging all three test runs by file — production-code coverage is **87.62%** (`Sailfish` 87.72%, `Sailfish.TestAdapter` 86.00%, `Sailfish.Analyzers` 96.84%).

The 46% figure is essentially what the `Tests.TestAdapter` job alone reports in isolation (overall 48.02%). The other two matrix jobs (`Tests.Library`, `Tests.Analyzers`) are being thrown away.

**Root cause.** The three parallel matrix jobs all upload to codecov **without flags**, and `codecov.yml` has `after_n_builds: 1`. Codecov computes its verdict on whichever upload arrives first and the subsequent uploads either overwrite it or get dropped, depending on race ordering. So the badge reflects only one of three jobs, not the union.

## Results

**`.github/workflows/build-v3.0.yml`**
- Add `flags: ${{ matrix.project }}` and `name: ${{ matrix.project }}` to the `codecov-action` call so each parallel upload is tracked separately and merged by file.
- Add `fail_ci_if_error: false` so a transient codecov outage doesn't fail the CI run.

**`codecov.yml`**
- Bump `after_n_builds: 1` → `3` so codecov waits for all three uploads before computing the verdict.
- Replace the dead `unittest`/`integration` flag stubs with real `Tests.Library`/`Tests.TestAdapter`/`Tests.Analyzers` flag definitions, each with `carryforward: true` so a missing upload on a given commit reuses the last known value instead of dropping to 0.
- Fix the test-project ignore glob: `**/*Tests.*` was filename-shaped and didn't actually match paths like `Tests.Common/Foo.cs`. Replace with `source/Tests.*/**`.
- Explicitly ignore demo/perf projects (`Demo.API`, `ConsoleAppDemo`, `ScaleFishDemo`, `PerformanceTests`, `AdaptiveSamplingQuickTest`) so the denominator reflects shippable code only.

**`source/Tests.Library/Execution/OperationsPerInvokeTunerTests.cs`** *(follow-up commit)*
- Stabilize `Tune_FastRelativeToTarget_IncreasesOPI`, which had been flaky on one of the three TFM runs in CI (Azure `eastus` multi-tenant vCPU). The old setup used ~10 ms per op against a 30 ms target — only 3:1 headroom, which the runner's timing jitter could blow past. Widened to ~5 ms per op against a 100 ms target (~20:1 headroom) so the assertion stays robust without changing what's being tested.

Expected effect after this lands on main: codecov badge moves from ~46% to ~87%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting to consolidate results from parallel test jobs, use finer-grained coverage categories, and make coverage service outages non-blocking.
  * Expanded coverage ignore rules to more precisely exclude demo/performance/quicktest areas.

* **Tests**
  * Adjusted a timing-sensitive unit test to reduce flakiness by updating delays and target durations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

