### PR TITLE
Emit TestCase.Hierarchy + ManagedType/ManagedMethod for Rider grouping (#98)

### DIFF
--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -70,6 +70,19 @@ internal static class TestCaseItemCreator
         testCase.SetPropertyValue(SailfishManagedProperty.SailfishDisplayNameDefinitionProperty, testCaseId.DisplayName);
         testCase.SetPropertyValue(SailfishManagedProperty.SailfishFormedVariableSectionDefinitionProperty, testCaseId.TestCaseVariables.FormVariableSection());
 
+        // Standard VSTest hierarchy + managed-name properties. Each variant of a parameterized
+        // SailfishMethod shares the same Hierarchy array, which lets Rider's Unit Tests tool
+        // window (and VS Test Explorer) group them under a single parent method node instead of
+        // listing them as flat siblings under the class.
+        var hierarchy = new string?[SailfishManagedProperty.HierarchyTotalLevelCount];
+        hierarchy[SailfishManagedProperty.HierarchyContainerIndex] = null;
+        hierarchy[SailfishManagedProperty.HierarchyNamespaceIndex] = testType.Namespace;
+        hierarchy[SailfishManagedProperty.HierarchyClassIndex] = testType.Name;
+        hierarchy[SailfishManagedProperty.HierarchyTestGroupIndex] = methodName;
+        testCase.SetPropertyValue(SailfishManagedProperty.TestCaseHierarchyProperty, hierarchy);
+        testCase.SetPropertyValue(SailfishManagedProperty.TestCaseManagedTypeProperty, testType.FullName);
+        testCase.SetPropertyValue(SailfishManagedProperty.TestCaseManagedMethodProperty, methodName);
+
         // comparison properties (if present)
         if (!string.IsNullOrEmpty(comparisonGroup))
         {

--- a/source/Sailfish.TestAdapter/TestProperties/SailfishManagedProperty.cs
+++ b/source/Sailfish.TestAdapter/TestProperties/SailfishManagedProperty.cs
@@ -63,4 +63,40 @@ public static class SailfishManagedProperty
         o => o == null || !string.IsNullOrWhiteSpace(o as string),
         TestPropertyAttributes.Hidden,
         typeof(SailfishManagedProperty));
+
+    public static readonly TestProperty TestCaseHierarchyProperty = TestProperty.Register(
+        "TestCase.Hierarchy",
+        "Hierarchy",
+        string.Empty,
+        string.Empty,
+        typeof(string[]),
+        o => o is string[] arr && arr.Length == HierarchyTotalLevelCount,
+        TestPropertyAttributes.Hidden,
+        typeof(TestCase));
+
+    public static readonly TestProperty TestCaseManagedTypeProperty = TestProperty.Register(
+        "TestCase.ManagedType",
+        "ManagedType",
+        string.Empty,
+        string.Empty,
+        typeof(string),
+        o => !string.IsNullOrWhiteSpace(o as string),
+        TestPropertyAttributes.Hidden,
+        typeof(TestCase));
+
+    public static readonly TestProperty TestCaseManagedMethodProperty = TestProperty.Register(
+        "TestCase.ManagedMethod",
+        "ManagedMethod",
+        string.Empty,
+        string.Empty,
+        typeof(string),
+        o => !string.IsNullOrWhiteSpace(o as string),
+        TestPropertyAttributes.Hidden,
+        typeof(TestCase));
+
+    public const int HierarchyContainerIndex = 0;
+    public const int HierarchyNamespaceIndex = 1;
+    public const int HierarchyClassIndex = 2;
+    public const int HierarchyTestGroupIndex = 3;
+    public const int HierarchyTotalLevelCount = 4;
 }

--- a/source/Tests.TestAdapter/TestCaseItemCreatorTests.cs
+++ b/source/Tests.TestAdapter/TestCaseItemCreatorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using NSubstitute;
+using Sailfish.Attributes;
 using Sailfish.TestAdapter;
 using Sailfish.TestAdapter.Discovery;
 using Sailfish.TestAdapter.TestProperties;
