### PR TITLE
Docs: Rider VSTest project-name wildcard for Sailfish play buttons

### DIFF
--- a/site/src/pages/docs/2/sailfish.md
+++ b/site/src/pages/docs/2/sailfish.md
@@ -43,6 +43,29 @@ If using Sailfish as a test project, you can create a `.sailfish.json` file in t
 If you are using JetBrains Rider, you need to [enable VS Test Adapter Support](https://www.jetbrains.com/help/rider/Reference__Options__Tools__Unit_Testing__VSTest.html).
 
 In contrast to test frameworks natively supported by Rider, tests from VSTest adapters are only discovered after test projects are built.
+
+**Getting the gutter "play" buttons to appear on Sailfish tests**
+
+Rider does not auto-detect VSTest-based test projects unless they reference one of the natively supported adapters (NUnit, xUnit, MSTest). Because Sailfish ships its own VSTest adapter, you need to tell Rider which of your projects to treat as test projects via a file-mask wildcard.
+
+1. Open **Settings → Build, Execution, Deployment → Unit Testing → VSTest**.
+2. Tick the checkbox at the top of the page to enable VSTest discovery.
+3. Under **Projects with unit tests**, add a file mask that matches your Sailfish test projects. The mask is matched against the `.csproj` filename.
+
+Examples — pick patterns that match how you name your Sailfish projects:
+
+```
+**performance-test*.csproj
+**benchmark*.csproj
+**PerformanceTests.csproj
+**Benchmarks.csproj
+```
+
+You can add multiple patterns. The `*` and `?` wildcards behave as in standard file globs (`?` = one character, `*` = zero or more).
+
+4. Build your solution. The play-button gutter icons should now appear next to each `[Sailfish]` class and test method.
+
+If the icons still don't appear, double-check that the project's `.csproj` filename actually matches one of your masks (the patterns operate on the project filename, not the assembly name or folder), and that the project has been built at least once since the masks were added.
 {% /callout %}
 
 


### PR DESCRIPTION
## Summary
- The existing Rider setup callout in `docs/2/sailfish.md` told users to "enable VS Test Adapter Support" but stopped there — many users still don't get gutter play buttons because Rider also requires a file-mask wildcard under **Projects with unit tests** to recognize projects that don't reference a natively-supported adapter (NUnit/xUnit/MSTest).
- Added step-by-step guidance: the exact Settings path, example patterns (`**performance-test*.csproj`, `**benchmark*.csproj`, `**PerformanceTests.csproj`, `**Benchmarks.csproj`), how `*`/`?` wildcards behave, and a short troubleshooting note (the mask matches the `.csproj` filename, and the project must be built at least once).

## Test plan
- [ ] Render the site locally and confirm the new section appears inside the existing "JetBrains Rider setup" callout under `/docs/2/sailfish`
- [ ] Verify links and code blocks display correctly
- [ ] Sanity-check the steps against a real Rider install (Settings → Build, Execution, Deployment → Unit Testing → VSTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)