### PR TITLE
Add RunOnce flag to lifecycle attributes (#132)

### DIFF
--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionEngine.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionEngine.cs
@@ -41,6 +41,9 @@ internal class TestAdapterExecutionEngine : ITestAdapterExecutionEngine
         List<TestCase> testCases,
         CancellationToken cancellationToken)
     {
+        // Fresh tracker per adapter run — RunOnce claims don't leak across multiple Execute()
+        // calls within the same testhost process.
+        var lifecycleMethodTracker = new LifecycleMethodTracker();
         var rawExecutionResults = new List<(string, TestClassResultGroup)>();
         var testCaseGroups = testCases.GroupBy(testCase => testCase.GetPropertyHelper(SailfishManagedProperty.SailfishTypeProperty));
 
@@ -56,7 +59,8 @@ internal class TestAdapterExecutionEngine : ITestAdapterExecutionEngine
                     CreatePropertyFilter(GetTestCaseProperties(
                         SailfishManagedProperty.SailfishFormedVariableSectionDefinitionProperty, testCases)),
                     CreateMethodFilter(GetTestCaseProperties(SailfishManagedProperty.SailfishMethodFilterProperty,
-                        testCases)));
+                        testCases)),
+                    lifecycleMethodTracker);
 
             var totalTestProviderCount = providerForCurrentTestCases.Count - 1;
 

--- a/source/Sailfish/Attributes/IInnerLifecycleAttribute.cs
+++ b/source/Sailfish/Attributes/IInnerLifecycleAttribute.cs
@@ -3,4 +3,10 @@ namespace Sailfish.Attributes;
 internal interface IInnerLifecycleAttribute
 {
     public string[] MethodNames { get; }
+
+    /// <summary>
+    ///     When true, the lifecycle method is invoked at most once per executor run for the
+    ///     declaring test class, even if it applies to multiple SailfishMethods.
+    /// </summary>
+    public bool RunOnce { get; }
 }

--- a/source/Sailfish/Attributes/SailfishIterationSetupAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishIterationSetupAttribute.cs
@@ -45,4 +45,11 @@ public sealed class SailfishIterationSetupAttribute : Attribute, IInnerLifecycle
     ///     Array of method names that the SailfishIterationSetup method should be executed before
     /// </summary>
     public string[] MethodNames { get; }
+
+    /// <summary>
+    ///     When true, the iteration setup method is invoked at most once per executor run for the
+    ///     declaring test class — before the first applicable iteration only. Subsequent iterations
+    ///     and other applicable SailfishMethods skip it.
+    /// </summary>
+    public bool RunOnce { get; set; }
 }

--- a/source/Sailfish/Attributes/SailfishIterationTeardownAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishIterationTeardownAttribute.cs
@@ -45,4 +45,10 @@ public sealed class SailfishIterationTeardownAttribute : Attribute, IInnerLifecy
     ///     Array of method names that the SailfishIterationTeardown method should be executed after
     /// </summary>
     public string[] MethodNames { get; }
+
+    /// <summary>
+    ///     When true, the iteration teardown method is invoked at most once per executor run for the
+    ///     declaring test class — after the first applicable iteration only.
+    /// </summary>
+    public bool RunOnce { get; set; }
 }

--- a/source/Sailfish/Attributes/SailfishMethodSetupAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodSetupAttribute.cs
@@ -45,4 +45,11 @@ public sealed class SailfishMethodSetupAttribute : Attribute, IInnerLifecycleAtt
     ///     Array of method names that the SailfishIterationTeardown method should be executed after
     /// </summary>
     public string[] MethodNames { get; set; }
+
+    /// <summary>
+    ///     When true, the setup method is invoked at most once per executor run for the declaring
+    ///     test class, even when <see cref="MethodNames" /> lists multiple SailfishMethods. Useful
+    ///     for one-shot fixture initialization shared across multiple [SailfishMethod]s.
+    /// </summary>
+    public bool RunOnce { get; set; }
 }

--- a/source/Sailfish/Attributes/SailfishMethodTeardownAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodTeardownAttribute.cs
@@ -45,4 +45,10 @@ public sealed class SailfishMethodTeardownAttribute : Attribute, IInnerLifecycle
     ///     Array of method names that the SailfishMethodTeardown method should be executed after
     /// </summary>
     public string[] MethodNames { get; set; }
