### PR TITLE
Clean up adapter wiring + document Rider setup for test discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Sailfish is a .NET performance testing framework that makes it easy to write, ru
 - [Algorithm Comparisons](#algorithm-comparisons)
 - [Adaptive Sampling](#adaptive-sampling)
 - [Installation](#installation)
+- [IDE setup](#ide-setup)
 - [Outputs and Reporting](#outputs-and-reporting)
 - [Used By](#used-by)
 - [Contributing](#contributing)
@@ -149,6 +150,23 @@ Install via NuGet:
 ```bash
 dotnet add package Sailfish
 ```
+
+## IDE setup
+
+### Visual Studio
+Works out of the box. Reference `Sailfish.TestAdapter` (NuGet or `ProjectReference`) and Test Explorer will discover tests after a build.
+
+### JetBrains Rider
+Rider needs a one-time setting flipped so it engages VSTest discovery for projects that use Sailfish (or any third-party VSTest adapter without a built-in ReSharper provider).
+
+1. `Settings → Build, Execution, Deployment → Unit Testing → VSTest`
+2. Confirm **Enable VSTest adapters support** is on.
+3. Under **Projects with unit tests**, click `+` and add a file mask. Use `*` to opt every project in the solution in (recommended), or a specific name like `*PerformanceTests*` to narrow.
+4. Save → `Build → Rebuild Solution`.
+
+Sailfish tests then appear in the Unit Tests tool window with gutter play-buttons, and parameterized variants nest under their parent `SailfishMethod` (via the `TestCase.Hierarchy` properties the adapter emits).
+
+**Why the mask is needed**: ReSharper has built-in providers for xUnit / NUnit / MSTest only. For other VSTest adapters, it relies on the project being explicitly opted in to VSTest discovery via this mask — without it, ReSharper treats the project as non-test and greys out the run command. See issue [#98](https://github.com/paulegradie/Sailfish/issues/98) for background.
 
 ## Outputs and Reporting
 - N×N method comparison matrices per comparison group

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -25,9 +25,13 @@
 
         Sailfish.TestAdapter.dll is already copied to $(OutputPath) by the default
         ProjectReference copy-local behavior, so we just need to point the runner at it.
+
+        Uses Path.GetFullPath(path, basePath) so a custom $(OutputPath) that's already an
+        absolute path (e.g. CI layouts that point at /tmp/tests or C:\artifacts) is honored
+        as-is; only when $(OutputPath) is relative is it resolved against the project dir.
     -->
     <ItemGroup>
-        <TestAdapterPath Include="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(OutputPath)'))" />
+        <TestAdapterPath Include="$([System.IO.Path]::GetFullPath('$(OutputPath)', '$(MSBuildProjectDirectory)'))" />
     </ItemGroup>
 
     <!-- Exclude the Analyzer ItemGroup if building with Visual Studio -->

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -20,15 +20,14 @@
 
     <!--
         Register the Sailfish test adapter via the modern MSBuild TestAdapterPath ItemGroup.
-        VS Test Explorer is lenient and auto-discovers adapters in the output folder, but
-        Rider/ReSharper drives VSTest via the MSBuild TestAdapterPath items only — without
-        these, Rider greys out 'Run Unit Tests' and shows no discoverable tests.
+        Using an absolute path because some hosts (notably ReSharper / Rider) resolve
+        TestAdapterPath items relative to a working directory other than the project root.
 
         Sailfish.TestAdapter.dll is already copied to $(OutputPath) by the default
         ProjectReference copy-local behavior, so we just need to point the runner at it.
     -->
     <ItemGroup>
-        <TestAdapterPath Include="$(OutputPath)" />
+        <TestAdapterPath Include="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(OutputPath)'))" />
     </ItemGroup>
 
     <!-- Exclude the Analyzer ItemGroup if building with Visual Studio -->

--- a/source/PerformanceTests/PerformanceTests.csproj
+++ b/source/PerformanceTests/PerformanceTests.csproj
@@ -18,33 +18,18 @@
         <ProjectReference Include="..\Sailfish.TestAdapter\Sailfish.TestAdapter.csproj"/>
     </ItemGroup>
 
-    <!-- Ensure the test adapter is available for test discovery -->
-    <Target Name="CopyTestAdapter" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net8.0'">
-        <ItemGroup>
-            <TestAdapterFiles Include="$(MSBuildProjectDirectory)\..\Sailfish.TestAdapter\bin\$(Configuration)\net8.0\Sailfish.TestAdapter.dll" />
-        </ItemGroup>
-        <Copy SourceFiles="@(TestAdapterFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="false" />
-    </Target>
+    <!--
+        Register the Sailfish test adapter via the modern MSBuild TestAdapterPath ItemGroup.
+        VS Test Explorer is lenient and auto-discovers adapters in the output folder, but
+        Rider/ReSharper drives VSTest via the MSBuild TestAdapterPath items only — without
+        these, Rider greys out 'Run Unit Tests' and shows no discoverable tests.
 
-    <Target Name="CopyTestAdapterNet9" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net9.0'">
-        <ItemGroup>
-            <TestAdapterFiles Include="$(MSBuildProjectDirectory)\..\Sailfish.TestAdapter\bin\$(Configuration)\net9.0\Sailfish.TestAdapter.dll" />
-        </ItemGroup>
-        <Copy SourceFiles="@(TestAdapterFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="false" />
-    </Target>
-
-    <Target Name="CopyTestAdapterNet10" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net10.0'">
-        <ItemGroup>
-            <TestAdapterFiles Include="$(MSBuildProjectDirectory)\..\Sailfish.TestAdapter\bin\$(Configuration)\net10.0\Sailfish.TestAdapter.dll" />
-        </ItemGroup>
-        <Copy SourceFiles="@(TestAdapterFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="false" />
-    </Target>
-
-    <!-- Tell VSTest where to find the test adapter -->
-
-    <PropertyGroup>
-        <VSTestAdapterPath>$(OutputPath)</VSTestAdapterPath>
-    </PropertyGroup>
+        Sailfish.TestAdapter.dll is already copied to $(OutputPath) by the default
+        ProjectReference copy-local behavior, so we just need to point the runner at it.
+    -->
+    <ItemGroup>
+        <TestAdapterPath Include="$(OutputPath)" />
+    </ItemGroup>
 
     <!-- Exclude the Analyzer ItemGroup if building with Visual Studio -->
     <!--    Normally this will be a nuget package referece, so no additional properties necessary, .e.g OutputItemType and ReferenceOutperAssembly -->


### PR DESCRIPTION
## Summary

Two related changes that together let fresh contributors get Sailfish tests showing up in **both** Visual Studio and Rider with no manual MSBuild fiddling.

### 1. `PerformanceTests.csproj` cleanup
Replaces the three hand-rolled per-TFM `Copy` targets and the legacy `<VSTestAdapterPath>` property with a single modern `<TestAdapterPath>` ItemGroup, using an absolute path:

\`\`\`xml
<ItemGroup>
    <TestAdapterPath Include=\"\$([System.IO.Path]::GetFullPath('\$(MSBuildProjectDirectory)/\$(OutputPath)'))\" />
</ItemGroup>
\`\`\`

- `<TestAdapterPath>` is the modern MSBuild item honored by \`dotnet test\`, \`dotnet vstest\`, and VS Test Explorer.
- The old Copy targets were redundant — \`ProjectReference\` already copies the adapter DLL to \`\$(OutputPath)\` via default copy-local behavior.
- Absolute path because some hosts (notably ReSharper / Rider) resolve TestAdapterPath items relative to a working directory other than the project root.

### 2. README \"IDE setup\" section
Documents the one-time Rider setting that's required for test discovery: \`Settings → Build, Execution, Deployment → Unit Testing → VSTest → Projects with unit tests\` needs a file mask (\`*\` works) before Rider engages VSTest discovery for Sailfish projects.

This is a ReSharper-side gate, not anything that can be set from MSBuild. Without it, the run-test command is greyed out and the Unit Tests window stays empty even though VSTest itself can find the adapter and tests fine. Discovered the hard way while debugging the issue #98 follow-up.

### What this does **not** include
A ReSharper plugin for first-run zero-config UX. With the documented mask in place, Rider's built-in VSTest fallback handles discovery and execution — a custom \`IUnitTestProvider\` plugin would only give marginal benefits (live source discovery without a build). Tracked but not blocking.

## Verified

- [x] \`dotnet test source/PerformanceTests --list-tests\` discovers all Sailfish tests on the branch.
- [x] \`dotnet vstest PerformanceTests.dll --ListTests\` works.
- [x] \`bin/Debug/<tfm>/Sailfish.TestAdapter.dll\` still present after clean build.
- [x] VS Test Explorer continues to discover tests (user-confirmed).
- [x] Rider with the documented mask configured discovers and runs tests (user-confirmed).

Related: #98 (test-case grouping — see PR #223 for the hierarchy properties that take effect once discovery works).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified test adapter registration in the build system by adopting a standard MSBuild configuration approach, replacing previous framework-specific custom build logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->