### PR TITLE
Docs: audit pass for accuracy against current source

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,29 +100,19 @@ Note: Global settings act as defaults/overrides and can be combined with attribu
 ## Outlier Handling (defaults + opt‑in)
 By default, Sailfish removes both upper and lower outliers (Tukey fences) to preserve historical behavior.
 
-To opt into configurable outlier handling per run, enable the flag on ExecutionSettings and choose a strategy:
+To opt into configurable outlier handling, set the flag on the `[Sailfish]` attribute (per class) or on `RunSettingsBuilder` (globally).
+
+Per class:
 
 ````csharp
-var settings = new ExecutionSettings(asCsv: false, asConsole: true, asMarkdown: true, sampleSize: 20, numWarmupIterations: 0)
-{
+[Sailfish(
     UseConfigurableOutlierDetection = true,
     OutlierStrategy = OutlierStrategy.RemoveUpper // or RemoveLower, RemoveAll, DontRemove, Adaptive
-};
-
-// When converting programmatically
-var result = PerformanceRunResult.ConvertFromPerfTimer(testCaseId, performanceTimer, settings);
+)]
+public class MyTest { }
 ````
 
-- Legacy default (no behavior change): UseConfigurableOutlierDetection = false → RemoveAll
-- Strategies:
-  - RemoveUpper: remove only upper-fence outliers
-  - RemoveLower: remove only lower-fence outliers
-  - RemoveAll: remove both sides (legacy behavior)
-  - DontRemove: keep all data points, still reporting detected outliers
-  - Adaptive: choose based on which side(s) have detected outliers
-
-
-Global configuration for an entire run via RunSettingsBuilder:
+Globally (overrides per-class values):
 
 ````csharp
 var run = RunSettingsBuilder.CreateBuilder()
@@ -130,7 +120,13 @@ var run = RunSettingsBuilder.CreateBuilder()
     .Build();
 ````
 
-Note: Attribute-level knobs for outlier strategy are not yet exposed; programmatic configuration is available for advanced scenarios and runners that surface ExecutionSettings.
+- Legacy default (no behavior change): `UseConfigurableOutlierDetection = false` → `RemoveAll`
+- Strategies:
+  - `RemoveUpper`: remove only upper-fence outliers
+  - `RemoveLower`: remove only lower-fence outliers
+  - `RemoveAll`: remove both sides (legacy behavior)
+  - `DontRemove`: keep all data points, still reporting detected outliers
+  - `Adaptive`: choose based on which side(s) have detected outliers
 
 ## Reproducible Run Order (Seed)
 Set a seed to make run order deterministic across test classes, methods, and variable sets:
@@ -145,10 +141,17 @@ var run = RunSettingsBuilder.CreateBuilder()
 - The seed is surfaced in the Markdown header and in the Reproducibility Manifest
 
 ## Installation
+
+Requires **.NET 9** or **.NET 10**.
+
 Install via NuGet:
 
 ```bash
+# For a class-library / programmatic runner
 dotnet add package Sailfish
+
+# For tests that should be discovered by Visual Studio / Rider Test Explorer
+dotnet add package Sailfish.TestAdapter
 ```
 
 ## IDE setup
@@ -188,4 +191,4 @@ See the full documentation for output details and examples: https://paulgradie.c
 Contributions are welcome! Feel free to open issues and pull requests.
 
 ## License