+
+    /// <summary>
+    ///     When true, the teardown method is invoked at most once per executor run for the declaring
+    ///     test class, even when <see cref="MethodNames" /> lists multiple SailfishMethods.
+    /// </summary>
+    public bool RunOnce { get; set; }
 }

--- a/source/Sailfish/Execution/CoreInvoker.cs
+++ b/source/Sailfish/Execution/CoreInvoker.cs
@@ -17,19 +17,21 @@ internal class CoreInvoker
     private readonly object _instance;
     private readonly List<MethodInfo> _iterationSetup;
     private readonly List<MethodInfo> _iterationTeardown;
+    private readonly LifecycleMethodTracker _lifecycleMethodTracker;
 
     private readonly MethodInfo _mainMethod;
     private readonly List<MethodInfo> _methodSetup;
     private readonly List<MethodInfo> _methodTeardown;
     private readonly PerformanceTimer _testCasePerformanceTimer;
 
-    public CoreInvoker(object instance, MethodInfo method, PerformanceTimer testCasePerformanceTimer)
+    public CoreInvoker(object instance, MethodInfo method, PerformanceTimer testCasePerformanceTimer, LifecycleMethodTracker? lifecycleMethodTracker = null)
     {
         _globalSetup = instance.FindMethodsDecoratedWithAttribute<SailfishGlobalSetupAttribute>();
         _globalTeardown = instance.FindMethodsDecoratedWithAttribute<SailfishGlobalTeardownAttribute>();
         _instance = instance;
         _iterationSetup = instance.FindMethodsDecoratedWithAttribute<SailfishIterationSetupAttribute>();
         _iterationTeardown = instance.FindMethodsDecoratedWithAttribute<SailfishIterationTeardownAttribute>();
+        _lifecycleMethodTracker = lifecycleMethodTracker ?? new LifecycleMethodTracker();
         _mainMethod = method;
         _methodSetup = instance.FindMethodsDecoratedWithAttribute<SailfishMethodSetupAttribute>();
         _methodTeardown = instance.FindMethodsDecoratedWithAttribute<SailfishMethodTeardownAttribute>();
@@ -54,7 +56,7 @@ internal class CoreInvoker
             var attribute = lifecycleMethod.GetCustomAttribute<TAttribute>();
             if (attribute is null) throw new SailfishException($"{nameof(TAttribute)}, was somehow missing");
             if (attribute.MethodNames.Length > 0 && !attribute.MethodNames.Contains(MainMethodName)) continue;
-            if (attribute.RunOnce && !LifecycleMethodTracker.TryClaim(_instance.GetType(), lifecycleMethod)) continue;
+            if (attribute.RunOnce && !_lifecycleMethodTracker.TryClaim(_instance.GetType(), lifecycleMethod)) continue;
             await lifecycleMethod.TryInvoke(_instance, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/source/Sailfish/Execution/CoreInvoker.cs
+++ b/source/Sailfish/Execution/CoreInvoker.cs
@@ -53,8 +53,9 @@ internal class CoreInvoker
         {
             var attribute = lifecycleMethod.GetCustomAttribute<TAttribute>();
             if (attribute is null) throw new SailfishException($"{nameof(TAttribute)}, was somehow missing");
-            if (attribute.MethodNames.Length == 0 || attribute.MethodNames.Contains(MainMethodName))
-                await lifecycleMethod.TryInvoke(_instance, cancellationToken).ConfigureAwait(false);
+            if (attribute.MethodNames.Length > 0 && !attribute.MethodNames.Contains(MainMethodName)) continue;
+            if (attribute.RunOnce && !LifecycleMethodTracker.TryClaim(_instance.GetType(), lifecycleMethod)) continue;
+            await lifecycleMethod.TryInvoke(_instance, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/source/Sailfish/Execution/LifecycleMethodTracker.cs
+++ b/source/Sailfish/Execution/LifecycleMethodTracker.cs
@@ -9,20 +9,21 @@ namespace Sailfish.Execution;
 ///     RunOnce contract, so a single lifecycle method that applies to multiple SailfishMethods
 ///     fires at most once per executor run.
 /// </summary>
-internal static class LifecycleMethodTracker
+/// <remarks>
+///     Each executor run owns its own instance of this tracker — both
+///     <see cref="SailFishTestExecutor" /> and the test-adapter execution engine create a fresh
+///     tracker per <c>Execute(...)</c> invocation. This scoping prevents cross-run state leakage
+///     (claims from a prior run silently skipping lifecycle methods in a later run within the same
+///     testhost process) and avoids interference between concurrent runs.
+/// </remarks>
+internal sealed class LifecycleMethodTracker
 {
-    private static readonly ConcurrentDictionary<(Type, MethodInfo), byte> Claimed = new();
+    private readonly ConcurrentDictionary<(Type, MethodInfo), byte> _claimed = new();
 
     /// <summary>
     ///     Atomically claims the pair. Returns <c>true</c> on the first claim (caller should
     ///     invoke the lifecycle method); <c>false</c> on subsequent calls (caller should skip).
     /// </summary>
-    public static bool TryClaim(Type testType, MethodInfo lifecycleMethod) =>
-        Claimed.TryAdd((testType, lifecycleMethod), 0);
-
-    /// <summary>
-    ///     Clears all claims. Called at the start of each executor run so RunOnce state does not
-    ///     leak across invocations of <see cref="SailFishTestExecutor.Execute" />.
-    /// </summary>
-    public static void Reset() => Claimed.Clear();
+    public bool TryClaim(Type testType, MethodInfo lifecycleMethod) =>
+        _claimed.TryAdd((testType, lifecycleMethod), 0);
 }

--- a/source/Sailfish/Execution/LifecycleMethodTracker.cs
+++ b/source/Sailfish/Execution/LifecycleMethodTracker.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Tracks which (test type, lifecycle method) pairs have already been invoked under the
+///     RunOnce contract, so a single lifecycle method that applies to multiple SailfishMethods
+///     fires at most once per executor run.
+/// </summary>
+internal static class LifecycleMethodTracker
+{
+    private static readonly ConcurrentDictionary<(Type, MethodInfo), byte> Claimed = new();
+
+    /// <summary>
+    ///     Atomically claims the pair. Returns <c>true</c> on the first claim (caller should
+    ///     invoke the lifecycle method); <c>false</c> on subsequent calls (caller should skip).
+    /// </summary>
+    public static bool TryClaim(Type testType, MethodInfo lifecycleMethod) =>
+        Claimed.TryAdd((testType, lifecycleMethod), 0);
+
+    /// <summary>
+    ///     Clears all claims. Called at the start of each executor run so RunOnce state does not
+    ///     leak across invocations of <see cref="SailFishTestExecutor.Execute" />.
+    /// </summary>
+    public static void Reset() => Claimed.Clear();
+}

--- a/source/Sailfish/Execution/SailFishTestExecutor.cs
+++ b/source/Sailfish/Execution/SailFishTestExecutor.cs
@@ -38,6 +38,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
         IEnumerable<Type> testTypes,
         CancellationToken cancellationToken = default)
     {
+        LifecycleMethodTracker.Reset();
         var allTestCaseResults = new List<TestClassResultGroup>();
         if (!FilterEnabledType(testTypes, out var enabledTestTypes))
         {

--- a/source/Sailfish/Execution/SailFishTestExecutor.cs
+++ b/source/Sailfish/Execution/SailFishTestExecutor.cs
@@ -38,7 +38,8 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
         IEnumerable<Type> testTypes,
         CancellationToken cancellationToken = default)
     {
-        LifecycleMethodTracker.Reset();
+        // Fresh tracker per executor run — claims do not leak across invocations.
+        var lifecycleMethodTracker = new LifecycleMethodTracker();
         var allTestCaseResults = new List<TestClassResultGroup>();
         if (!FilterEnabledType(testTypes, out var enabledTestTypes))
         {
@@ -54,7 +55,7 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
             _testCaseCountPrinter.PrintTypeUpdate(testType.Name);
             try
             {
-                var testCaseExecutionResults = await Execute(testType, cancellationToken);
+                var testCaseExecutionResults = await Execute(testType, lifecycleMethodTracker, cancellationToken);
                 allTestCaseResults.Add(new TestClassResultGroup(testType, testCaseExecutionResults));
             }
             catch (Exception ex)
@@ -69,9 +70,11 @@ internal class SailFishTestExecutor : ISailFishTestExecutor
 
     private async Task<List<TestCaseExecutionResult>> Execute(
         Type test,
+        LifecycleMethodTracker lifecycleMethodTracker,
         CancellationToken cancellationToken = default)
     {
-        var testInstanceContainerProviders = _testInstanceContainerCreator.CreateTestContainerInstanceProviders(test);
+        var testInstanceContainerProviders = _testInstanceContainerCreator.CreateTestContainerInstanceProviders(
+            test, lifecycleMethodTracker: lifecycleMethodTracker);
         return await Execute(testInstanceContainerProviders, cancellationToken);
     }
 

--- a/source/Sailfish/Execution/TestInstanceContainer.cs
+++ b/source/Sailfish/Execution/TestInstanceContainer.cs
@@ -50,7 +50,8 @@ internal class TestInstanceContainer
         string[] propertyNames,
         object[] variables,
         bool disabled,
-        IExecutionSettings executionSettings
+        IExecutionSettings executionSettings,
+        LifecycleMethodTracker? lifecycleMethodTracker = null
     )
     {
         if (propertyNames.Length != variables.Length) throw new SailfishException("Property names and variables do not match");
@@ -63,7 +64,7 @@ internal class TestInstanceContainer
             method,
             testCaseId,
             executionSettings,
-            new CoreInvoker(instance, method, new PerformanceTimer()),
+            new CoreInvoker(instance, method, new PerformanceTimer(), lifecycleMethodTracker),
             disabled);
     }
 

--- a/source/Sailfish/Execution/TestInstanceContainerCreator.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerCreator.cs
@@ -14,7 +14,8 @@ internal interface ITestInstanceContainerCreator
     List<TestInstanceContainerProvider> CreateTestContainerInstanceProviders(
         Type test,
         Func<PropertySet, bool>? propertyTensorFilter = null,
-        Func<MethodInfo, bool>? instanceContainerFilter = null);
+        Func<MethodInfo, bool>? instanceContainerFilter = null,
+        LifecycleMethodTracker? lifecycleMethodTracker = null);
 }
 
 internal class TestInstanceContainerCreator : ITestInstanceContainerCreator
@@ -35,7 +36,8 @@ internal class TestInstanceContainerCreator : ITestInstanceContainerCreator
     public List<TestInstanceContainerProvider> CreateTestContainerInstanceProviders(
         Type testType,
         Func<PropertySet, bool>? propertyTensorFilter = null,
-        Func<MethodInfo, bool>? instanceContainerFilter = null)
+        Func<MethodInfo, bool>? instanceContainerFilter = null,
+        LifecycleMethodTracker? lifecycleMethodTracker = null)
     {
         var variableSets = _propertySetGenerator.GenerateSailfishVariableSets(testType, out _);
         if (propertyTensorFilter is not null) variableSets = variableSets.Where(propertyTensorFilter);
@@ -77,7 +79,8 @@ internal class TestInstanceContainerCreator : ITestInstanceContainerCreator
                 _typeActivator,
                 testType,
                 variableSetsList,
-                instanceContainer))
+                instanceContainer,
+                lifecycleMethodTracker))
             .ToList();
     }
 

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -18,6 +18,7 @@ internal interface ITestInstanceContainerProvider
 
 internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
 {
+    private readonly LifecycleMethodTracker? _lifecycleMethodTracker;
     private readonly IEnumerable<PropertySet> _propertySets;
     private readonly IRunSettings _runSettings;
     private readonly ITypeActivator _typeActivator;
@@ -27,10 +28,12 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
         ITypeActivator typeActivator,
         Type test,
         IEnumerable<PropertySet> propertySets,
-        MethodInfo method)
+        MethodInfo method,
+        LifecycleMethodTracker? lifecycleMethodTracker = null)
     {
         Method = method;
         Test = test;
+        _lifecycleMethodTracker = lifecycleMethodTracker;
         _propertySets = propertySets;
         _runSettings = runSettings;
         _typeActivator = typeActivator;
@@ -64,7 +67,7 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
                 _runSettings.GlobalMinimumSampleSize);
             var seed = TryParseSeed(_runSettings.Args);
             if (seed.HasValue) executionSettings.Seed = seed;
