### PR TITLE
Fix: single SailfishComparison test reports TestOutcome.None

### DIFF
--- a/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs
@@ -104,9 +104,13 @@ internal class MethodComparisonBatchProcessor
             }
             else
             {
-                _logger.Log(LogLevel.Debug,
-                    "Skipping comparison group '{0}' with insufficient methods: {1}",
-                    group.Key ?? "null", groupMethods.Count);
+                // A single-method comparison group still needs to be published as a regular
+                // pass/fail framework notification — otherwise VSTest/Rider sees TestOutcome.None
+                // and renders "Inconclusive" because FrameworkPublishingProcessor deferred to us.
+                _logger.Log(LogLevel.Information,
+                    "Publishing single-method comparison group '{0}' without comparison enhancement",
+                    group.Key ?? "null");
+                await PublishEnhancedFrameworkNotificationsForGroup(groupMethods, cancellationToken);
             }
         }
     }

--- a/source/Tests.TestAdapter/Queue/MethodComparisonProcessorTests.cs
+++ b/source/Tests.TestAdapter/Queue/MethodComparisonProcessorTests.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using MediatR;
 using NSubstitute;
 using Sailfish.Analysis.SailDiff.Formatting;
+using Sailfish.Execution;
 using Sailfish.Logging;
 using Sailfish.TestAdapter.Execution;
+using Sailfish.TestAdapter.Handlers.FrameworkHandlers;
 using Sailfish.TestAdapter.Queue.Contracts;
 using Sailfish.TestAdapter.Queue.Processors.MethodComparison;
 using Shouldly;
@@ -513,8 +515,15 @@ public class MethodComparisonProcessorTests
     }
 
     [Fact]
-    public async Task MethodComparisonBatchProcessor_ProcessBatch_WithSingleMethod_ShouldSkipComparison()
+    public async Task MethodComparisonBatchProcessor_ProcessBatch_WithSingleMethod_StillPublishesFrameworkNotification()
     {
+        // Regression test for the "TestOutcome.None" bug: when a user runs a single
+        // SailfishComparison method in isolation (e.g., from Rider's test explorer),
+        // FrameworkPublishingProcessor defers to MethodComparisonBatchProcessor for
+        // any message tagged with ComparisonGroup. Previously the batch processor
+        // bailed out for groups with fewer than two methods and never published,
+        // so VSTest/Rider saw TestOutcome.None ("Inconclusive: Outcome value None
+        // is not understood"). The lone test must still be published as pass/fail.
         // Arrange
         var processor = new MethodComparisonBatchProcessor(
             _sailDiff,
@@ -527,10 +536,36 @@ public class MethodComparisonProcessorTests
         // Act
         await processor.ProcessBatch(batch, CancellationToken.None);
 
-        // Assert
-        _logger.Received().Log(LogLevel.Debug,
-            Arg.Is<string>(s => s.Contains("Skipping comparison group")),
-            Arg.Any<object[]>());
+        // Assert: the lone test case was published with a Success status (the helper
+        // builds messages with TestResult.IsSuccess == true by default).
+        await _mediator.Received(1).Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n => n.StatusCode == StatusCode.Success),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MethodComparisonBatchProcessor_ProcessBatch_WithSingleFailedMethod_PublishesFailureNotification()
+    {
+        // Arrange
+        var processor = new MethodComparisonBatchProcessor(
+            _sailDiff,
+            _mediator,
+            _logger,
+            _unifiedFormatter);
+
+        var batch = CreateTestCaseBatch("Group1", new[] { "TestMethod1" });
+        var loneMessage = batch.TestCases.Single();
+        loneMessage.TestResult.IsSuccess = false;
+        loneMessage.TestResult.ExceptionMessage = "boom";
+        loneMessage.TestResult.ExceptionType = "InvalidOperationException";
+
+        // Act
+        await processor.ProcessBatch(batch, CancellationToken.None);
+
+        // Assert: failure propagates as StatusCode.Failure on the framework notification.
+        await _mediator.Received(1).Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n => n.StatusCode == StatusCode.Failure),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Single-method `SailfishComparison` groups now publish a proper pass/fail framework notification instead of dropping it on the floor.
- `FrameworkPublishingProcessor` defers any message tagged with `ComparisonGroup` to `MethodComparisonBatchProcessor`. That processor previously bailed out for groups with `< 2` methods and never published anything — VSTest/Rider then rendered the test as `TestOutcome.None` ("Inconclusive: Outcome value None is not understood").
- The fix publishes singleton groups directly via `PublishEnhancedFrameworkNotificationsForGroup` in `ProcessBatch`, skipping the pairwise SailDiff loop (there's nothing to diff against). The existing `CreateFrameworkNotification` helper already maps `TestResult.IsSuccess` to `StatusCode.Success` / `StatusCode.Failure`, so the lone notification carries the right outcome.
- `ProcessComparisonGroup`'s own `< 2` guard is left in place — the SailDiff loop inside it is meaningless for one test. The fix belongs at the `ProcessBatch` level.

## Why the regression slipped through
The existing `MethodComparisonBatchProcessor_ProcessBatch_WithSingleMethod_ShouldSkipComparison` test only asserted the skip log message — it never checked whether the mediator published. The bug was invisible to it.

It is replaced with a stronger test that asserts the mediator received exactly one `Publish<FrameworkTestCaseEndNotification>` with `StatusCode.Success` (the helper's default), plus a new variant asserting `StatusCode.Failure` when the lone test's `TestResult.IsSuccess` is `false`.

Verified by stashing the production change and rerunning — both new tests fail with "Expected to receive exactly 1 call ... Actually received no matching calls." Re-applying the fix restores green.

## Test plan
- [x] `dotnet build source/Sailfish.sln` — clean
- [x] `dotnet test source/Tests.TestAdapter/Tests.TestAdapter.csproj --filter "FullyQualifiedName~MethodComparisonProcessorTests"` — 60 passed on net9.0 and net10.0
- [x] Confirmed new tests fail against the unpatched `MethodComparisonBatchProcessor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single-method comparisons now properly report test outcomes with pass/fail status instead of being skipped, ensuring complete test result visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->