-This project is licensed. See the LICENSE file in the repository for details.
+Sailfish is released under the [MIT license](LICENSE).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
-﻿## What's Changed in vNEXT_VERSION
+﻿## What's Changed in v0.0.117
+
+- Fix: failed `[SailfishComparison]` members now publish `TestOutcome.Failed` instead of `TestOutcome.None`, so IDE Test Explorer surfaces the exception and stack trace correctly (#228, #230)
+- Fix: comparison batch readiness no longer waits on members that failed — single-survivor groups complete cleanly and N×N matrices are computed across the surviving members only (#231)
+- Fix: a single `[SailfishComparison]` test (no siblings) now reports its real outcome rather than `TestOutcome.None`
+- New: `[SailfishMethodSetup]` / `[SailfishMethodTeardown]` gain a `RunOnce` flag — invoke a setup/teardown at most once per executor run for the declaring class, even when `MethodNames` lists multiple methods (#224)
+- New: `SailfishPreset` recipes (`Default` / `Tight` / `Relaxed`) — `RunSettingsBuilder.WithPreset(SailfishPreset.Tight)` seeds adaptive sampling, outlier handling, and SailDiff defaults in one call; explicit `WithGlobalX` / `WithSailDiff` calls win over the preset, and `WithPreset` itself is last-wins when called multiple times (#218, #219)
+- Build: drop `net8.0`; Sailfish, `Sailfish.TestAdapter`, and `Sailfish.Analyzers` now target `net9.0` and `net10.0` only (#226)
+- Rider discovery: emit `TestCase.Hierarchy` + `ManagedType`/`ManagedMethod` properties and honor absolute `OutputPath` in `TestAdapterPath` so parameterized variants nest correctly under their parent method (#223, #225). Includes a documented one-time VSTest opt-in.
+- TestAdapter robustness: `AdapterRunSettingsLoader` no longer silently swallows exceptions when `.sailfish.json` is malformed; failures surface as `TestClassInstantiationException` (#222).
+
+## v0.0.116 and earlier
 - New: NxN Method Comparisons rigor + CSV parity
   - Test Adapter and session markdown: NxN comparisons per group with Benjamini–Hochberg FDR–adjusted q-values and 95% ratio confidence intervals (computed on the log scale)
   - CSV session output updated to include: ComparisonGroup, Method1, Method2, Mean1, Mean2, Ratio, CI95_Lower, CI95_Upper, q_value, Label, ChangeDescription (legacy column retained for backward compatibility)

--- a/site/src/pages/docs/0/installation.md
+++ b/site/src/pages/docs/0/installation.md
@@ -1,8 +1,19 @@
 ---
 title: Installation
 ---
-Packages are available on Nuget:
 
- - [Sailfish](https://www.nuget.org/packages/Sailfish/)
- - [Sailfish.TestAdapter](https://www.nuget.org/packages/Sailfish.TestAdapter/)
- - [Sailfish.Analyzers](https://www.nuget.org/packages/Sailfish.Analyzers/)
+Sailfish targets **.NET 9** and **.NET 10**. Older runtimes are not supported.
+
+Packages are available on NuGet:
+
+ - [Sailfish](https://www.nuget.org/packages/Sailfish/) — the core runner, used when you embed Sailfish in a console app or library.
+ - [Sailfish.TestAdapter](https://www.nuget.org/packages/Sailfish.TestAdapter/) — the VSTest adapter; install this in a test project so Visual Studio / Rider Test Explorer discovers `[Sailfish]` classes.
+ - [Sailfish.Analyzers](https://www.nuget.org/packages/Sailfish.Analyzers/) — Roslyn analyzers (e.g. SF1001/SF1002/SF1003) that catch dead-code-elimination hazards. Pulled in transitively by the core package.
+
+```bash
+# Class library / programmatic runner
+dotnet add package Sailfish
+
+# Test project discovered by VSTest
+dotnet add package Sailfish.TestAdapter
+```

--- a/site/src/pages/docs/0/quick-start.md
+++ b/site/src/pages/docs/0/quick-start.md
@@ -16,6 +16,8 @@ public class Example
 {
     private readonly IClient client;
 
+    // SailfishVariable accepts an explicit list of values — this produces two runs (N=1, N=10).
+    // For an inclusive range with a step, use [SailfishRangeVariable(start, count, step)].
     [SailfishVariable(1, 10)]
     public int N { get; set; }
 
@@ -83,9 +85,9 @@ public class RegistrationProvider : IProvideARegistrationCallback
 {
     public async Task RegisterAsync(
         ContainerBuilder builder,
-        CancellationToken ct)
+        CancellationToken cancellationToken = default)
     {
-       var typeInstance = await MyClientFactory.Create(ct);
+       var typeInstance = await MyClientFactory.Create(cancellationToken);
        builder.Register(_ => typeInstance).As<IClient>();
     }
 }
@@ -147,15 +149,12 @@ Outliers Removed: 3
 
 When using `[WriteToMarkdown]` or `[WriteToCsv]`, consolidated files are generated:
 
-**Markdown**: `TestSession_abc12345_Results_20250803_103000.md`
-- Session summary and metadata
-- Individual test results
-- N×N comparison matrices
-- Statistical analysis
+**Markdown**: `TestSession_abc12345_MethodComparisons_2025-08-03_10-30-00.md`
+- Session header (Generated, Session ID, Total Test Classes, Total Test Cases)
+- Per‑group comparison sections with N×N matrices
+- Per‑class detailed results table (Method, Mean, Median, Sample Size, Status)
 
 **CSV**: `TestSession_abc12345_Results_20250803_103000.csv`
 - Excel-friendly format
-- Session metadata
-- Individual test results
-- Method comparison data
-- Performance ratios and change descriptions
+- Individual test results (TestClass, TestMethod, MeanTime, MedianTime, StdDev, SampleSize, ComparisonGroup, Status)
+- Pairwise comparison rows with ratios, 95% CI, q-values (BH-FDR), and labels

--- a/site/src/pages/docs/0/when-to-use-sailfish.md
+++ b/site/src/pages/docs/0/when-to-use-sailfish.md
@@ -4,7 +4,7 @@ title: When should I use Sailfish?
 
 Benchmarking software performance is kind of like measuring the size of objects in the universe. Sometimes you need to measure very quick things (or small things like atoms), and other times you'll need to measure very slow things (or big things, like stars).
 
-The same can be said for benchmarking. Sometimes you need to measure extremely quick things - like an addtion operation that completes in nanoseconds. Other times you'll be measuring relatively slow things, like an API request that return in over milliseconds.
+The same can be said for benchmarking. Sometimes you need to measure extremely quick things — like an addition operation that completes in nanoseconds. Other times you'll be measuring relatively slow things, like an API request that returns in milliseconds.
 
 **Sailfish is the tool to reach for** when you need a library that can:
 
@@ -18,7 +18,7 @@ The same can be said for benchmarking. Sometimes you need to measure extremely q
 
  - **runs in process**, so you can debug your tests without attaching to an external process
 
- - **has a test adapter** that you can install to make salefish tests behave like NUnit or xUnit in the IDE
+ - **has a test adapter** that you can install to make Sailfish tests behave like NUnit or xUnit in the IDE
 
  - **performs statistical analysis and predictive modelling**, leveraging outlier detection and distribution testing to estimate complexity
 

--- a/site/src/pages/docs/1/csv-output.md
+++ b/site/src/pages/docs/1/csv-output.md
@@ -30,30 +30,16 @@ public class PerformanceTest
 
 ## CSV Structure
 
-The generated CSV files use a multi-section format with clear organization:
+The generated CSV file uses a two-section format. Each section starts with a `#`-prefixed comment header.
 
-### Section 1: Session Metadata
-
-```csv
-# Session Metadata
-SessionId,Timestamp,TotalClasses,TotalTests
-abc12345,2025-08-03T10:30:00Z,1,6
-```
-
-**Fields:**
-- **SessionId**: Unique identifier for the test session
-- **Timestamp**: When the test session completed (UTC)
-- **TotalClasses**: Number of test classes with `[WriteToCsv]` in the session
-- **TotalTests**: Total number of test methods executed
-
-### Section 2: Individual Test Results
+### Section 1: Individual Test Results
 
 ```csv
 # Individual Test Results
-TestClass,TestMethod,MeanTime,MedianTime,StdDev,SampleSize,ComparisonGroup,Status,CI95_MOE,CI99_MOE
-PerformanceTest,BubbleSort,45.200,44.100,3.100,100,Algorithms,Success,1.2345,1.6789
-PerformanceTest,QuickSort,2.100,2.000,0.300,100,Algorithms,Success,0.1234,0.2345
-PerformanceTest,RegularMethod,1.000,1.000,0.100,100,,Success,0.0500,0.0800
+TestClass,TestMethod,MeanTime,MedianTime,StdDev,SampleSize,ComparisonGroup,Status
+PerformanceTest,BubbleSort,45.200,44.100,3.100,100,Algorithms,Success
+PerformanceTest,QuickSort,2.100,2.000,0.300,100,Algorithms,Success
+PerformanceTest,RegularMethod,1.000,1.000,0.100,100,,Success
 ```
 
 **Fields:**
@@ -63,13 +49,14 @@ PerformanceTest,RegularMethod,1.000,1.000,0.100,100,,Success,0.0500,0.0800
 - **MedianTime**: Median execution time in milliseconds
 - **StdDev**: Standard deviation of execution times
 - **SampleSize**: Number of iterations executed
-- **ComparisonGroup**: Comparison group name (if using `[SailfishComparison]`)
-- **Status**: Test execution status (Success/Failed)
+- **ComparisonGroup**: Comparison group name (if using `[SailfishComparison]`); empty for ungrouped methods
+- **Status**: Test execution status (`Success` / `Failed`)
 
-- **CI95_MOE**: Margin of error (ms) at 95% confidence; computed using Student’s t distribution and standard error of the mean. Precision is adaptively formatted in output displays; CSV stores numeric values.
-- **CI99_MOE**: Margin of error (ms) at 99% confidence; computed using Student’s t distribution and standard error of the mean. Precision is adaptively formatted in output displays; CSV stores numeric values.
+{% callout title="Where are CI95_MOE / CI99_MOE?" type="note" %}
+The session CSV intentionally keeps the per-test row narrow. The CI95 / CI99 margin-of-error columns are emitted in the **per-class tracking CSV** (next to the tracking JSON used by SailDiff) and surfaced in the [Reproducibility Manifest](/docs/1/reproducibility-manifest).
+{% /callout %}
 
-### Section 3: Method Comparisons
+### Section 2: Method Comparisons
 
 ```csv
 # Method Comparisons

--- a/site/src/pages/docs/1/environment-health.md
+++ b/site/src/pages/docs/1/environment-health.md
@@ -22,10 +22,10 @@ The current set of checks includes:
 - JIT (Tiered/OSR) — reports TieredCompilation, QuickJit, QuickJitForLoops, On-Stack Replacement flags; recommend enabling Tiered JIT for representative steady-state performance
 - Process Priority (recommend AboveNormal/High)
 - GC Mode (recommend Server GC)
-- CPU Affinity (recommend pinning to 1 core for microbenchmarks)
+- CPU Affinity (recommend pinning to 1 core for microbenchmarks). Reported as `Unsupported` on macOS.
 - High‑Resolution Timer availability + Sleep/Delay granularity check
-- Power Plan (recommend High Performance)
-- Background CPU load (process)
+- Power Plan / Power Management — on Windows the entry is `Power Plan` (parses `powercfg /getactivescheme`); on macOS it appears as `Power Management` and recommends disabling App Nap + Energy Saver
+- Background CPU (current process's CPU usage as a proxy)
 
 Each check contributes to the health score and may include a brief recommendation.
 
@@ -45,7 +45,7 @@ Sailfish Environment Health: 87/100 (Excellent)
  - CPU Affinity: Warn (All cores) — Pin to 1 core to minimize cross-core jitter
  - Timer: Pass (High‑resolution timer; Sleep(1) median ≈ 15.6 ms)
  - Power Plan: Pass (High performance)
- - Background CPU (process): Pass (1%)
+ - Background CPU: Pass (1%)
 ```
 ## Timer granularity and short sleeps
 

--- a/site/src/pages/docs/1/markdown-output.md
+++ b/site/src/pages/docs/1/markdown-output.md
@@ -30,58 +30,50 @@ public class PerformanceTest
 
 ## Markdown Structure
 
-The generated markdown files use a well-organized, multi-section format:
+The session-consolidated markdown file is organized as follows:
 
-### Section 1: Session Metadata
+### Section 1: Session Header
 
 ```markdown
-# Performance Test Results
+# 📊 Test Session Results
+
+**Generated:** 2025-08-03 10:30:00 UTC
 **Session ID:** abc12345
-**Timestamp:** 2025-08-03T10:30:00Z
-**Total Classes:** 1
-**Total Tests:** 3
+**Total Test Classes:** 1
+**Total Test Cases:** 3
 ```
 
 **Fields:**
+- **Generated**: When the test session completed (UTC)
 - **Session ID**: Unique identifier for the test session
-- **Timestamp**: When the test session completed (UTC)
-- **Total Classes**: Number of test classes with `[WriteToMarkdown]` in the session
-- **Total Tests**: Total number of test methods executed
+- **Total Test Classes**: Number of test classes with `[WriteToMarkdown]` in the session
+- **Total Test Cases**: Total number of test cases (methods × variable combinations) executed
 
-### Section 2: Individual Test Results
+The header is followed by optional `## 🏥 Environment Health Check` and `## 🔁 Reproducibility Summary` sections — see below.
 
-#### PerformanceTest
+### Section 2: Per-Group Comparison Sections
 
-| Method | Mean (ms) | Median (ms) | StdDev (N=100) | CI95 MOE | CI99 MOE | Status |
-|--------|-----------|-------------|----------------|----------|----------|--------|
-| BubbleSort | 45.2000 | 44.1000 | 3.1000 | ±1.2345 | ±1.6789 | ✅ Success |
-| QuickSort | 2.1000 | 2.0000 | 0.3000 | ±0.1234 | ±0.2345 | ✅ Success |
-| RegularMethod | 1.0000 | 1.0000 | 0.1000 | ±0.0500 | ±0.0800 | ✅ Success |
+For each `[SailfishComparison]` group with at least two methods, the file emits an `## 🔬 Comparison Group: {GroupName}` section containing:
 
-**Columns:**
-- **Method**: Name of the test method
-- **Mean (ms)**: Average execution time in milliseconds
-- **Median (ms)**: Median execution time in milliseconds
-- **StdDev (N=X)**: Standard deviation with sample size indicator
-- **CI95 MOE**: Margin of error at 95% confidence (±ms)
-- **CI99 MOE**: Margin of error at 99% confidence (±ms)
-- **Status**: Test execution status with emoji indicator
+- A `### Performance Comparison Matrix` — the N×N matrix with ratios (col / row), 95% ratio CIs, and BH-FDR q-values.
+- A `### Detailed Results` table:
 
-### Section 3: Method Comparison Matrices
-
-#### Comparison Group: Algorithms
-
-| Method 1 | Method 2 | Mean 1 (ms) | Mean 2 (ms) | Ratio | 95% CI | q-value (FDR) | Label |
-|----------|----------|-------------|-------------|-------|--------|----------------|-------|
-| BubbleSort | QuickSort | 45.2000 | 2.1000 | 21.5 | [18.3, 24.9] | 0.000 | Slower |
+```markdown
+| Method | Mean Time | Median Time | Sample Size | Status |
+|--------|-----------|-------------|-------------|--------|
+| BubbleSort | 45.200ms | 44.100ms | 100 | ✅ Success |
+| QuickSort | 2.100ms | 2.000ms | 100 | ✅ Success |
+```
 
 **Columns:**
-- **Method 1 / Method 2**: Methods being compared
-- **Mean 1 / Mean 2**: Mean execution times for each method
-- **Ratio**: `Mean1 / Mean2` (unitless). Values > 1 indicate Method 1 is slower; values < 1 indicate it is faster.
-- **95% CI**: Confidence interval for the ratio computed on the log scale. If the interval crosses 1.0, the label is "Similar".
-- **q-value (FDR)**: Benjamini–Hochberg adjusted p-value accounting for multiple comparisons within the group.
-- **Label**: One of Improved, Similar, or Slower (consolidated outputs use "Slower" rather than "Regressed").
+- **Method**: Test case display name
+- **Mean Time / Median Time**: Average and median execution time (ms, 3 decimal places)
+- **Sample Size**: Number of iterations after outlier filtering
+- **Status**: ✅ Success or ❌ Failed
+
+### Section 3: Individual Test Results
+
+Methods that aren't part of a comparison group are grouped under `## 📊 Individual Test Results` using the same five-column table.
 
 ## Session-Based Consolidation
 
@@ -92,7 +84,7 @@ Markdown files use **session-based consolidation**, meaning:
 - **Unique naming**: Files use session IDs and timestamps to prevent conflicts
 - **Complete data**: All test results from the entire session are included
 
-**Example filename**: `TestSession_abc12345_Results_20250803_103000.md`
+**Example filename**: `TestSession_abc12345_MethodComparisons_2025-08-03_10-30-00.md`
 
 ### 🏥 Environment Health Section (when enabled)
 
@@ -147,21 +139,7 @@ See [latest performance results](./TestSession_abc12345_Results_20250803_103000.
 
 ### Multiple Comparison Groups
 
-When you have multiple comparison groups, each generates its own comparison matrix:
-
-#### Comparison Group: StringOperations
-
-| Method 1 | Method 2 | Mean 1 (ms) | Mean 2 (ms) | Ratio | 95% CI | q-value (FDR) | Label |
-|----------|----------|-------------|-------------|-------|--------|----------------|-------|
-| StringConcat | StringBuilder | 15.2000 | 8.1000 | 1.9 | [1.7, 2.2] | 0.000 | Slower |
-| StringConcat | StringInterpolation | 15.2000 | 12.3000 | 1.2 | [1.1, 1.4] | 0.023 | Slower |
-| StringBuilder | StringInterpolation | 8.1000 | 12.3000 | 0.66 | [0.60, 0.72] | 0.001 | Improved |
-
-#### Comparison Group: Collections
-
-| Method 1 | Method 2 | Mean 1 (ms) | Mean 2 (ms) | Ratio | 95% CI | q-value (FDR) | Label |
-|----------|----------|-------------|-------------|-------|--------|----------------|-------|
-| ListIteration | ArrayIteration | 5.4000 | 3.2000 | 1.7 | [1.5, 1.9] | 0.000 | Slower |
+When you have multiple comparison groups, each gets its own `## 🔬 Comparison Group: {GroupName}` section with its own NxN matrix and detailed results table. The detailed table is always 5 columns (Method, Mean Time, Median Time, Sample Size, Status); ratios and q‑values live in the matrix above it.
 
 ### N×N Comparison Matrices
 
@@ -186,16 +164,16 @@ Sailfish uses adaptive precision to ensure readability:
 
 ### Mixed Test Types
 
-The markdown includes both comparison and regular methods:
+The session markdown includes both comparison methods (under per-group sections) and ungrouped methods (under `## 📊 Individual Test Results`). All tables share the same 5-column shape:
 
-#### MyTest
+```markdown
+| Method | Mean Time | Median Time | Sample Size | Status |
+|--------|-----------|-------------|-------------|--------|
+| RegularMethod        | 1.000ms  | 1.000ms  | 100 | ✅ Success |
+| AnotherRegularMethod | 1.100ms  | 1.000ms  | 100 | ✅ Success |
+```
 
-| Method | Mean (ms) | Median (ms) | StdDev (N=100) | CI95 MOE | CI99 MOE | Status |
-|--------|-----------|-------------|----------------|----------|----------|--------|
-| ComparisonMethod1 | 10.5000 | 9.8000 | 1.2000 | ±0.4567 | ±0.6789 | ✅ Success |
-| ComparisonMethod2 | 8.3000 | 8.1000 | 0.9000 | ±0.3456 | ±0.5123 | ✅ Success |
-| RegularMethod | 1.0000 | 1.0000 | 0.1000 | ±0.0500 | ±0.0800 | ✅ Success |
-| AnotherRegularMethod | 1.1000 | 1.0000 | 0.1000 | ±0.0500 | ±0.0800 | ✅ Success |
+For per-test CI95/CI99 margins of error or standard deviation, consult the per-class tracking CSV or the [Reproducibility Manifest](/docs/1/reproducibility-manifest).
 
 ## Best Practices
 

--- a/site/src/pages/docs/1/method-comparisons.md
+++ b/site/src/pages/docs/1/method-comparisons.md
@@ -287,12 +287,39 @@ You can configure SailDiff behavior using `.sailfish.json`:
 ```json
 {
   "SailDiffSettings": {
-    "TestType": "TTest",
-    "Alpha": 0.05,
+    "TestType": "Test",
+    "Alpha": 0.001,
     "Disabled": false
   }
 }
 ```
+
+### Attribute properties
+
+`[SailfishComparison]` has two optional named arguments beyond the required group name:
+
+- **`DisplayName`** — overrides the method name in comparison output. Useful when you want a friendly label without renaming the C# method.
+- **`Disabled`** — when `true`, the method is excluded from comparisons even though other methods in the group are present. Lets you toggle a comparator off without removing the attribute.
+
+```csharp
+[SailfishMethod]
+[SailfishComparison("SortingAlgorithms", DisplayName = "Built-in Array.Sort")]
+public void QuickSort() { /* ... */ }
+
+[SailfishMethod]
+[SailfishComparison("SortingAlgorithms", Disabled = true)]
+public void OldExperiment() { /* ... */ }
+```
+
+### Failure handling
+
+If a `[SailfishComparison]` method throws, Sailfish publishes a normal failed `TestOutcome` for that case immediately and **excludes it from the batch**:
+
+- The exception surfaces in the IDE Test Explorer as a failure, with the stack trace attached.
+- Sibling comparators are not blocked — the comparison batch readiness check only counts surviving members.
+- The N×N matrix is computed across the surviving members. If fewer than two members survive, no matrix is produced (and a short note is emitted to the consolidated outputs).
+
+This is why a partially-failing group still reports useful comparisons rather than silently hanging.
 
 ## Best Practices
 

--- a/site/src/pages/docs/1/outlier-handling.md
+++ b/site/src/pages/docs/1/outlier-handling.md
@@ -42,7 +42,15 @@ var run = RunSettingsBuilder.CreateBuilder()
 This sets a typed, discoverable global policy that flows to all test classes in the run. You can switch strategies (e.g., `DontRemove` for raw analysis, or `Adaptive` for side‑aware removal).
 
 ## Per‑class configuration
-Attribute‑level controls for outlier strategy are not yet exposed. Use the global configuration above to set a consistent policy across tests.
+
+You can also opt in to configurable outlier handling on a single class via the `[Sailfish]` attribute. Class-level values are overridden by `RunSettingsBuilder.WithGlobalOutlierHandling(...)` when that is set.
+
+```csharp
+[Sailfish(
+    UseConfigurableOutlierDetection = true,
+    OutlierStrategy = OutlierStrategy.RemoveUpper)]
+public class MyTest { ... }
+```
 
 ## How it interacts with statistics
 - Outliers that are removed do not participate in mean, standard deviation, or confidence interval calculations.

--- a/site/src/pages/docs/1/output-attributes.md
+++ b/site/src/pages/docs/1/output-attributes.md
@@ -38,13 +38,13 @@ public class PerformanceTest
 ### Markdown Output Features
 
 - **Session-based consolidation**: Single markdown file per test session
-- **Individual test results**: Detailed statistics for each method
-- **Method comparison matrices**: N×N comparisons between methods in the same comparison group
-- **Statistical analysis**: P-values, significance testing, and performance ratios
-- **Organized sections**: Clear separation between different types of data
-- **Multiple confidence intervals**: Displays 95% and 99% by default with adaptive precision
+- **Per-group sections**: NxN comparison matrix and a five-column detailed results table per comparison group
+- **Statistical analysis**: BH-FDR q-values and 95% ratio confidence intervals in the matrix
+- **Environment & reproducibility headers**: Optional `🏥 Environment Health Check` and `🔁 Reproducibility Summary` sections near the top when enabled
 
-**Example filename**: `TestSession_abc12345_Results_20250803_103000.md`
+CI95/CI99 margins of error are not embedded in the consolidated session markdown — they're available in the per-class tracking CSV and in the Reproducibility Manifest.
+
+**Example filename**: `TestSession_abc12345_MethodComparisons_2025-08-03_10-30-00.md`
 
 
 {% callout title="See also" type="note" %}
@@ -86,23 +86,16 @@ public class PerformanceTest
 
 ### CSV Output Features
 
-- **Multi-section format**: Session metadata, individual results, and method comparisons
+- **Two-section format**: Individual test results and pairwise method comparisons
 - **Excel-compatible**: Easy to import and analyze in spreadsheet applications
 - **Session-based consolidation**: Single CSV file per test session
-- **Comprehensive data**: All test metrics and comparison results in tabular format
-- **Comment-friendly**: Section headers using `#` comments for clear organization
-- **Multiple confidence intervals**: Includes CI95_MOE and CI99_MOE columns for margin-of-error at 95% and 99% confidence
-
+- **Numeric ratios with confidence intervals and q-values**: Comparison rows include the BH-FDR q-value and 95% ratio CI bounds
 
 **Example filename**: `TestSession_abc12345_Results_20250803_103000.csv`
 
 ### CSV Structure
 
 ```csv
-# Session Metadata
-SessionId,Timestamp,TotalClasses,TotalTests
-abc12345,2025-08-03T10:30:00Z,1,6
-
 # Individual Test Results
 TestClass,TestMethod,MeanTime,MedianTime,StdDev,SampleSize,ComparisonGroup,Status
 PerformanceTest,BubbleSort,45.200,44.100,3.100,100,Algorithms,Success
@@ -110,8 +103,8 @@ PerformanceTest,QuickSort,2.100,2.000,0.300,100,Algorithms,Success
 PerformanceTest,RegularMethod,1.000,1.000,0.100,100,,Success
 
 # Method Comparisons
-ComparisonGroup,Method1,Method2,Method1Mean,Method2Mean,PerformanceRatio,ChangeDescription
-Algorithms,BubbleSort,QuickSort,45.200,2.100,21.5x slower,Regressed
+ComparisonGroup,Method1,Method2,Mean1,Mean2,Ratio,CI95_Lower,CI95_Upper,q_value,Label,ChangeDescription
+Algorithms,BubbleSort,QuickSort,45.200,2.100,0.046,0.040,0.054,1.2e-12,Improved,Improved
 ```
 
 ## Combined Usage

--- a/site/src/pages/docs/1/presets.md
+++ b/site/src/pages/docs/1/presets.md
@@ -2,24 +2,24 @@
 title: Configuration Recipes
 ---
 
-Sailfish exposes a handful of knobs that, together, decide how much data you collect before declaring a result stable. This page gives you three pre-tuned recipes you can copy as a starting point: a sensible default, a tighter profile for release gates, and a looser profile for noisy CI hosts.
+Sailfish exposes a handful of knobs that, together, decide how much data you collect before declaring a result stable. This page gives you three pre-tuned recipes you can apply with a single builder call: a sensible default, a tighter profile for release gates, and a looser profile for noisy CI hosts.
 
 {% callout title="TL;DR" type="note" %}
+- Use `RunSettingsBuilder.WithPreset(SailfishPreset.Default | Tight | Relaxed)` to seed the whole run.
+- Presets seed adaptive sampling, outlier handling, **and** SailDiff alpha at once.
+- Any explicit `WithGlobalX` / `WithSailDiff(...)` call on the builder wins over the preset.
 - The three knobs that matter most are `TargetCoefficientOfVariation`, `MaxConfidenceIntervalWidth`, and `MinimumSampleSize`. `MaximumSampleSize` caps total work.
-- Tighter (lower CV / lower CI width / higher min N) → catches smaller regressions, runs longer.
-- Looser (higher CV / wider CI width / lower min N) → finishes sooner, may miss small regressions.
-- These are recipes, not an API. There is no `Preset` enum today — copy the values that fit your environment.
 {% /callout %}
 
 ## Recipes
 
-| Recipe | When to use | `TargetCoefficientOfVariation` | `MaxConfidenceIntervalWidth` | `MinimumSampleSize` | `MaximumSampleSize` |
-| --- | --- | --- | --- | --- | --- |
-| **Default** | Most local and CI runs. Matches Sailfish's built-in defaults. | `0.05` (5%) | `0.20` (20%) | `10` | `1000` |
-| **Tight** | Release gates and baseline verification where small regressions matter. | `0.03` (3%) | `0.12` (12%) | `50` | `2000` |
-| **Relaxed** | Shared/noisy CI hosts where predictable completion time matters more than micro-changes. | `0.10` (10%) | `0.30` (30%) | `10` | `1000` |
+| Recipe | When to use | `TargetCoefficientOfVariation` | `MaxConfidenceIntervalWidth` | `MinimumSampleSize` | `MaximumSampleSize` | `OutlierStrategy` | SailDiff `alpha` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **Default** | Most local and CI runs. Matches Sailfish's built-in defaults. | `0.05` (5%) | `0.20` (20%) | `10` | `1000` | `RemoveUpper` | `0.001` |
+| **Tight** | Release gates and baseline verification where small regressions matter. | `0.03` (3%) | `0.12` (12%) | `50` | `2000` | `RemoveUpper` | `0.0005` |
+| **Relaxed** | Shared/noisy CI hosts where predictable completion time matters more than micro-changes. | `0.10` (10%) | `0.30` (30%) | `10` | `1000` | `Adaptive` | `0.01` |
 
-The **Default** row is what you get from a bare `[Sailfish]` attribute today — see [SailfishAttribute defaults](https://github.com/paulegradie/Sailfish/blob/main/source/Sailfish/Attributes/SailfishAttribute.cs).
+The **Default** row is what you get from a bare `[Sailfish]` attribute today.
 
 {% callout title="Sailfish already auto-tunes for fast methods" type="note" %}
 When `UseAdaptiveSampling = true`, the [Adaptive Sampling](/docs/1/adaptive-sampling) selector inspects a short pilot and *automatically* tightens CV / CI / min-N for fast methods (e.g., UltraFast → CV `0.03`, CI `0.12`, min `50`). You generally don't need a "Tight" recipe just to catch fast-method regressions — you need it when you want all methods to meet that bar.
@@ -27,21 +27,24 @@ When `UseAdaptiveSampling = true`, the [Adaptive Sampling](/docs/1/adaptive-samp
 
 ## Apply globally (recommended)
 
-Set one policy for the whole run with `RunSettingsBuilder`:
+Seed the whole run from a preset with one call:
 
 ```csharp
 var run = RunSettingsBuilder.CreateBuilder()
-    .WithGlobalAdaptiveSampling(
-        targetCoefficientOfVariation: 0.05,
-        maximumSampleSize: 1000)
+    .WithPreset(SailfishPreset.Default) // or .Tight / .Relaxed
+    .WithSailDiff()                     // presets seed SailDiff defaults, but SailDiff itself is still opt-in
     .Build();
 ```
 
-{% callout title="Limitation" type="note" %}
-`WithGlobalAdaptiveSampling` currently exposes only `TargetCoefficientOfVariation` and `MaximumSampleSize` globally. To pin `MinimumSampleSize` and `MaxConfidenceIntervalWidth` across a run today, set them on each `[Sailfish]` attribute (or via a shared base class). A richer global API is tracked in the preset-builder work.
-{% /callout %}
+Notes:
+
+- The preset is applied at `Build()`, so any explicit `WithGlobalX` (e.g. `WithGlobalOutlierHandling`, `WithGlobalAdaptiveSampling`) or `WithSailDiff(settings)` call **wins** over the preset, regardless of call order.
+- Calling `WithPreset` multiple times — last call wins (no silent divergence between execution and SailDiff settings).
+- `WithPreset` does **not** enable SailDiff by itself; call `WithSailDiff()` separately if you want SailDiff to run.
 
 ## Apply per class (attribute)
+
+If you'd rather pin the values per class, the same numbers map directly onto the attribute:
 
 ```csharp
 // Default
@@ -68,13 +71,15 @@ public class TightGateBenchmarks { }
     MinimumSampleSize = 10,
     TargetCoefficientOfVariation = 0.10,
     MaxConfidenceIntervalWidth = 0.30,
-    MaximumSampleSize = 1000)]
+    MaximumSampleSize = 1000,
+    UseConfigurableOutlierDetection = true,
+    OutlierStrategy = OutlierStrategy.Adaptive)]
 public class RelaxedCiBenchmarks { }
 ```
 
 ## What about outliers?
 
-`OutlierStrategy` is orthogonal to the recipes above but matters at least as much on noisy hosts. The shipping default preserves legacy behavior (`RemoveAll`); most users on shared CI runners are better off with `RemoveUpper` or `Adaptive`. See [Outlier Handling](/docs/1/outlier-handling) for the full picture and the global builder hook.
+Presets already seed `OutlierStrategy` (Default/Tight → `RemoveUpper`, Relaxed → `Adaptive`). If you skip presets, the global default still falls back to the legacy `RemoveAll` path until you opt in via `UseConfigurableOutlierDetection`. See [Outlier Handling](/docs/1/outlier-handling) for the full picture.
 
 ## Where the numbers come from
 

--- a/site/src/pages/docs/1/reproducibility-manifest.md
+++ b/site/src/pages/docs/1/reproducibility-manifest.md
@@ -48,7 +48,7 @@ Example snippet:
 ### Session info
 - Timestamp (UTC)
 - Session ID (unique per run)
-- Randomization Seed (when seeded randomized run order is enabled)
+- Randomization configuration (`Seed`, `Types`, `Methods`, `PropertySets`) — populated when seeded randomized run order is enabled
 - Tags (from Run Settings)
 - CI system detection (e.g., GitHub Actions)
 
@@ -77,16 +77,29 @@ When available, Sailfish includes a short "Reproducibility Summary" near the top
 {
   "SailfishVersion": "2.3.0",
   "DotNetRuntime": ".NET 9.0.7",
-  "OS": "Microsoft Windows 11 Pro",
-  "GCMode": "Server",
+  "Os": "Microsoft Windows 11 Pro",
+  "OsArchitecture": "X64",
+  "ProcessArchitecture": "X64",
+  "GcMode": "Server",
   "Jit": "Tiered=default; QuickJit=default; QuickJitForLoops=default; OSR=default",
   "EnvironmentHealthScore": 85,
+  "EnvironmentHealthLabel": "Good",
   "SessionId": "20250115_120301-ab12cd34",
+  "Randomization": { "Seed": 12345, "Types": true, "Methods": true, "PropertySets": true },
   "Methods": [
-    { "TestCaseDisplayName": "MyTests.Foo()", "SampleSize": 100, "Mean": 1.2345, "StdDev": 0.0456, "CI95_MarginOfError": 0.0123 }
+    {
+      "TestCaseDisplayName": "MyTests.Foo()",
+      "SampleSize": 100,
+      "Mean": 1.2345,
+      "StdDev": 0.0456,
+      "Ci95MarginOfError": 0.0123,
+      "Ci99MarginOfError": 0.0162
+    }
   ]
 }
 ```
+
+JSON property names match the C# property names verbatim (the default `System.Text.Json` policy): `Os`, `GcMode`, `Ci95MarginOfError`, etc. — not `OS` / `GCMode` / `CI95_MarginOfError`.
 
 ## Notes
 - The manifest is written on a best‑effort basis; failures are logged at debug level and do not fail the test run.

--- a/site/src/pages/docs/1/required-attributes.md
+++ b/site/src/pages/docs/1/required-attributes.md
@@ -11,7 +11,7 @@ Apply the `[Sailfish]` attribute to the class.
 ```csharp
 [Sailfish(
     SampleSize = 45,
-    NumWarmupIterations = 2,
+    NumWarmupIterations = 3,
     DisableOverheadEstimation = false,
     Disabled = false)]
 public class AMostBasicTest { ... }
@@ -24,7 +24,7 @@ public class AMostBasicTest { ... }
     UseAdaptiveSampling = true,
     TargetCoefficientOfVariation = 0.05,
     MaximumSampleSize = 1000,
-    NumWarmupIterations = 2)]
+    NumWarmupIterations = 3)]
 public class AdaptiveTest { ... }
 ```
 
@@ -38,7 +38,7 @@ These parameters control traditional fixed-sample-size testing.
 
 Sets the number of times the SailfishMethod will be invoked. This number should be as high as you can tolerate. Larger sample size improves the quality of the result.
 
-**Default:** 20
+**Default:** 3
 **Range:** 2 to int.MaxValue
 **Note:** Ignored when `UseAdaptiveSampling = true`
 
@@ -46,7 +46,7 @@ Sets the number of times the SailfishMethod will be invoked. This number should 
 
 Sets the number of times the SailfishMethod will be invoked before timing begins. This includes invocation of the SailfishIterationSetup and SailfishIterationTeardown lifecycle methods.
 
-**Default:** 2
+**Default:** 3
 **Range:** 0 to int.MaxValue
 **Note:** Applies to both fixed and adaptive sampling
 
@@ -118,14 +118,32 @@ public class DetailedAnalysis { ... }
 - **Default (1000):** Sufficient for most scenarios
 - **Higher (1500-3000):** For noisy workloads that need more samples to converge
 
-{% callout title="Additional Adaptive Parameters" type="note" %}
-The following adaptive sampling parameters are available via global configuration using `RunSettingsBuilder` but cannot be set per-class:
-- **MinimumSampleSize:** Minimum samples before checking convergence (default: 10)
-- **ConfidenceLevel:** Confidence level for CI width calculation (default: 0.95)
-- **MaxConfidenceIntervalWidth:** Maximum relative CI width threshold (default: 0.20)
-- **UseRelativeConfidenceInterval:** Whether to use relative CI width (default: true)
+#### MinimumSampleSize
+Minimum number of samples to collect before checking convergence.
 
-See [Adaptive Sampling](/docs/1/adaptive-sampling) for details on global configuration.
+- Default: `10`
+- Type: `int`
+
+#### ConfidenceLevel
+Confidence level used for interval estimation. Affects the CI width gate during adaptive sampling and the per‑sample CI emitted in outputs.
+
+- Default: `0.95`
+- Type: `double`
+
+#### MaxConfidenceIntervalWidth
+Maximum allowed confidence interval width. Interpreted as a relative width (fraction of the mean) when `UseRelativeConfidenceInterval = true`.
+
+- Default: `0.20` (20%)
+- Type: `double`
+
+#### UseRelativeConfidenceInterval
+When `true` (default), `MaxConfidenceIntervalWidth` is treated as a fraction of the mean; when `false`, it is interpreted as an absolute width in the same units as the measurement.
+
+- Default: `true`
+- Type: `bool`
+
+{% callout title="Global counterparts" type="note" %}
+Each of these knobs has a matching `WithGlobalX` setter on `RunSettingsBuilder`. The builder’s global value overrides per-class attribute values when set. See [Adaptive Sampling](/docs/1/adaptive-sampling) for global configuration details.
 {% /callout %}
 
 ---
@@ -147,6 +165,34 @@ Tests are discoverable but ignored when set to true. Useful for temporarily disa
 
 **Default:** `false`
 **Type:** `bool`
+
+#### EnableDefaultDiagnosers
+
+Enables lightweight default diagnosers (memory/GC/threading snapshots) for this class.
+
+**Default:** `false`
+**Type:** `bool`
+
+#### OutlierStrategy
+
+Preferred outlier handling strategy when configurable detection is enabled.
+
+**Default:** `OutlierStrategy.RemoveUpper`
+**Type:** `OutlierStrategy` (`None`, `RemoveAll`, `RemoveUpper`, `Adaptive`)
+
+#### UseConfigurableOutlierDetection
+
+Opt-in to settings-driven outlier handling for this class. When `false` (default), the legacy detector is used to preserve backward compatibility. See [Outlier Handling](/docs/1/outlier-handling).
+
+**Default:** `false`
+**Type:** `bool`
+
+```csharp
+[Sailfish(
+    UseConfigurableOutlierDetection = true,
+    OutlierStrategy = OutlierStrategy.Adaptive)]
+public class NoisyTest { ... }
+```
 
 ---
 
@@ -201,6 +247,31 @@ Apply the [SailfishMethod] attribute to a method you wish to time.
 [SailfishMethod]
 public async Task SailfishMethod(CancellationToken ct) => ...
 ```
+
+#### Order
+Sets the execution order for a SailfishMethod within the class. Ordered methods always run before unordered methods. Among unordered methods, order is not guaranteed.
+
+- Default: `int.MaxValue` (unordered)
+- Type: `int`
+
+#### Disabled
+When `true`, the method is discoverable but skipped at execution time.
+
+- Default: `false`
+- Type: `bool`
+
+#### DisableComplexity
+Disables ScaleFish complexity analysis for this specific method.
+
+- Default: `false`
+- Type: `bool`
+
+#### DisableOverheadEstimation
+Disables overhead estimation for this specific method (overrides the class-level value when set). Useful for very fast methods where the overhead-calibration cost is dominant.
+
+- Default: `false`
+- Type: `bool`
+
 ---
 
 ### Injecting Cancellation Tokens

--- a/site/src/pages/docs/1/sailfish-test-lifecycle.md
+++ b/site/src/pages/docs/1/sailfish-test-lifecycle.md
@@ -83,6 +83,15 @@ You may do this with:
 - **SailfishIterationSetup**
 - **SailfishIterationTeardown**
 
+### RunOnce on method setup/teardown
+
+`SailfishMethodSetup` and `SailfishMethodTeardown` expose a `RunOnce` property. When `true`, the hook is invoked **at most once** per executor run for the declaring class, even when `MethodNames` lists multiple `[SailfishMethod]`s. This is useful for one-shot fixture initialization shared across multiple methods.
+
+```csharp
+[SailfishMethodSetup(nameof(Foo), nameof(Bar), RunOnce = true)]
+public Task ShareFixture(CancellationToken ct) => InitializeOnce(ct);
+```
+
 ## Property and Field Management
 
 When multiple test cases are created for a class, distinct instances of the class are created. Properties and Fields that are set in the global lifecycle methods must therefore be cloned to new instances that do not execute the global lifecycle method.

--- a/site/src/pages/docs/1/sailfish-variables.md
+++ b/site/src/pages/docs/1/sailfish-variables.md
@@ -53,18 +53,20 @@ public class Example
 
 #### Parameters:
 - **start**: The starting number for the range
-- **count**: The number of elements to create
-- **step**: The number of values to skip before taking the next value
+- **count**: The number of values to produce
+- **step**: The increment added between successive values (default `1`)
 
 ### Supported Simple Types
 
-Sailfish variables can be any type that is compatible with the base **Attribute** class:
+`SailfishVariable` has overloads for the following params arrays: `int`, `double`, `string`, `float`, `long`, `decimal`, `bool`. Enums are also supported via the underlying attribute machinery.
 
 ```csharp
-[SailfishVariable(10, 100, 1000)]           // integers
-[SailfishVariable(0.24, 1.6)]               // doubles
-[SailfishVariable("ScenarioA", "ScenarioB")] // strings
+[SailfishVariable(10, 100, 1000)]               // integers
+[SailfishVariable(0.24, 1.6)]                   // doubles
+[SailfishVariable("ScenarioA", "ScenarioB")]    // strings
 [SailfishVariable(MyEnum.First, MyEnum.Second)] // enums
+[SailfishVariable(true, false)]                 // booleans
+[SailfishVariable(1L, 2L, 3L)]                  // longs
 ```
 
 ---
@@ -445,9 +447,13 @@ public class MixedVariableApproachesExample
 When applying a variable attribute, you may choose to specify that variable for ScaleFish complexity estimation and modeling. To do so set the first optional parameter to true:
 
 ```csharp
-[SailfishVariable(scalefish: true, 10, 100, 1000)]
+[SailfishVariable(scaleFish: true, 10, 100, 1000)]
 ```
 
-{% callout title="ScaleFish constraint" type="warning" %}
-When using ScaleFish, variables must be of type `int`. Non-int and complex `Type` variables are not currently supported for complexity estimation.
+{% callout title="ScaleFish constraints" type="warning" %}
+When using ScaleFish:
+- Variables must be of type `int`. Non-int and complex `Type` variables are not supported.
+- At least **three** values are required so the regression has enough points to fit.
+
+`SailfishRangeVariable` also has a ScaleFish overload — `(bool scaleFish, int start, int count, int step = 1)`.
 {% /callout %}

--- a/site/src/pages/docs/1/test-dependencies.md
+++ b/site/src/pages/docs/1/test-dependencies.md
@@ -1,26 +1,30 @@
 ---
 title: Registering Tests Dependencies
 ---
-Simlply implement one of the following three interfaces.
+Sailfish supports several ways to register dependencies that test classes can consume. Implement one of the interfaces below depending on the level of control you need.
 
-Sailfish will scan the calling assembly by default to discover implementations of this interface. You can customize the search location by providing an anchor type to the IRunSettings builder.
+Sailfish will scan the calling assembly by default to discover implementations. You can customize the search location by passing one or more anchor types to `RunSettingsBuilder.ProvidersFromAssembliesContaining(...)`.
 
 # IProvideARegistrationCallback
 
-Implement the `IProvideARegistrationCallback` interface, which provides access to an autofac container builder. The container will hold and resolve your dependencies from a separate lifetime scope from Sailfish.
+Implement `IProvideARegistrationCallback` to get an Autofac `ContainerBuilder` callback. The container holds and resolves your dependencies from a lifetime scope managed by Sailfish.
 
 ```csharp
+// In your Program.cs / Main
 var runSettings = RunSettingsBuilder
+    .CreateBuilder()
     .ProvidersFromAssembliesContaining(typeof(RegistrationProvider))
     .Build();
+await SailfishRunner.Run(runSettings);
 
+// In a class somewhere in the same assembly
 public class RegistrationProvider : IProvideARegistrationCallback
 {
     public async Task RegisterAsync(
         ContainerBuilder builder,
-        CancellationToken ct)
+        CancellationToken cancellationToken = default)
     {
-       var typeInstance = await MyClientFactory.Create(ct);
+       var typeInstance = await MyClientFactory.Create(cancellationToken);
        builder.Register(ctx => typeInstance).As<IClient>();
        builder.RegisterType<MyType>().AsSelf();
     }
@@ -28,14 +32,31 @@ public class RegistrationProvider : IProvideARegistrationCallback
 ```
 ---
 
+# IProvideAdditionalRegistrations
+
+For purely synchronous registrations you can implement `IProvideAdditionalRegistrations`. Sailfish discovers and runs all implementations alongside any `IProvideARegistrationCallback` providers.
+
+```csharp
+public class AdditionalRegistrations : IProvideAdditionalRegistrations
+{
+    public void Load(ContainerBuilder builder)
+    {
+        builder.RegisterType<MyType>().AsSelf();
+    }
+}
+```
+---
+
 # ISailfishDependency
+
+Mark a concrete type with `ISailfishDependency` to have it auto‑registered as itself. Use this when your dependency has a parameterless constructor and you just need it available for injection.
 
 ```csharp
 public class MyDependency : ISailfishDependency
 {
     public void Print()
     {
-        Console.WriteLine("Hello Wolrd");
+        Console.WriteLine("Hello World");
     }
 }
 ```
@@ -51,18 +72,18 @@ public class MyDependency
     public MyDependency() // must be parameterless
     {
         // do synchronous things as part of your setup
-        lazyClient = new Lazy<IClient>(
+        lazyClient = new Lazy<Task<IClient>>(
             async () => await ClientFactory.Create());
     }
 
-    private Lazy<IClient> lazyClient;
-    public async Task<IClient> GetClient() => lazyClient.Value;
+    private readonly Lazy<Task<IClient>> lazyClient;
+    public Task<IClient> GetClient() => lazyClient.Value;
 }
 
 [Sailfish]
 public class Example : ISailfishFixture<MyDependency>
 {
-    private readonly myDependency;
+    private readonly MyDependency myDependency;
 
     public Example(MyDependency dependency)
     {
@@ -72,9 +93,9 @@ public class Example : ISailfishFixture<MyDependency>
     public IClient Client { get; set; }
 
     [SailfishGlobalSetup]
-    public async Task GlobalSetup(CancellationToken ct);
+    public async Task GlobalSetup(CancellationToken ct)
     {
-        Client = await myDependency.GetClient()
+        Client = await myDependency.GetClient();
     }
 
     [SailfishMethod]

--- a/site/src/pages/docs/2/saildiff.md
+++ b/site/src/pages/docs/2/saildiff.md
@@ -41,8 +41,8 @@ If using Sailfish as a test project, you can create a `.sailfish.json` file in t
     "SampleSizeOverride": 30
   },
   "SailDiffSettings": {
-    "TestType": "TTest",
-    "Alpha": 0.005,
+    "TestType": "Test",
+    "Alpha": 0.001,
     "Disabled": false
   },
   "ScaleFishSettings": {},
@@ -61,18 +61,18 @@ If using Sailfish as a test project, you can create a `.sailfish.json` file in t
 
 Description: Specifies an enum type for a statistical test. One of:
 
-  - TwoSampleWilcoxonSignedRankTest
+  - TwoSampleWilcoxonSignedRankTest (**Default**)
   - WilcoxonRankSumTest
   - KolmogorovSmirnovTest
-  - TTest (**Default**)
+  - Test (Student's t‑test)
 
-
+Note: the JSON value must match the enum member exactly — use `"Test"` (not `"TTest"`) when selecting the t‑test.
 
 **Alpha**
 
 Description: Threshold for significance detection. (Aka 'PValue threshold').
 
-Default: 0.005
+Default: 0.001 (library) / 0.0001 (test adapter)
 
 **Disabled**
 
@@ -86,10 +86,10 @@ Default: false
 ```
 Statistical Test
 ----------------
-Test Used:       TTest
-PVal Threshold:  0.005
+Test Used:       Test
+PVal Threshold:  0.001
 PValue:          0.0528963431
-Change:          No Change  (reason: 0.0528963431 > 0.005)
+Change:          No Change  (reason: 0.0528963431 > 0.001)
 
 |             | Before (ms) | After (ms) |
 | ---         | ---         | ---        |
@@ -111,17 +111,17 @@ The Mean and median are both presented alongside a PValue and Change description
 You may use the `RunSettingsBuilder` to configure SailDiff before running.
 
 ```csharp
-var settings = new SailfDiffSettings(
+var sailDiffSettings = new SailDiffSettings(
     alpha: 0.001,
     round: 3,
     useOutlierDetection: true,
-    testType: TestType.TTest,
+    testType: TestType.Test,
     maxDegreeOfParallelism: 4,
     disableOrdering: false);
 
-var settings = RunSettingsBuilder
+var runSettings = RunSettingsBuilder
     .CreateBuilder()
-    .WithSailDiff(settings)
+    .WithSailDiff(sailDiffSettings)
     .Build();
 ```
 
@@ -138,10 +138,10 @@ The flow of the analysis is
 1. `ReadInBeforeAndAfterDataRequest`
 1. Saildiff
 
-This flow shows that there are two points at which you can minipulate the data inputs:
+This flow shows that there are two points at which you can manipulate the data inputs:
 
-- IRequestHandler<BeforeAndAfterFileLocationRequest, BeforeAndAfterFileLocationResponse>
-- IRequestHandler<ReadInBeforeAndAfterDataCommand, ReadInBeforeAndAfterDataResponse>
+- `IRequestHandler<BeforeAndAfterFileLocationRequest, BeforeAndAfterFileLocationResponse>`
+- `IRequestHandler<ReadInBeforeAndAfterDataRequest, ReadInBeforeAndAfterDataResponse>`
 
 
 ### Runtime API (in-memory TestData)
@@ -163,26 +163,27 @@ Notes:
 
 ```csharp
 internal class SailfishBeforeAndAfterFileLocationHandler
-    : IRequestHandler<BeforeAndAfterFileLocationCommand, BeforeAndAfterFileLocationResponse>
+    : IRequestHandler<BeforeAndAfterFileLocationRequest, BeforeAndAfterFileLocationResponse>
 {
+    private readonly IRunSettings runSettings;
     private readonly ITrackingFileDirectoryReader trackingFileDirectoryReader;
 
     public SailfishBeforeAndAfterFileLocationHandler(
         IRunSettings runSettings,
         ITrackingFileDirectoryReader trackingFileDirectoryReader)
     {
+        this.runSettings = runSettings;
         this.trackingFileDirectoryReader = trackingFileDirectoryReader;
-        this.runSettings = runSettings
     }
 
     public Task<BeforeAndAfterFileLocationResponse> Handle(
-        BeforeAndAfterFileLocationCommand request,
+        BeforeAndAfterFileLocationRequest request,
         CancellationToken cancellationToken)
     {
         var trackingFiles = trackingFileDirectoryReader
-        .FindTrackingFilesInDirectoryOrderedByLastModified(
-            runSettings.GetRunSettingsTrackingDirectoryPath(),
-            ascending: false);
+            .FindTrackingFilesInDirectoryOrderedByLastModified(
+                runSettings.GetRunSettingsTrackingDirectoryPath(),
+                ascending: false);
 
         // Consider reading data from a:
         // - database
@@ -192,8 +193,8 @@ internal class SailfishBeforeAndAfterFileLocationHandler
         // - local directory
 
         return Task.FromResult(new BeforeAndAfterFileLocationResponse(
-            new List<string>() { trackingFiles.BeforeFilePath }.Where(x => !string.IsNullOrEmpty(x)),
-            new List<string>() { trackingFiles.AfterFilePath }.Where(x => !string.IsNullOrEmpty(x))));
+            trackingFiles.BeforeFilePaths.Where(x => !string.IsNullOrEmpty(x)),
+            trackingFiles.AfterFilePaths.Where(x => !string.IsNullOrEmpty(x))));
     }
 }
 ```
@@ -202,17 +203,17 @@ internal class SailfishBeforeAndAfterFileLocationHandler
 
 ```csharp
 internal class SailfishReadInBeforeAndAfterDataHandler
-: IRequestHandler<ReadInBeforeAndAfterDataCommand, ReadInBeforeAndAfterDataResponse>
+    : IRequestHandler<ReadInBeforeAndAfterDataRequest, ReadInBeforeAndAfterDataResponse>
 {
     public async Task<ReadInBeforeAndAfterDataResponse> Handle(
-        ReadInBeforeAndAfterDataCommand request,
+        ReadInBeforeAndAfterDataRequest request,
         CancellationToken cancellationToken)
     {
         // When you return the data, you are also required to
         // provide an IEnumerable<string> that represents the files that were used.
         return new ReadInBeforeAndAfterDataResponse(
             new TestData(dataSourcesBefore, beforeData),
-             new TestData(dataSourcesAfter, afterData));
+            new TestData(dataSourcesAfter, afterData));
     }
 }
 ```
@@ -223,16 +224,16 @@ SailDiff will automatically aggregate data when multiple files are provided.
 
 ## Which SailDiff Test should I use?
 
-When customizing the TestSettings **TestType** (either via .sailfish.json or RunSettingsBuilder), you have three options to choose from.
+When customizing the TestSettings **TestType** (either via .sailfish.json or RunSettingsBuilder), you have four options to choose from.
 
 You can follow this rule of thumb when choosing:
 
 ```python
 if (your test makes requests over a network):
-One of:
+    One of:
     - TwoSampleWilcoxonSignedRankTest
     - WilcoxonRankSumTest
     - KolmogorovSmirnovTest
 else:
-    - TTest
+    - Test (Student's t‑test)
 ```

--- a/site/src/pages/docs/2/sailfish.md
+++ b/site/src/pages/docs/2/sailfish.md
@@ -24,8 +24,8 @@ If using Sailfish as a test project, you can create a `.sailfish.json` file in t
     "SampleSizeOverride": 30
   },
   "SailDiffSettings": {
-    "TestType": "TTest",
-    "Alpha": 0.005,
+    "TestType": "Test",
+    "Alpha": 0.001,
     "Disabled": false
   },
   "ScaleFishSettings": {},

--- a/site/src/pages/docs/2/scalefish.md
+++ b/site/src/pages/docs/2/scalefish.md
@@ -18,15 +18,36 @@ This outputs a model file and a results file once your run is complete. The mode
 The first thing you'll need to do when enabling **ScaleFish** is to specify a SailfishVariable or SailfishRangeVariable and set the optional complexity boolean to true.
 
 ```csharp
-[SailfishRangeVariable(true, start: 5, 4, 6)]
+// SailfishRangeVariable: (bool scaleFish, int start, int count, int step = 1)
+// produces { 5, 11, 17, 23 } — start=5, count=4, step=6
+[SailfishRangeVariable(scaleFish: true, 5, 4, 6)]
 public int N { get; set; }
 
 // or
 
-[SailfishVariable(true, 1, 10, 50, 100, 500, 1000)]
+// SailfishVariable: (bool scaleFish, params int[] n) — requires at least 3 int values
+[SailfishVariable(scaleFish: true, 1, 10, 50, 100, 500, 1000)]
 public int N { get; set; }
-
 ```
+
+ScaleFish only accepts `int` variables (because models map a numeric size N to elapsed time), and the ScaleFish overloads require **at least three values** so the regression has enough points to fit. Accuracy improves with more values spread over a wider range.
+
+### Supported complexity classes
+
+Sailfish fits each variable against the following functions and picks the best/next‑best fit:
+
+| Name        | BigO          | Quality   |
+| ----------- | ------------- | --------- |
+| Linear      | O(n)          | Good      |
+| NLogN       | O(nLog(n))    | Good      |
+| LogLinear   | O(nlog\_2(n)) | Okay      |
+| Quadratic   | O(n^2)        | Bad       |
+| Cubic       | O(n^3)        | Very Bad  |
+| SqrtN       | O(sqrt(n))    | Very Good |
+| Exponential | O(2^n)        | Very Bad  |
+| Factorial   | O(n!)         | Worst!    |
+
+Note: there is no `Constant` / `O(1)` model and no isolated `Logarithmic` / `O(log n)` model — pure-constant data will still report the closest fit (typically Linear with a near‑zero slope).
 
 If using Sailfish as a test project, you can create a `.sailfish.json` file in the root of your test project (next to your `.csproj` file). This file can hold various configuration settings. When found, SailDiff will be automatically run. If any compatible setting is omitted, a sensible default will be used.
 
@@ -40,8 +61,8 @@ If using Sailfish as a test project, you can create a `.sailfish.json` file in t
     "SampleSizeOverride": 30
   },
   "SailDiffSettings": {
-    "TestType": "TTest",
-    "Alpha": 0.005,
+    "TestType": "Test",
+    "Alpha": 0.001,
     "Disabled": false
   },
   "ScaleFishSettings": {},
@@ -130,7 +151,7 @@ Sailfish provides basic tools for loading models and making predictions.
 ```csharp
 var model = ModelLoader
   .LoadModelFile("ScalefishModels_#####_####.json")
-  .GetScalefishModel(
+  .GetScaleFishModel(
     nameof(ScaleFishExample),
     nameof(ScaleFishExample.Linear),
     nameof(ScaleFishExample.N));

--- a/site/src/pages/docs/3/extensibility.md
+++ b/site/src/pages/docs/3/extensibility.md
@@ -119,6 +119,7 @@ public record TestClassCompletedNotification(
 ## TestCaseDisabledNotification
 
 - A notification that signals that the current test case is disabled
+- Currently declared `internal` — consumers cannot subscribe directly. If you need this hook publicly, please open an issue.
 
 ```csharp
 internal record TestCaseDisabledNotification(
@@ -177,15 +178,8 @@ public record ScaleFishAnalysisCompleteNotification(
 - Used to write
 
 ```csharp
-public class SailDiffAnalysisCompleteNotification : INotification
-{
-    public IEnumerable<TestCaseResults> TestCaseResults { get; }
-    public string ResultsAsMarkdown { get; }
-
-    public SailDiffAnalysisCompleteNotification(IEnumerable<TestCaseResults> testCaseResults, string resultsAsMarkdown)
-    {
-        TestCaseResults = testCaseResults;
-        ResultsAsMarkdown = resultsAsMarkdown;
-    }
-}
+public record SailDiffAnalysisCompleteNotification(
+    IEnumerable<SailDiffResult> TestCaseResults,
+    string ResultsAsMarkdown)
+    : INotification;
 ```

--- a/site/src/pages/docs/4/releasenotes.md
+++ b/site/src/pages/docs/4/releasenotes.md
@@ -3,20 +3,30 @@ title: Release Notes
 ---
 
 ## Current Release Notes
-{% callout title="Build hygiene: Zero warnings" type="success" %}
-Core library, Test Adapter, and Analyzers all build cleanly on .NET 8 and .NET 9. Analyzer release tracking and test harness updates increased stability.
+
+{% callout title=".NET 10 support, .NET 8 dropped" type="success" %}
+Sailfish, `Sailfish.TestAdapter`, and `Sailfish.Analyzers` now target `net9.0` and `net10.0` only. If you're on `net8.0`, stay on Sailfish 0.0.115 or upgrade your project.
 {% /callout %}
 
+{% callout title="Feature: Configuration Recipes via SailfishPreset" type="note" %}
+`RunSettingsBuilder.WithPreset(SailfishPreset.Default | Tight | Relaxed)` seeds adaptive sampling, outlier handling, and SailDiff defaults from a single call. [Learn more →](/docs/1/presets)
+{% /callout %}
+
+{% callout title="Feature: RunOnce on method setup/teardown" type="note" %}
+`[SailfishMethodSetup(nameof(Foo), nameof(Bar), RunOnce = true)]` invokes a setup/teardown at most once per executor run, even when multiple `MethodNames` are listed. [Learn more →](/docs/1/sailfish-test-lifecycle)
+{% /callout %}
+
+{% callout title="Fix: SailfishComparison failure handling" type="note" %}
+Failed `[SailfishComparison]` members now publish `TestOutcome.Failed` (no more silent `TestOutcome.None`) and don't block sibling members from completing the comparison batch. [Learn more →](/docs/1/method-comparisons)
+{% /callout %}
 
 {% callout title="Feature highlight: Timer Calibration + Jitter Score" type="note" %}
 Captures timer resolution and baseline overhead, computes a 0–100 Jitter Score from dispersion, and surfaces it in Markdown, the manifest, and Environment Health (Timer Jitter). [Learn more →](/docs/1/markdown-output)
 {% /callout %}
 
-
 {% callout title="Feature highlight: Precision/Time Budget Controller" type="note" %}
 Helps tests finish within per-method time budgets by conservatively relaxing precision targets when enabled. [Learn more →](/docs/1/precision-time-budget)
 {% /callout %}
-
 
 {% callout title="Feature highlight: Environment Health Check" type="note" %}
 Validates your benchmarking environment and appends a health summary to each test’s Output window.


### PR DESCRIPTION
## Summary

A sweep of the documentation site (and `README.md` / `RELEASE_NOTES.md`) against the current source, prompted by a documentation completeness review. The goal was to find places where docs had drifted from the code — broken examples, stale defaults, fictional sample outputs, and missing coverage for recently-shipped features.

Highlights:

### 🔴 Broken examples (wouldn't compile against shipped code)
- SailDiff `"TestType": "TTest"` / `TestType.TTest` → `"Test"` / `TestType.Test` (enum member is `Test`, not `TTest` — `"TTest"` would fail JSON binding)
- `SailfDiffSettings(...)` → `SailDiffSettings(...)`
- `BeforeAndAfterFileLocationCommand` / `ReadInBeforeAndAfterDataCommand` → `…Request`; `BeforeFilePath` / `AfterFilePath` → plural
- `GetScalefishModel` → `GetScaleFishModel`
- `scalefish:` → `scaleFish:` (named-arg casing)
- `SailDiffAnalysisCompleteNotification` retyped to `IEnumerable<SailDiffResult>`
- `test-dependencies.md` rewritten so the examples actually compile

### 🟠 Drifted defaults and stale caveats
- `[Sailfish]` `SampleSize` / `NumWarmupIterations` default `3` (was documented as 20/2)
- SailDiff library default `alpha=0.001`, default test type `TwoSampleWilcoxonSignedRankTest` (was 0.005 + TTest)
- Removed “outlier attribute not yet exposed” copy — `OutlierStrategy` / `UseConfigurableOutlierDetection` are on `[Sailfish]`
- Removed “no Preset enum today” copy — `SailfishPreset` + `WithPreset` shipped
- `SailfishRangeVariable.step` documented correctly as the increment between values (not a "skip count")
- README: license is MIT; require .NET 9 / .NET 10

### 🟡 Sample output rewrites
- Session CSV is 8 columns, not 10 (CI95/CI99 MOE live in the tracking CSV)
- Method-comparison CSV is 11 columns with numeric ratio + CI bounds + q-value, not the old 7-column flat shape
- Markdown header is `# 📊 Test Session Results` with `Generated` / `Total Test Classes` / `Total Test Cases`; detail tables are five columns; pairwise output is the NxN matrix
- Markdown session filename: `..._MethodComparisons_yyyy-MM-dd_HH-mm-ss.md`
- Reproducibility manifest JSON uses verbatim property names (`Os`, `GcMode`, `Ci95MarginOfError`, `Ci99MarginOfError`) and includes the structured `Randomization` object
- Environment health entry name is `Background CPU` (not `Background CPU (process)`); flagged that `Power Plan` becomes `Power Management` on macOS

### 🔵 Missing coverage filled
- `required-attributes.md`: every `[Sailfish]` knob documented (`EnableDefaultDiagnosers`, `OutlierStrategy`, `UseConfigurableOutlierDetection`, `MinimumSampleSize`, `ConfidenceLevel`, `MaxConfidenceIntervalWidth`, `UseRelativeConfidenceInterval`); `[SailfishMethod]` properties (`Order`, `Disabled`, `DisableComplexity`, `DisableOverheadEstimation`)
- `method-comparisons.md`: `[SailfishComparison]` `DisplayName` / `Disabled`, plus a "Failure handling" subsection covering the recent fixes (failed members publish `TestOutcome.Failed`; batch counts only surviving members)
- `sailfish-test-lifecycle.md`: `RunOnce` on method setup / teardown
- `sailfish-variables.md`: full supported-types list, ScaleFish constraints (int + ≥3 values), `SailfishRangeVariable` ScaleFish overload
- `test-dependencies.md`: `IProvideAdditionalRegistrations`
- `scalefish.md`: enumerate the actual complexity classes — no `Logarithmic` / `Constant` model exists

### Release notes
Replaced the `vNEXT_VERSION` placeholder with v0.0.117 and added entries for `SailfishPreset`, `RunOnce`, the `SailfishComparison` batch + failed-outcome fixes, .NET 10 support, Rider discovery fixes, and the `TestClassInstantiationException` fix in the adapter settings loader.

## Test plan

- [ ] Skim the rendered site locally (`cd site && npm install && npm run dev`) to confirm markdoc callouts and tables render
- [ ] Spot-check the rewritten markdown / CSV sample blocks against a real `dotnet test` run
- [ ] Verify the JSON sample in `reproducibility-manifest.md` matches a freshly emitted `Manifest_*.json`
- [ ] Sanity-check `scalefish.md` snippet against `source/ScaleFishDemo/Program.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)