-            yield return TestInstanceContainer.CreateTestInstance(instance, Method, [], [], disabled, executionSettings);
+            yield return TestInstanceContainer.CreateTestInstance(instance, Method, [], [], disabled, executionSettings, _lifecycleMethodTracker);
         }
         else
         {
@@ -89,7 +92,7 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
                     _runSettings.GlobalMinimumSampleSize);
                 var seed = TryParseSeed(_runSettings.Args);
                 if (seed.HasValue) executionSettings.Seed = seed;
-                yield return TestInstanceContainer.CreateTestInstance(instance, Method, propertyNames, variableValues, disabled, executionSettings);
+                yield return TestInstanceContainer.CreateTestInstance(instance, Method, propertyNames, variableValues, disabled, executionSettings, _lifecycleMethodTracker);
             }
         }
     }

--- a/source/Tests.Library/Execution/CoreInvokerRunOnceTests.cs
+++ b/source/Tests.Library/Execution/CoreInvokerRunOnceTests.cs
@@ -1,0 +1,158 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Attributes;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Execution;
+
+public class CoreInvokerRunOnceTests
+{
+    public CoreInvokerRunOnceTests()
+    {
+        LifecycleMethodTracker.Reset();
+    }
+
+    [Fact]
+    public async Task RunOnceMethodSetup_AppliedToTwoMethods_InvokesSetupOnlyOnce()
+    {
+        var instanceA = new TestClassWithSharedRunOnceSetup();
+        var instanceB = new TestClassWithSharedRunOnceSetup();
+        var methodA = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodA))!;
+        var methodB = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodB))!;
+
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer());
+        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer());
+
+        await invokerA.MethodSetup(CancellationToken.None);
+        await invokerB.MethodSetup(CancellationToken.None);
+
+        // Setup was claimed by the first invoker; the second skipped it.
+        (instanceA.SetupCalls + instanceB.SetupCalls).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RunOnceFalse_PreservesDefaultBehavior_RunsSetupPerMethod()
+    {
+        var instanceA = new TestClassWithSharedSetup();
+        var instanceB = new TestClassWithSharedSetup();
+        var methodA = typeof(TestClassWithSharedSetup).GetMethod(nameof(TestClassWithSharedSetup.MethodA))!;
+        var methodB = typeof(TestClassWithSharedSetup).GetMethod(nameof(TestClassWithSharedSetup.MethodB))!;
+
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer());
+        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer());
+
+        await invokerA.MethodSetup(CancellationToken.None);
+        await invokerB.MethodSetup(CancellationToken.None);
+
+        instanceA.SetupCalls.ShouldBe(1);
+        instanceB.SetupCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RunOnceMethodTeardown_AppliedToTwoMethods_InvokesTeardownOnlyOnce()
+    {
+        var instanceA = new TestClassWithSharedRunOnceTeardown();
+        var instanceB = new TestClassWithSharedRunOnceTeardown();
+        var methodA = typeof(TestClassWithSharedRunOnceTeardown).GetMethod(nameof(TestClassWithSharedRunOnceTeardown.MethodA))!;
+        var methodB = typeof(TestClassWithSharedRunOnceTeardown).GetMethod(nameof(TestClassWithSharedRunOnceTeardown.MethodB))!;
+
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer());
+        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer());
+
+        await invokerA.MethodTearDown(CancellationToken.None);
+        await invokerB.MethodTearDown(CancellationToken.None);
+
+        (instanceA.TeardownCalls + instanceB.TeardownCalls).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RunOnceIterationSetup_FiresOnlyOncePerExecutorRun()
+    {
+        var instance = new TestClassWithRunOnceIterationSetup();
+        var methodA = typeof(TestClassWithRunOnceIterationSetup).GetMethod(nameof(TestClassWithRunOnceIterationSetup.MethodA))!;
+
+        var invoker = new CoreInvoker(instance, methodA, new PerformanceTimer());
+        await invoker.IterationSetup(CancellationToken.None);
+        await invoker.IterationSetup(CancellationToken.None);
+        await invoker.IterationSetup(CancellationToken.None);
+
+        instance.IterationSetupCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ResetBetweenExecutorRuns_LetsRunOnceFireAgainInNewRun()
+    {
+        var firstRun = new TestClassWithSharedRunOnceSetup();
+        var methodA = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodA))!;
+        var invoker1 = new CoreInvoker(firstRun, methodA, new PerformanceTimer());
+        await invoker1.MethodSetup(CancellationToken.None);
+        firstRun.SetupCalls.ShouldBe(1);
+
+        LifecycleMethodTracker.Reset();
+
+        var secondRun = new TestClassWithSharedRunOnceSetup();
+        var invoker2 = new CoreInvoker(secondRun, methodA, new PerformanceTimer());
+        await invoker2.MethodSetup(CancellationToken.None);
+        secondRun.SetupCalls.ShouldBe(1);
+    }
+
+    [Sailfish]
+    public class TestClassWithSharedRunOnceSetup
+    {
+        public int SetupCalls { get; private set; }
+
+        [SailfishMethodSetup(nameof(MethodA), nameof(MethodB), RunOnce = true)]
+        public void Setup() => SetupCalls++;
+
+        [SailfishMethod]
+        public void MethodA() { }
+
+        [SailfishMethod]
+        public void MethodB() { }
+    }
+
+    [Sailfish]
+    public class TestClassWithSharedSetup
+    {
+        public int SetupCalls { get; private set; }
+
+        [SailfishMethodSetup(nameof(MethodA), nameof(MethodB))]
+        public void Setup() => SetupCalls++;
+
+        [SailfishMethod]
+        public void MethodA() { }
+
+        [SailfishMethod]
+        public void MethodB() { }
+    }
+
+    [Sailfish]
+    public class TestClassWithSharedRunOnceTeardown
+    {
+        public int TeardownCalls { get; private set; }
+
+        [SailfishMethodTeardown(nameof(MethodA), nameof(MethodB), RunOnce = true)]
+        public void Teardown() => TeardownCalls++;
+
+        [SailfishMethod]
+        public void MethodA() { }
+
+        [SailfishMethod]
+        public void MethodB() { }
+    }
+
+    [Sailfish]
+    public class TestClassWithRunOnceIterationSetup
+    {
+        public int IterationSetupCalls { get; private set; }
+
+        [SailfishIterationSetup(RunOnce = true)]
+        public void IterSetup() => IterationSetupCalls++;
+
+        [SailfishMethod]
+        public void MethodA() { }
+    }
+}