@@ -203,6 +204,63 @@ public class TestCaseItemCreatorTests
         fullyQualifiedNames.ShouldAllBe(name => !string.IsNullOrEmpty(name));
     }
 
+    [Fact]
+    public void AssembleTestCases_ShouldSetHierarchyAndManagedNameProperties()
+    {
+        // Arrange
+        var classMetaData = CreateClassMetaData();
+        var hashAlgorithm = Substitute.For<IHashAlgorithm>();
+        hashAlgorithm.GuidFromString(Arg.Any<string>()).Returns(Guid.NewGuid());
+
+        // Act
+        var testCases = TestCaseItemCreator.AssembleTestCases(classMetaData, "source.dll", hashAlgorithm).ToList();
+
+        // Assert
+        testCases.ShouldNotBeEmpty();
+        var first = testCases.First();
+        var hierarchy = (string[]?)first.GetPropertyValue(SailfishManagedProperty.TestCaseHierarchyProperty);
+        hierarchy.ShouldNotBeNull();
+        hierarchy!.Length.ShouldBe(SailfishManagedProperty.HierarchyTotalLevelCount);
+        hierarchy[SailfishManagedProperty.HierarchyContainerIndex].ShouldBeNull();
+        hierarchy[SailfishManagedProperty.HierarchyNamespaceIndex].ShouldBe(typeof(TestCaseItemCreatorTestClass).Namespace);
+        hierarchy[SailfishManagedProperty.HierarchyClassIndex].ShouldBe(typeof(TestCaseItemCreatorTestClass).Name);
+        hierarchy[SailfishManagedProperty.HierarchyTestGroupIndex].ShouldBe("TestMethod1");
+
+        first.GetPropertyValue(SailfishManagedProperty.TestCaseManagedTypeProperty)
+            .ShouldBe(typeof(TestCaseItemCreatorTestClass).FullName);
+        first.GetPropertyValue(SailfishManagedProperty.TestCaseManagedMethodProperty)
+            .ShouldBe("TestMethod1");
+    }
+
+    [Fact]
+    public void AssembleTestCases_ParameterizedVariants_ShouldShareHierarchyArrayPerMethod()
+    {
+        // Arrange — a class with a SailfishVariable produces multiple test cases for the same method.
+        var classMetaData = new ClassMetaData(
+            filePath: "/path/to/ParameterizedTest.cs",
+            classFullName: typeof(ParameterizedSailfishTestClass).FullName!,
+            performanceTestType: typeof(ParameterizedSailfishTestClass),
+            syntaxTree: Substitute.For<SyntaxTree>(),
+            methods: new[] { new MethodMetaData("ParamMethod", 10, null) });
+        var hashAlgorithm = Substitute.For<IHashAlgorithm>();
+        hashAlgorithm.GuidFromString(Arg.Any<string>()).Returns(_ => Guid.NewGuid());
+
+        // Act
+        var testCases = TestCaseItemCreator.AssembleTestCases(classMetaData, "source.dll", hashAlgorithm).ToList();
+
+        // Assert — multiple variants, each with the same hierarchy[TestGroup] value so Rider
+        // groups them under the parent method.
+        testCases.Count.ShouldBeGreaterThan(1);
+        var hierarchies = testCases
+            .Select(tc => (string[]?)tc.GetPropertyValue(SailfishManagedProperty.TestCaseHierarchyProperty))
+            .ToList();
+        hierarchies.ShouldAllBe(h => h != null);
+        hierarchies.ShouldAllBe(h =>
+            h![SailfishManagedProperty.HierarchyTestGroupIndex] == "ParamMethod" &&
+            h[SailfishManagedProperty.HierarchyClassIndex] == typeof(ParameterizedSailfishTestClass).Name &&
+            h[SailfishManagedProperty.HierarchyNamespaceIndex] == typeof(ParameterizedSailfishTestClass).Namespace);
+    }
+
     #endregion
 
     #region Helper Methods
