### PR TITLE
Throw TestClassInstantiationException on test class activation failure (#136)

### DIFF
--- a/source/Sailfish/Exceptions/TestClassInstantiationException.cs
+++ b/source/Sailfish/Exceptions/TestClassInstantiationException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Sailfish.Exceptions;
+
+public class TestClassInstantiationException : Exception
+{
+    public TestClassInstantiationException(Type testType, Exception inner, string? message = null)
+        : base(message ?? $"Failed to instantiate test class '{testType.FullName}'. " +
+                          "This usually indicates a missing dependency registration or a constructor that threw.", inner)
+    {
+        TestType = testType;
+    }
+
+    public Type TestType { get; }
+}

--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -130,6 +130,11 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
             var msg = $"Error resolving test from {testProvider.Test.FullName}";
             _logger.Log(LogLevel.Fatal, ex, msg);
 
+            if (ex is TestClassInstantiationException)
+            {
+                return [new TestCaseExecutionResult(ex)];
+            }
+
             var testCaseEnumerationException = new TestCaseEnumerationException(ex,
                 $"Failed to create test cases for {testProvider.Test.FullName}");
             return [new TestCaseExecutionResult(testCaseEnumerationException)];

--- a/source/Sailfish/Execution/TypeActivator.cs
+++ b/source/Sailfish/Execution/TypeActivator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Autofac;
@@ -25,11 +26,34 @@ public class TypeActivator : ITypeActivator
     public object CreateDehydratedTestInstance(Type test, TestCaseId testCaseId, bool disabled)
     {
         var ctorArgTypes = test.GetCtorParamTypes();
-        if (disabled) return Activator.CreateInstance(test, ctorArgTypes.Select(_ => null! as object).ToArray())!;
+        if (disabled)
+        {
+            try
+            {
+                return Activator.CreateInstance(test, ctorArgTypes.Select(_ => null! as object).ToArray())!;
+            }
+            catch (Exception ex)
+            {
+                throw new TestClassInstantiationException(test, ex);
+            }
+        }
 
         if (ctorArgTypes.Length != ctorArgTypes.Distinct().Count()) throw new SailfishException($"Multiple ctor arguments of the same type were found in {test.Name}");
 
-        var ctorArgs = ctorArgTypes.Where(x => x != typeof(TestCaseId)).Select(x => _lifetimeScope.Resolve(x)).ToList();
+        List<object> ctorArgs;
+        try
+        {
+            ctorArgs = ctorArgTypes.Where(x => x != typeof(TestCaseId)).Select(x => _lifetimeScope.Resolve(x)).ToList();
+        }
+        catch (Exception ex)
+        {
+            throw new TestClassInstantiationException(
+                test,
+                ex,
+                $"Failed to resolve constructor dependencies for test class '{test.FullName}'. " +
+                "Check that all constructor parameter types are registered with the DI container.");
+        }
+
         if (ctorArgTypes.Contains(typeof(TestCaseId)))
         {
             var caseIdIndex = Array.IndexOf(ctorArgTypes, typeof(TestCaseId));
@@ -38,14 +62,30 @@ public class TypeActivator : ITypeActivator
 
         var constructors = test.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
-        var obj = constructors.Length switch
+        object? obj;
+        try
         {
-            0 => Activator.CreateInstance(test),
-            1 => constructors.Single().Invoke([.. ctorArgs]),
-            _ => throw new SailfishException("Sailfish tests are allowed only a single constructor")
-        };
+            obj = constructors.Length switch
+            {
+                0 => Activator.CreateInstance(test),
+                1 => constructors.Single().Invoke([.. ctorArgs]),
+                _ => throw new SailfishException("Sailfish tests are allowed only a single constructor")
+            };
+        }
+        catch (SailfishException)
+        {
+            throw;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw new TestClassInstantiationException(test, ex.InnerException);
+        }
+        catch (Exception ex)
+        {
+            throw new TestClassInstantiationException(test, ex);
+        }
 
-        if (obj is null) throw new SailfishException($"Couldn't create instance of {test.Name}");
+        if (obj is null) throw new TestClassInstantiationException(test, new InvalidOperationException($"Couldn't create instance of {test.Name}"));
 
         return obj;
     }

--- a/source/Tests.Library/Execution/TypeActivatorTests.cs
+++ b/source/Tests.Library/Execution/TypeActivatorTests.cs
@@ -1,0 +1,81 @@
+using System;
+using Autofac;
+using Autofac.Core.Registration;
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Exceptions;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Execution;
+
+public class TypeActivatorTests
+{
+    [Sailfish]
+    private class TestClassWithDependency
+    {
+        private readonly INotRegistered _dependency;
+
+        public TestClassWithDependency(INotRegistered dependency)
+        {
+            _dependency = dependency;
+        }
+
+        [SailfishMethod]
+        public void Method() { _ = _dependency; }
+    }
+
+    [Sailfish]
+    private class TestClassThatThrowsInCtor
+    {
+        public TestClassThatThrowsInCtor()
+        {
+            throw new InvalidOperationException("boom from ctor");
+        }
+
+        [SailfishMethod]
+        public void Method() { }
+    }
+
+    private interface INotRegistered { }
+
+    private static ILifetimeScope EmptyScope()
+    {
+        return new ContainerBuilder().Build().BeginLifetimeScope();
+    }
+
+    [Fact]
+    public void CreateDehydratedTestInstance_WhenDependencyIsNotRegistered_ThrowsTestClassInstantiationException()
+    {
+        using var scope = EmptyScope();
+        var activator = new TypeActivator(scope);
+
+        var ex = Should.Throw<TestClassInstantiationException>(() =>
+            activator.CreateDehydratedTestInstance(
+                typeof(TestClassWithDependency),
+                new TestCaseId("TestClassWithDependency.Method"),
+                disabled: false));
+
+        ex.TestType.ShouldBe(typeof(TestClassWithDependency));
+        ex.InnerException.ShouldBeOfType<ComponentNotRegisteredException>();
+        ex.Message.ShouldContain(typeof(TestClassWithDependency).FullName!);
+    }
+
+    [Fact]
+    public void CreateDehydratedTestInstance_WhenConstructorThrows_ThrowsTestClassInstantiationException_UnwrappingTargetInvocationException()
+    {
+        using var scope = EmptyScope();
+        var activator = new TypeActivator(scope);
+
+        var ex = Should.Throw<TestClassInstantiationException>(() =>
+            activator.CreateDehydratedTestInstance(
+                typeof(TestClassThatThrowsInCtor),
+                new TestCaseId("TestClassThatThrowsInCtor.Method"),
+                disabled: false));
+
+        ex.TestType.ShouldBe(typeof(TestClassThatThrowsInCtor));
+        ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+        ex.InnerException!.Message.ShouldBe("boom from ctor");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TestClassInstantiationException`, a dedicated exception that wraps any failure during test class activation (DI resolution, constructor invocation) and carries the failing `Type`.
- `TypeActivator` now wraps:
  - Autofac `Resolve` failures (e.g. missing DI registration)
  - `TargetInvocationException` from constructors (unwrapping the inner exception)
  - Other ctor-invocation errors
- `SailfishExecutionEngine` propagates `TestClassInstantiationException` unchanged instead of wrapping it in `TestCaseEnumerationException`, so downstream consumers can filter on it.
- Two new unit tests in `TypeActivatorTests` cover the missing-registration and ctor-throws cases.

Closes #136.

## Test plan
- [x] `dotnet test Tests.Library/Tests.Library.csproj --framework net9.0` — 1170 passing
- [x] `dotnet test Tests.TestAdapter/Tests.TestAdapter.csproj --framework net9.0` — 544 passing
- [x] New tests `TypeActivatorTests.CreateDehydratedTestInstance_WhenDependencyIsNotRegistered_ThrowsTestClassInstantiationException` and `..._WhenConstructorThrows_...` pass