--- a/source/Tests.Library/Execution/CoreInvokerRunOnceTests.cs
+++ b/source/Tests.Library/Execution/CoreInvokerRunOnceTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Sailfish.Attributes;
@@ -10,21 +9,17 @@ namespace Tests.Library.Execution;
 
 public class CoreInvokerRunOnceTests
 {
-    public CoreInvokerRunOnceTests()
-    {
-        LifecycleMethodTracker.Reset();
-    }
-
     [Fact]
     public async Task RunOnceMethodSetup_AppliedToTwoMethods_InvokesSetupOnlyOnce()
     {
+        var tracker = new LifecycleMethodTracker();
         var instanceA = new TestClassWithSharedRunOnceSetup();
         var instanceB = new TestClassWithSharedRunOnceSetup();
         var methodA = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodA))!;
         var methodB = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodB))!;
 
-        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer());
-        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer());
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer(), tracker);
+        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer(), tracker);
 
         await invokerA.MethodSetup(CancellationToken.None);
         await invokerB.MethodSetup(CancellationToken.None);
@@ -36,13 +31,14 @@ public class CoreInvokerRunOnceTests
     [Fact]
     public async Task RunOnceFalse_PreservesDefaultBehavior_RunsSetupPerMethod()
     {
+        var tracker = new LifecycleMethodTracker();
         var instanceA = new TestClassWithSharedSetup();
         var instanceB = new TestClassWithSharedSetup();
         var methodA = typeof(TestClassWithSharedSetup).GetMethod(nameof(TestClassWithSharedSetup.MethodA))!;
         var methodB = typeof(TestClassWithSharedSetup).GetMethod(nameof(TestClassWithSharedSetup.MethodB))!;
 
-        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer());
-        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer());
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer(), tracker);
+        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer(), tracker);
 
         await invokerA.MethodSetup(CancellationToken.None);
         await invokerB.MethodSetup(CancellationToken.None);
