### PR TITLE
Fix: align comparison batch readiness check with success-only filter

### DIFF
--- a/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonProcessor.cs
@@ -211,15 +211,22 @@ internal class MethodComparisonProcessor : TestCompletionQueueProcessorBase
                 return;
             }
 
-            // Check if the batch has multiple methods for comparison
+            // Check if the batch has enough SUCCESSFUL methods for comparison.
+            // Failed members must be excluded from the count: MethodComparisonBatchProcessor
+            // filters them out before doing N×N, so counting them here would let a single
+            // surviving sibling trigger ProcessBatch early (publishing it as an unenhanced
+            // single-method group), only to publish it a SECOND time once the next sibling
+            // arrives and the group actually runs the comparison. See issue #229
+            // and PR #230 follow-up.
             var comparisonMethods = batch.TestCases
                 .Where(tc => !string.IsNullOrEmpty(ExtractComparisonGroup(tc)))
+                .Where(tc => tc.TestResult.IsSuccess)
                 .ToList();
 
             if (comparisonMethods.Count >= 2)
             {
                 Logger.Log(LogLevel.Information,
-                    "Comparison batch '{0}' is complete with {1} methods. Processing comparisons...",
+                    "Comparison batch '{0}' is complete with {1} successful methods. Processing comparisons...",
                     batchId, comparisonMethods.Count);
 
                 // Process the complete batch
@@ -231,7 +238,7 @@ internal class MethodComparisonProcessor : TestCompletionQueueProcessorBase
             else
             {
                 Logger.Log(LogLevel.Debug,
-                    "Comparison batch '{0}' has insufficient methods for comparison: {1} methods",
+                    "Comparison batch '{0}' has insufficient successful methods for comparison: {1} methods",
                     batchId, comparisonMethods.Count);
             }
         }

--- a/source/Tests.TestAdapter/Queue/MethodComparisonProcessorTests.cs
+++ b/source/Tests.TestAdapter/Queue/MethodComparisonProcessorTests.cs
@@ -336,7 +336,7 @@ public class MethodComparisonProcessorTests
 
         // Assert
         _logger.Received().Log(LogLevel.Debug,
-            Arg.Is<string>(s => s.Contains("insufficient methods")),
+            Arg.Is<string>(s => s.Contains("insufficient successful methods")),
             Arg.Any<object[]>());
     }
 
@@ -430,6 +430,99 @@ public class MethodComparisonProcessorTests
         // Assert: no suppression marker, no batch lookup.
         message.Metadata.ShouldNotContainKey("SuppressIndividualOutput");
         await _batchingService.DidNotReceive().GetBatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessTestCompletion_WithFailedSiblingInBatch_ShouldNotTriggerEarlyProcessing()
