### PR TITLE
Fix: failed [SailfishComparison] tests publish TestOutcome.None (#229)

### DIFF
--- a/source/Sailfish.TestAdapter/Queue/Processors/FrameworkPublishingProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/FrameworkPublishingProcessor.cs
@@ -313,6 +313,15 @@ public class FrameworkPublishingProcessor : TestCompletionQueueProcessorBase
     /// <returns>True if this is a comparison method, false otherwise.</returns>
     private static bool IsComparisonMethod(TestCompletionQueueMessage message)
     {
+        // A failed [SailfishComparison] test case can never contribute to an N×N
+        // comparison: there are no usable timing samples and no sibling will ever
+        // arrive that "completes" the batch. Treating it as a comparison method
+        // would defer publishing to MethodComparisonBatchProcessor, where it
+        // could get stranded — VSTest/Rider would then see TestOutcome.None
+        // ("Outcome value None is not understood"). Publish the failure here
+        // immediately and let the batch processor handle only successful members.
+        if (!message.TestResult.IsSuccess) return false;
+
         // Check if the message has comparison metadata
         var hasComparisonGroup = message.Metadata.TryGetValue("ComparisonGroup", out var groupObj) &&
                                  groupObj is string group && !string.IsNullOrEmpty(group);

--- a/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs
@@ -79,9 +79,14 @@ internal class MethodComparisonBatchProcessor
                 testCase.TestCaseId, group ?? "null", role ?? "null");
         }
 
-        // Group test cases by comparison group
+        // Group test cases by comparison group. Failed members are excluded:
+        // FrameworkPublishingProcessor already publishes them as Failed (see
+        // its IsComparisonMethod guard), so re-publishing here would emit a
+        // duplicate notification, and a failed case has no usable samples to
+        // contribute to an N×N comparison anyway.
         var comparisonGroups = batch.TestCases
             .Where(HasComparisonMetadata)
+            .Where(tc => tc.TestResult.IsSuccess)
             .GroupBy(ExtractComparisonGroup)
             .Where(g => !string.IsNullOrEmpty(g.Key))
             .ToList();

--- a/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonProcessor.cs
@@ -92,6 +92,20 @@ internal class MethodComparisonProcessor : TestCompletionQueueProcessorBase
 
         if (!string.IsNullOrEmpty(comparisonGroup))
         {
+            // Failed comparison members can never participate in N×N analysis.
+            // Adding them to a batch would either keep the batch incomplete
+            // forever (when their siblings never run, e.g., a failing
+            // [SailfishGlobalSetup]) or pollute the comparison output with
+            // zero-sample data. Leave such messages alone here so that
+            // FrameworkPublishingProcessor publishes them as Failed.
+            if (!message.TestResult.IsSuccess)
+            {
+                Logger.Log(LogLevel.Information,
+                    "Comparison method '{0}' failed - skipping batch processing; framework will publish a Failed outcome",
+                    message.TestCaseId);
+                return;
+            }
+
             Logger.Log(LogLevel.Information,
                 "Received test completion for comparison group '{0}': {1}",
                 comparisonGroup, message.TestCaseId);

--- a/source/Tests.TestAdapter/Queue/FrameworkPublishingProcessorTests.cs
+++ b/source/Tests.TestAdapter/Queue/FrameworkPublishingProcessorTests.cs
@@ -305,6 +305,28 @@ public class FrameworkPublishingProcessorTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ProcessTestCompletion_WithFailedComparisonMethod_ShouldPublishFailureImmediately()
+    {
+        // Regression test for #229: when a [SailfishComparison] member fails
+        // (e.g., because [SailfishGlobalSetup] threw), it must NOT be deferred
+        // to MethodComparisonBatchProcessor. The failed member can never
+        // contribute to an N×N comparison and its sibling may never run, so
+        // the batch would stay incomplete and the IDE would see
+        // TestOutcome.None ("Outcome value None is not understood" in Rider).
+        // Arrange
+        var message = CreateFailedTestMessage();
+        message.Metadata["ComparisonGroup"] = "Group1";
+
+        // Act
+        await _processor.ProcessTestCompletion(message, CancellationToken.None);
+
+        // Assert: published immediately with StatusCode.Failure.
+        await _mediator.Received(1).Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n => n.StatusCode == StatusCode.Failure),
+            Arg.Any<CancellationToken>());
+    }
+
     #endregion
 
     #region Duration Calculation Tests

--- a/source/Tests.TestAdapter/Queue/MethodComparisonProcessorTests.cs
+++ b/source/Tests.TestAdapter/Queue/MethodComparisonProcessorTests.cs
@@ -411,6 +411,27 @@ public class MethodComparisonProcessorTests
         message.Metadata.ShouldNotContainKey("SuppressIndividualOutput");
     }
 
+    [Fact]
+    public async Task ProcessTestCompletion_WithFailedComparisonMethod_ShouldNotSuppressOrBatch()
+    {
+        // Regression test for #229: a failed [SailfishComparison] member must
+        // not be deferred to the batch processor (its sibling may never run
+        // because [SailfishGlobalSetup] failed, leaving the batch
+        // permanently incomplete) — leave the message alone so
+        // FrameworkPublishingProcessor publishes it as Failed.
+        // Arrange
+        var message = CreateTestMessage("TestMethod1", "Group1");
+        message.TestResult.IsSuccess = false;
+        message.TestResult.ExceptionMessage = "simulated setup failure";
+
+        // Act
+        await _processor.ProcessTestCompletion(message, CancellationToken.None);
+
+        // Assert: no suppression marker, no batch lookup.
+        message.Metadata.ShouldNotContainKey("SuppressIndividualOutput");
+        await _batchingService.DidNotReceive().GetBatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
     #endregion
 
     #region MethodComparisonBatchProcessor Tests
@@ -544,8 +565,13 @@ public class MethodComparisonProcessorTests
     }
 
     [Fact]