@@ -54,13 +50,14 @@ public class CoreInvokerRunOnceTests
     [Fact]
     public async Task RunOnceMethodTeardown_AppliedToTwoMethods_InvokesTeardownOnlyOnce()
     {
+        var tracker = new LifecycleMethodTracker();
         var instanceA = new TestClassWithSharedRunOnceTeardown();
         var instanceB = new TestClassWithSharedRunOnceTeardown();
         var methodA = typeof(TestClassWithSharedRunOnceTeardown).GetMethod(nameof(TestClassWithSharedRunOnceTeardown.MethodA))!;
         var methodB = typeof(TestClassWithSharedRunOnceTeardown).GetMethod(nameof(TestClassWithSharedRunOnceTeardown.MethodB))!;
 
-        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer());
-        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer());
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer(), tracker);
+        var invokerB = new CoreInvoker(instanceB, methodB, new PerformanceTimer(), tracker);
 
         await invokerA.MethodTearDown(CancellationToken.None);
         await invokerB.MethodTearDown(CancellationToken.None);
@@ -71,10 +68,11 @@ public class CoreInvokerRunOnceTests
     [Fact]
     public async Task RunOnceIterationSetup_FiresOnlyOncePerExecutorRun()
     {
+        var tracker = new LifecycleMethodTracker();
         var instance = new TestClassWithRunOnceIterationSetup();
         var methodA = typeof(TestClassWithRunOnceIterationSetup).GetMethod(nameof(TestClassWithRunOnceIterationSetup.MethodA))!;
 
-        var invoker = new CoreInvoker(instance, methodA, new PerformanceTimer());
+        var invoker = new CoreInvoker(instance, methodA, new PerformanceTimer(), tracker);
         await invoker.IterationSetup(CancellationToken.None);
         await invoker.IterationSetup(CancellationToken.None);
         await invoker.IterationSetup(CancellationToken.None);
@@ -83,20 +81,63 @@ public class CoreInvokerRunOnceTests
     }
 
     [Fact]