+    {
+        // Regression test for PR #230 follow-up: when one member of a
+        // comparison group failed and only ONE successful sibling has arrived
+        // so far, the batch is NOT ready. Previously CheckAndProcessCompleteBatch
+        // counted the failed member toward the "ready when >= 2" threshold,
+        // so the single survivor fired ProcessBatch early; the IsSuccess
+        // filter inside ProcessBatch then collapsed the group to one method,
+        // publishing the survivor as an unenhanced single-method result.
+        // When the LATER successful sibling arrived, ProcessBatch ran again
+        // and republished the same survivor — now with comparison output —
+        // producing a duplicate framework notification. Counting only
+        // successful members in the readiness check prevents the early fire.
+        // Arrange: batch already contains a failed member; a successful one
+        // is about to arrive.
+        var failed = CreateTestMessage("FailedMethod", "Group1");
+        failed.TestResult.IsSuccess = false;
+        failed.TestResult.ExceptionMessage = "boom";
+
+        var passing = CreateTestMessage("PassingMethod", "Group1");
+
+        var batch = new TestCaseBatch
+        {
+            BatchId = "Comparison_TestClass1_Group1",
+            TestCases = new List<TestCompletionQueueMessage> { failed, passing },
+            Status = BatchStatus.Pending
+        };
+        _batchingService.GetBatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(batch);
+
+        // Act
+        await _processor.ProcessTestCompletion(passing, CancellationToken.None);
+
+        // Assert: no early framework notification — ProcessBatch did not run,
+        // because there is still only one successful member in the group.
+        await _mediator.DidNotReceive().Publish(
+            Arg.Any<FrameworkTestCaseEndNotification>(),
+            Arg.Any<CancellationToken>());
+        _logger.Received().Log(LogLevel.Debug,
+            Arg.Is<string>(s => s.Contains("insufficient successful methods")),
+            Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public async Task ProcessTestCompletion_WithFailedSiblingAndTwoSurvivors_FiresOnceWithComparison()
+    {
+        // Companion to the test above: with a failed sibling already buffered
+        // and TWO successful members in the batch, the comparison group is
+        // ready and ProcessBatch should run exactly once. The failed member
+        // is filtered out by ProcessBatch, and the two survivors get a single
+        // N×N comparison publish — never an "unenhanced then enhanced"
+        // double publish on the first survivor.
+        // Arrange
+        var failed = CreateTestMessage("FailedMethod", "Group1");
+        failed.TestResult.IsSuccess = false;
+        failed.TestResult.ExceptionMessage = "boom";
+
+        var survivor1 = CreateTestMessage("Survivor1", "Group1");
+        var survivor2 = CreateTestMessage("Survivor2", "Group1");
+
+        var batch = new TestCaseBatch
+        {
+            BatchId = "Comparison_TestClass1_Group1",
+            TestCases = new List<TestCompletionQueueMessage> { failed, survivor1, survivor2 },
+            Status = BatchStatus.Pending
+        };
+        _batchingService.GetBatchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(batch);
+
+        // Act: the second survivor flows through the processor, triggering
+        // the comparison once both successful members are present.
+        await _processor.ProcessTestCompletion(survivor2, CancellationToken.None);
+
+        // Assert: each survivor was published exactly once, and the failed
+        // member was not republished here (FrameworkPublishingProcessor
+        // already published it as Failed).
+        await _mediator.Received(1).Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n =>
+                n.TestCase.FullyQualifiedName.EndsWith("Survivor1") &&
+                n.StatusCode == StatusCode.Success),
+            Arg.Any<CancellationToken>());
+        await _mediator.Received(1).Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n =>
+                n.TestCase.FullyQualifiedName.EndsWith("Survivor2") &&
+                n.StatusCode == StatusCode.Success),
+            Arg.Any<CancellationToken>());
+        await _mediator.DidNotReceive().Publish(
+            Arg.Is<FrameworkTestCaseEndNotification>(n =>
+                n.TestCase.FullyQualifiedName.EndsWith("FailedMethod")),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Follow-up to #230. The Codex reviewer on that PR flagged a real edge case I missed: in a comparison group where one member fails and two siblings succeed, the first survivor would get published twice — once as an unenhanced single-method result, then again with comparison output.

## Trace

Group of 3 methods `[A, B, C]`, A fails (via a code path that produces a failed `TestCaseCompletedNotification` — e.g., `SailfishMethod` body throws), B and C succeed:

1. **A fails.** `FrameworkPublishingProcessor` publishes it as Failed ✓. `MethodComparisonProcessor` early-returns ✓. A is still in the batch via `AddTestCaseToBatchAsync`.
2. **B succeeds.** `MethodComparisonProcessor.CheckAndProcessCompleteBatch` sees `[A, B]` — both carry `ComparisonGroup`, count = 2 — and fires `ProcessBatch` early. `ProcessBatch`'s `IsSuccess` filter (from #230) strips A, leaving `[B]`; the single-method path publishes B as Success without comparison output.
3. **C succeeds.** `CheckAndProcessCompleteBatch` sees `[A, B, C]`, count = 3, fires again. Filter yields `[B, C]`, N×N runs, and **B is published a second time** with comparison output.

The fix is one line: apply the same `IsSuccess` filter to the readiness check so the threshold and the filter agree. A comparison group is "ready" only once it has ≥2 *successful* members.

## What changed

- **`MethodComparisonProcessor.CheckAndProcessCompleteBatch`** now filters by `TestResult.IsSuccess` when counting comparison methods, matching what `ProcessBatch` itself does. Log messages updated to reflect "successful methods."

## Tests

- New: `ProcessTestCompletion_WithFailedSiblingInBatch_ShouldNotTriggerEarlyProcessing` — verifies that when only one of two members succeeded so far, no framework notification is emitted and the debug log indicates the batch is not ready. Confirmed to **fail without the fix** and pass with it.
- New: `ProcessTestCompletion_WithFailedSiblingAndTwoSurvivors_FiresOnceWithComparison` — two survivors plus one failed member: ProcessBatch runs exactly once, each survivor publishes exactly once, failed member is not republished here.
- Updated: `ProcessTestCompletion_WithInsufficientMethodsForComparison_ShouldLogDebug` — asserts the new "insufficient successful methods" wording.

554 / 554 Tests.TestAdapter pass on net9.0 and net10.0.

## Credit

Spotted by [chatgpt-codex-connector on #230](https://github.com/paulegradie/Sailfish/pull/230#discussion_r3315187023).

## Test plan

- [ ] A 3-method comparison group where one member throws inside the `SailfishMethod` body publishes each surviving member exactly once.
- [ ] Existing 2-method comparison runs still emit a single N×N comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)