-    public async Task MethodComparisonBatchProcessor_ProcessBatch_WithSingleFailedMethod_PublishesFailureNotification()
+    public async Task MethodComparisonBatchProcessor_ProcessBatch_SkipsFailedMembers_AvoidsDoublePublish()
     {
+        // Regression test for #229: a failed [SailfishComparison] member is
+        // published by FrameworkPublishingProcessor as Failed (its
+        // IsComparisonMethod guard no longer defers failed cases), so
+        // MethodComparisonBatchProcessor must not also republish it during
+        // batch teardown — that would emit a duplicate framework notification.
         // Arrange
         var processor = new MethodComparisonBatchProcessor(
             _sailDiff,
@@ -562,8 +588,45 @@ public class MethodComparisonProcessorTests
         // Act
         await processor.ProcessBatch(batch, CancellationToken.None);
 
-        // Assert: failure propagates as StatusCode.Failure on the framework notification.
+        // Assert: ProcessBatch must NOT publish anything for a comparison group
+        // whose only member already failed — FrameworkPublishingProcessor owns
+        // the Failed notification in that case.
+        await _mediator.DidNotReceive().Publish(
+            Arg.Any<FrameworkTestCaseEndNotification>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MethodComparisonBatchProcessor_ProcessBatch_MixedFailureAndSuccess_OnlyPublishesSuccessfulMember()
+    {
+        // Regression test for #229: when one member of a comparison group fails
+        // and another succeeds, the failed member is already published by
+        // FrameworkPublishingProcessor. The batch processor should only
+        // publish the surviving successful member (as a single-method group)
+        // and never re-publish the failed one.
+        // Arrange
+        var processor = new MethodComparisonBatchProcessor(
+            _sailDiff,
+            _mediator,
+            _logger,
+            _unifiedFormatter);
+
+        var batch = CreateTestCaseBatch("Group1", new[] { "FailingMethod", "PassingMethod" });
+        var failingMessage = batch.TestCases.Single(tc => tc.TestCaseId.EndsWith("FailingMethod"));
+        failingMessage.TestResult.IsSuccess = false;
+        failingMessage.TestResult.ExceptionMessage = "boom";
+        failingMessage.TestResult.ExceptionType = "InvalidOperationException";
+
+        // Act
+        await processor.ProcessBatch(batch, CancellationToken.None);
+
+        // Assert: exactly one notification, for the passing member, with Success.
         await _mediator.Received(1).Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n =>
+                n.StatusCode == StatusCode.Success &&
+                n.TestCase.FullyQualifiedName.EndsWith("PassingMethod")),
+            Arg.Any<CancellationToken>());
+        await _mediator.DidNotReceive().Publish(
             Arg.Is<FrameworkTestCaseEndNotification>(n => n.StatusCode == StatusCode.Failure),
             Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## Summary

Fixes #229. A `[SailfishMethod]` decorated with `[SailfishComparison]` that failed (e.g., because `[SailfishGlobalSetup]` threw) was reported to VSTest/Rider with `TestOutcome.None`, which Rider rejects with "Outcome value None is not understood."

`FrameworkPublishingProcessor` deferred any message carrying `ComparisonGroup` metadata to `MethodComparisonBatchProcessor`. When the test had failed the batch could never complete (no usable samples; the sibling might not even run), so the framework notification was never published.

## What changed

- **`FrameworkPublishingProcessor.IsComparisonMethod`** returns `false` for failed messages, so they publish immediately with `StatusCode.Failure` instead of being deferred.
- **`MethodComparisonProcessor.ProcessTestCompletionCore`** early-returns for failed comparison messages — no `SuppressIndividualOutput` flag, no batch lookup.
- **`MethodComparisonBatchProcessor.ProcessBatch`** filters failed members out of comparison groups at teardown, preventing a duplicate notification if a failed message reached the batch before the processors ran.

## Tests

- `FrameworkPublishingProcessorTests.ProcessTestCompletion_WithFailedComparisonMethod_ShouldPublishFailureImmediately`
- `MethodComparisonProcessorTests.ProcessTestCompletion_WithFailedComparisonMethod_ShouldNotSuppressOrBatch`
- `MethodComparisonProcessorTests.MethodComparisonBatchProcessor_ProcessBatch_SkipsFailedMembers_AvoidsDoublePublish` (replaces the prior single-failed-method test from #228, since publishing now happens upstream)
- `MethodComparisonProcessorTests.MethodComparisonBatchProcessor_ProcessBatch_MixedFailureAndSuccess_OnlyPublishesSuccessfulMember`

Full Tests.TestAdapter (552) and Tests.Library (1177) suites pass on net9.0 and net10.0.

## Test plan

- [ ] Repro from issue runs in Rider, JetBrains ReSharper runner, and `dotnet test` — failing case reports `Failed` with the original exception message in all three.
- [ ] Existing passing comparison runs still emit the consolidated markdown / CSV with the N×N matrix unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed comparison test methods now publish immediately to VSTest/Rider instead of being deferred, preventing unrecognized test outcomes.

* **Tests**
  * Added regression tests to verify failed comparison members are handled correctly and not republished during batch processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->