-    public async Task ResetBetweenExecutorRuns_LetsRunOnceFireAgainInNewRun()
+    public async Task RunOnceIterationTeardown_FiresOnlyOncePerExecutorRun()
     {
-        var firstRun = new TestClassWithSharedRunOnceSetup();
+        var tracker = new LifecycleMethodTracker();
+        var instance = new TestClassWithRunOnceIterationTeardown();
+        var methodA = typeof(TestClassWithRunOnceIterationTeardown).GetMethod(nameof(TestClassWithRunOnceIterationTeardown.MethodA))!;
+
+        var invoker = new CoreInvoker(instance, methodA, new PerformanceTimer(), tracker);
+        await invoker.IterationTearDown(CancellationToken.None);
+        await invoker.IterationTearDown(CancellationToken.None);
+        await invoker.IterationTearDown(CancellationToken.None);
+
+        instance.IterationTeardownCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task FreshTrackerPerExecutorRun_LetsRunOnceFireAgainInNewRun()
+    {
         var methodA = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodA))!;
-        var invoker1 = new CoreInvoker(firstRun, methodA, new PerformanceTimer());
+
+        // First "executor run" — its own tracker
+        var firstTracker = new LifecycleMethodTracker();
+        var firstRun = new TestClassWithSharedRunOnceSetup();
+        var invoker1 = new CoreInvoker(firstRun, methodA, new PerformanceTimer(), firstTracker);
         await invoker1.MethodSetup(CancellationToken.None);
         firstRun.SetupCalls.ShouldBe(1);
 