@@ -297,4 +355,16 @@ public class TestCaseItemCreatorTestClassWithVariables
 public class TestCaseItemCreatorTypeWithNullFullName
 {
     // This class is used to test edge cases where Type.FullName might be null
+}
+
+// Intentionally NOT annotated with [Sailfish] so the TestAdapter's own type discovery does
+// not pick this class up while the Tests.TestAdapter assembly is being scanned. The
+// PropertySetGenerator only inspects [SailfishVariable] on properties to enumerate variants,
+// which is all the TestCaseItemCreator test needs.
+public class ParameterizedSailfishTestClass
+{
+    [SailfishVariable(1, 2, 3)]
+    public int N { get; set; }
+
+    public void ParamMethod() { }
 }


### PR DESCRIPTION
## Summary

Rider's Unit Tests tool window (and VS Test Explorer) build their tree from the standard VSTest `TestCase.Hierarchy` property (per [RFC 0017](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0017-Managed-TestCase-Properties.md)). It's a 4-element `string[]` of `[container, namespace, class, testGroup]`. **All variants of a parameterized method must share the same array** for the runner to collapse them under one method node.

- MSTest emits this property — that's why parameterized MSTest tests group correctly in Rider.
- xUnit/NUnit *don't* emit it because Rider has internal special-case providers for those frameworks.
- Sailfish is a third-party adapter, so it must do what MSTest does.

This PR:
1. Registers three standard VSTest properties in `SailfishManagedProperty` — `TestCase.Hierarchy`, `TestCase.ManagedType`, `TestCase.ManagedMethod`.
2. Sets them in `TestCaseItemCreator.CreateTestCase` for every emitted `TestCase`. All variants of the same `SailfishMethod` share the same hierarchy array (slot 3 = method name only, no variable section), which is what makes Rider group them.
3. Does **not** change `FullyQualifiedName`, `DisplayName`, or `TestCase.Id` — those are heavily consumed downstream (FQN `EndsWith`/`Contains` matching in `TestCompletionMessageMapper`, `TestCaseCompletedNotificationHandler`, `FrameworkTestCaseEndNotification`), and any change there risks breaking CLI filters and result reporting.

## What the user sees

- Rider: parameterized Sailfish test cases now nest under the parent `SailfishMethod` node instead of appearing as flat siblings under the class (the desired xUnit-like behavior in the issue).
- VS Test Explorer: same — uses the same `TestCase.Hierarchy` mechanism.
- CLI / `dotnet test`: no observable change; `FullyQualifiedName` and filters are untouched.

Closes #98.

## Test plan

- [x] New tests `AssembleTestCases_ShouldSetHierarchyAndManagedNameProperties` and `AssembleTestCases_ParameterizedVariants_ShouldShareHierarchyArrayPerMethod` pass.
- [x] `dotnet test Tests.TestAdapter` — **546 passing**, 0 failing.
- [x] `dotnet test Tests.Library` — **1170 passing**, 0 failing.
- [ ] Manual smoke in Rider: open a Sailfish project with a `[SailfishVariable]` test, verify cases nest under the method in the Unit Tests window.

## Research notes

- [RFC 0017 — Managed TestCase Properties](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0017-Managed-TestCase-Properties.md)
- [vstest#4886 — confirmation that `TestCase.Hierarchy` is the mechanism, MSTest is the only built-in emitter](https://github.com/microsoft/vstest/issues/4886)
- [MSTest's HierarchyConstants source](https://github.com/microsoft/vstest/blob/main/src/Microsoft.TestPlatform.AdapterUtilities/HierarchyConstants.cs)

The `Microsoft.TestPlatform.AdapterUtilities` NuGet package would have provided the same constants but was avoided to keep the dep footprint small — the IDs/labels are stable and well-known.