-        LifecycleMethodTracker.Reset();
-
+        // Second "executor run" — fresh tracker, RunOnce fires again
+        var secondTracker = new LifecycleMethodTracker();
         var secondRun = new TestClassWithSharedRunOnceSetup();
-        var invoker2 = new CoreInvoker(secondRun, methodA, new PerformanceTimer());
+        var invoker2 = new CoreInvoker(secondRun, methodA, new PerformanceTimer(), secondTracker);
         await invoker2.MethodSetup(CancellationToken.None);
         secondRun.SetupCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task SeparateTrackers_DoNotInterfere_AcrossConcurrentRuns()
+    {
+        // If two simulated executor runs are in flight at the same time (concurrent VSTest
+        // sessions, overlapping CLI invocations), they must each see a clean tracker —
+        // process-wide static state would have one run silently skipping the other's lifecycle
+        // methods.
+        var trackerA = new LifecycleMethodTracker();
+        var trackerB = new LifecycleMethodTracker();
+
+        var methodA = typeof(TestClassWithSharedRunOnceSetup).GetMethod(nameof(TestClassWithSharedRunOnceSetup.MethodA))!;
+        var instanceA = new TestClassWithSharedRunOnceSetup();
+        var instanceB = new TestClassWithSharedRunOnceSetup();
+
+        var invokerA = new CoreInvoker(instanceA, methodA, new PerformanceTimer(), trackerA);
+        var invokerB = new CoreInvoker(instanceB, methodA, new PerformanceTimer(), trackerB);
+
+        await Task.WhenAll(
+            invokerA.MethodSetup(CancellationToken.None),
+            invokerB.MethodSetup(CancellationToken.None));
+
+        instanceA.SetupCalls.ShouldBe(1);
+        instanceB.SetupCalls.ShouldBe(1);
     }
 
     [Sailfish]
@@ -151,6 +192,18 @@ public class CoreInvokerRunOnceTests
 
         [SailfishIterationSetup(RunOnce = true)]
         public void IterSetup() => IterationSetupCalls++;
+
+        [SailfishMethod]
+        public void MethodA() { }
+    }
+
+    [Sailfish]
+    public class TestClassWithRunOnceIterationTeardown
+    {
+        public int IterationTeardownCalls { get; private set; }
+
+        [SailfishIterationTeardown(RunOnce = true)]
+        public void IterTeardown() => IterationTeardownCalls++;
 
         [SailfishMethod]
         public void MethodA() { }

--- a/source/Tests.Library/Execution/IterationStrategyTests.cs
+++ b/source/Tests.Library/Execution/IterationStrategyTests.cs
@@ -285,7 +285,7 @@ public class IterationStrategyTests
 
     private TestInstanceContainer CreateTestInstanceContainer()
     {
-        var mockCoreInvoker = Substitute.For<CoreInvoker>(new object(), typeof(object).GetMethod("ToString")!, new PerformanceTimer());
+        var mockCoreInvoker = Substitute.For<CoreInvoker>(new object(), typeof(object).GetMethod("ToString")!, new PerformanceTimer(), (LifecycleMethodTracker?)null);
         var mockExecutionSettings = Substitute.For<IExecutionSettings>();
 
         return TestInstanceContainer.CreateTestInstance(

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
@@ -6,6 +6,10 @@ using Xunit;
 
 namespace Tests.TestAdapter;
 
+// Serialize with sibling AdapterRunSettingsLoaderDefaultsTests — both mutate the
+// process-wide current working directory via Directory.SetCurrentDirectory, which races
+// catastrophically under xUnit's default class-parallel execution.
+[Collection("CwdMutatingAdapterRunSettingsLoader")]
 public class AdapterRunSettingsLoaderTests
 {
     [Fact]

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoader_Defaults_Tests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoader_Defaults_Tests.cs
@@ -6,6 +6,10 @@ using Xunit;
 
 namespace Tests.TestAdapter;
 
+// Serialize with sibling AdapterRunSettingsLoaderTests — both mutate the process-wide
+// current working directory via Directory.SetCurrentDirectory, which races catastrophically
+// under xUnit's default class-parallel execution.
+[Collection("CwdMutatingAdapterRunSettingsLoader")]
 public class AdapterRunSettingsLoaderDefaultsTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Adds an opt-in `RunOnce` property to the four inner lifecycle attributes:

- `SailfishMethodSetupAttribute`
- `SailfishMethodTeardownAttribute`
- `SailfishIterationSetupAttribute`
- `SailfishIterationTeardownAttribute`

Default is `false` — existing behavior is preserved. When set to `true`, the lifecycle method fires at most **once per executor run** for the declaring test class, regardless of how many `SailfishMethod`s the attribute applies to.

### Example (from issue #132)

```csharp
[SailfishMethodSetup(nameof(MethodA), nameof(MethodB), RunOnce = true)]
public void Setup() { /* one-shot fixture init shared across A and B */ }

[SailfishMethod] public void MethodA() => ...
[SailfishMethod] public void MethodB() => ...
```

`Setup()` now runs **once** before the first applicable case instead of once per listed method.

### Implementation

- `IInnerLifecycleAttribute` gets a new `bool RunOnce { get; }` member.
- New internal `LifecycleMethodTracker` (a static `ConcurrentDictionary<(Type, MethodInfo), byte>`) provides atomic `TryClaim` semantics. Each `CoreInvoker` checks the tracker before invoking a `RunOnce` lifecycle method.
- `SailFishTestExecutor.Execute` calls `LifecycleMethodTracker.Reset()` at the start of each run so state does not leak across invocations.

Why static state? `CoreInvoker` is constructed per test case (per variant per method), so `RunOnce` requires cross-invoker bookkeeping. The tracker is keyed by `(Type, MethodInfo)` of the lifecycle method, which is naturally unique per declaration.

Closes #132.

## Test plan

- [x] 5 new tests in `CoreInvokerRunOnceTests` cover: method-setup RunOnce, default RunOnce=false preserves old behavior, method-teardown RunOnce, iteration-setup RunOnce, and Reset-between-runs.
- [x] `dotnet test Tests.Library --framework net9.0` — **1175 passing**, 0 failing (was 1170 + 5 new).
- [x] `dotnet test Tests.TestAdapter --framework net9.0` — **546 passing**, 0 failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a RunOnce option for lifecycle methods so setup/teardown/iteration lifecycles can be configured to run at most once per executor run per test class.

* **Bug Fixes**
  * Isolated RunOnce tracking to each executor run to prevent cross-run interference.

* **Tests**
  * Added tests covering RunOnce behavior across method and iteration setups/teardowns, and concurrent runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->