### PR TITLE
ScaleFish phase 3: CV stability, tail percentiles, trend tracking, adaptive recommender, HTML report

### DIFF
--- a/site/src/pages/docs/2/scalefish.md
+++ b/site/src/pages/docs/2/scalefish.md
@@ -93,6 +93,11 @@ All ScaleFish settings are optional — omit any field to keep the default. Avai
 | `EnableParallelBootstrap` | `bool` | `true` | Run bootstrap iterations across multiple threads (output is bit-for-bit identical to the serial version — each iteration's RNG is seeded from `(data-hash, iteration-index)`). |
 | `EnableContinuousExponent` | `bool` | `true` | Fit the continuous power-log `(b, c)` diagnostic. |
 | `DistinguishabilityDelta` | `double` | `2.0` | Δ-AICc threshold for declaring the best model statistically separable from the runner-up. Raise to be more conservative. |
+| `EnableCrossValidation` | `bool` | `true` | Run leave-one-X-out cross-validation as an out-of-sample check on the classification. Produces `CvStability` with rank-agreement and prediction-error metrics. |
+| `EnableTailPercentileFits` | `bool` | `true` | When raw replicates are present, fit ScaleFish separately on per-X percentiles (default p50/p95/p99). Reveals when the tail scales differently from the mean. |
+| `TailPercentiles` | `double[]` | `[0.50, 0.95, 0.99]` | Percentiles to fit. Values must be in (0, 1). |
+| `EnableTrendTracking` | `bool` | `true` | Persist a per-run snapshot to the tracking directory and surface class transitions / parameter drift against the most-recent prior snapshot. |
+| `EmitHtmlReport` | `bool` | `true` | Emit a standalone HTML report (with inline SVG plots) alongside the markdown one. |
 
 Example `.sailfish.json`:
 
@@ -148,9 +153,9 @@ Custom families serialise/deserialise through the standard ScaleFish model file 
 
 **Test Class: ScaleFishExample**
 
-| Variable                  | BestFit | BigO | GoodnessOfFit | NextBest | NextBigO   | NextBestGoodnessOfFit | DeltaAICc | AkaikeWeight | Distinguishable | ContinuousExponent | SuggestNextN |
-| ------------------------- | ------- | ---- | ------------- | -------- | ---------- | --------------------- | --------- | ------------ | --------------- | ------------------ | ------------ |
-| ScaleFishExample.Linear.N | Linear  | O(n) | 0.99          | NLogN    | O(nLog(n)) | 0.99                  | 18.4      | 0.999        | yes             | b=1.03, c=0.02     | —            |
+| Variable                  | BestFit | BigO | GoodnessOfFit | NextBest | NextBigO   | NextBestGoodnessOfFit | DeltaAICc | AkaikeWeight | Distinguishable | ContinuousExponent | SuggestNextN | CvStability    |
+| ------------------------- | ------- | ---- | ------------- | -------- | ---------- | --------------------- | --------- | ------------ | --------------- | ------------------ | ------------ | -------------- |
+| ScaleFishExample.Linear.N | Linear  | O(n) | 0.99          | NLogN    | O(nLog(n)) | 0.99                  | 18.4      | 0.999        | yes             | b=1.03, c=0.02     | —            | agree=1.00 k=6 |
 
 For each variable, all other variables are held constant at their smallest scale. For each candidate family the estimator performs a **linear-in-parameters fit** (using `y = scale · basis(x) + bias`, with variance-weighting when replicate uncertainty is available) and computes:
 
@@ -160,6 +165,48 @@ For each variable, all other variables are held constant at their smallest scale
 - **Distinguishable** — `yes` when DeltaAICc ≥ 2, `no` when the top two candidates are too close to call.
 - **ContinuousExponent** — `b` and `c` from a continuous `y = a · x^b · (log x)^c + d` fit. Useful when reality is between two textbook curves (e.g. `b = 1.4, c = 0`: between Linear and Quadratic).
 - **SuggestNextN** — when `Distinguishable` is `no`, a recommended next X to add that would maximally separate the top two candidate families. Shown as `—` once the result is already distinguishable.
+- **CvStability** — leave-one-X-out rank agreement and fold count. `agree=1.00` means every hold-out fold picked the same winning family as the all-data fit.
+
+### Tail-percentile fits
+
+When raw replicates are present, ScaleFish additionally classifies each requested percentile (p50/p95/p99 by default). The result's `TailFits` collection has one entry per percentile, each with its own family classification, R², ΔAICc, Akaike weight, distinguishability flag, and fitted (scale, bias). Useful for spotting cases where the mean scales linearly but the p99 has quadratic behaviour — typically a sign of GC pauses, lock contention, or other amplifying noise sources.
+
+### Trend tracking & complexity regression detection
+
+When `EnableTrendTracking` is on (default), every ScaleFish run writes a slim per-fit snapshot under `<TrackingDir>/ComplexityHistory/` indexed by timestamp and commit SHA (resolved from `GITHUB_SHA`, `CI_COMMIT_SHA`, `BUILD_SOURCEVERSION`, `CIRCLE_SHA1`, `GIT_COMMIT`, or `git rev-parse HEAD` — whichever is available). On subsequent runs, the new snapshot is diffed against the most-recent prior; any transitions are appended to the markdown report and published via a `ComplexityRegressionDetectedNotification` for downstream consumers (CI scripts, IDE plugins).
+
+Transition kinds:
+
+| Kind | Meaning |
+| --- | --- |
+| `Stable` | Same best family, parameters within ±25 %, distinguishability flag unchanged. |
+| `ParameterDrift` | Same best family, but `scale` shifted more than ±25 % between snapshots. |
+| `ClassChanged` | Best family flipped (e.g. `O(n)` → `O(n²)`). The headline regression case. |
+| `DistinguishabilityChanged` | Family + parameters stable, but the `Distinguishable` flag flipped. |
+
+The `Stable` kind is filtered out of the markdown section; the notification only fires on non-stable transitions.
+
+### Adaptive X recommender
+
+`AdaptiveXRecommender` is a planning helper for sizing the next probe set:
+
+```csharp
+// Geometric initial probe across [16, 2048] with 7 points
+var probe = AdaptiveXRecommender.RecommendInitialProbe(minN: 16, maxN: 2048, points: 7);
+
+// Or refine against a prior run that came back undistinguishable
+var refined = AdaptiveXRecommender.RecommendRefinement(
+    previousProbeXs: probe,
+    previous: priorScaleFishModel,
+    targetMaxN: 16_384,
+    extraPoints: 3);
+```
+
+It's a pure function — copy the returned X values into a `SailfishVariableAttribute` for the next run.
+
+### HTML report
+
+With `EmitHtmlReport` enabled (default), ScaleFish writes `ScaleFishReport_yyyyMMdd-HHmmss.html` next to the markdown output. The file is self-contained (inline SVG and CSS, no external dependencies) and includes the empirical points, best/runner-up fitted curves, metrics tables, and tail-percentile blocks for each property.
 
 ## Models
 

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -58,6 +58,11 @@ public static class AdapterRunSettingsLoader
         if (parsed.EnableParallelBootstrap is not null) mapped.EnableParallelBootstrap = parsed.EnableParallelBootstrap.Value;
         if (parsed.EnableContinuousExponent is not null) mapped.EnableContinuousExponent = parsed.EnableContinuousExponent.Value;
         if (parsed.DistinguishabilityDelta is not null) mapped.DistinguishabilityDelta = parsed.DistinguishabilityDelta.Value;
+        if (parsed.EnableCrossValidation is not null) mapped.EnableCrossValidation = parsed.EnableCrossValidation.Value;
+        if (parsed.EnableTailPercentileFits is not null) mapped.EnableTailPercentileFits = parsed.EnableTailPercentileFits.Value;
+        if (parsed.TailPercentiles is not null && parsed.TailPercentiles.Length > 0) mapped.TailPercentiles = parsed.TailPercentiles;
+        if (parsed.EnableTrendTracking is not null) mapped.EnableTrendTracking = parsed.EnableTrendTracking.Value;
+        if (parsed.EmitHtmlReport is not null) mapped.EmitHtmlReport = parsed.EmitHtmlReport.Value;
         return mapped;
     }
 

--- a/source/Sailfish.TestAdapter/TestSettingsParser/ScaleFishSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/ScaleFishSettings.cs
@@ -20,4 +20,19 @@ public class ScaleFishSettings
 
     /// <summary>Δ-AICc threshold for declaring the best model "distinguishable".</summary>
     public double? DistinguishabilityDelta { get; set; }
+
+    /// <summary>Run leave-one-X-out cross-validation as a hold-out check.</summary>
+    public bool? EnableCrossValidation { get; set; }
+
+    /// <summary>Fit complexity on per-X percentile data (p50/p95/p99 by default).</summary>
+    public bool? EnableTailPercentileFits { get; set; }
+
+    /// <summary>Percentiles to fit when tail-percentile fits are enabled. Values in (0, 1).</summary>
+    public double[]? TailPercentiles { get; set; }
+
+    /// <summary>Persist a per-run snapshot to the tracking directory and diff against prior snapshots.</summary>
+    public bool? EnableTrendTracking { get; set; }
+
+    /// <summary>Emit a standalone HTML report alongside the markdown one.</summary>
+    public bool? EmitHtmlReport { get; set; }
 }

--- a/source/Sailfish/Analysis/ScaleFish/AdaptiveXRecommender.cs
+++ b/source/Sailfish/Analysis/ScaleFish/AdaptiveXRecommender.cs
@@ -70,8 +70,21 @@ public static class AdaptiveXRecommender
             // doubling, ignoring the suggestion. Caller can raise targetMaxN if desired.
             floor = currentMax + 1;
 
+        // SpacedRange requires count ≤ (end - start + 1) distinct integers. Cap extraPoints so a
+        // narrow extension range (e.g. floor = currentMax + 1 with default extraPoints = 3) degrades
+        // to whatever is achievable rather than throwing.
+        var availableIntegers = targetMaxN - floor + 1;
+        if (availableIntegers < 2)
+        {
+            // Even a single new point won't satisfy SpacedRange's count >= 2 contract — fall back to
+            // appending the single available integer at the end of the existing set.
+            if (availableIntegers == 1) existing.Add(floor);
+            return existing.Distinct().OrderBy(x => x).ToList();
+        }
+
+        var cappedExtraPoints = Math.Min(extraPoints, availableIntegers);
         var extras = SailfishRangeVariableAttribute
-            .SpacedRange(floor, targetMaxN, extraPoints, RangeSpacing.Geometric)
+            .SpacedRange(floor, targetMaxN, cappedExtraPoints, RangeSpacing.Geometric)
             .ToList();
 
         // Merge with existing, dedup, sort.

--- a/source/Sailfish/Analysis/ScaleFish/AdaptiveXRecommender.cs
+++ b/source/Sailfish/Analysis/ScaleFish/AdaptiveXRecommender.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Attributes;
+
+namespace Sailfish.Analysis.ScaleFish;
+
+/// <summary>
+/// Pre-run helper that recommends an optimal X probe set for a ScaleFish run, given a target N range and
+/// (optionally) a prior <see cref="ScaleFishModel"/>. Geometric spacing is used by default — equally
+/// spaced in log-x gives the most discrimination per data point.
+///
+/// <para>
+/// This is a planning utility — the user copies the recommended values into a
+/// <see cref="SailfishVariableAttribute"/> or <see cref="SailfishRangeVariableAttribute"/> for the next
+/// run. We deliberately don't drive the execution loop directly so the recommender stays a pure function
+/// and integrates with any test runner without pipeline changes.
+/// </para>
+/// </summary>
+public static class AdaptiveXRecommender
+{
+    /// <summary>
+    /// Recommend a geometric probe set in [<paramref name="minN"/>, <paramref name="maxN"/>] with
+    /// <paramref name="points"/> points. Equivalent to <see cref="SailfishRangeVariableAttribute.SpacedRange"/>
+    /// in Geometric mode but exposed as a planning helper.
+    /// </summary>
+    public static IReadOnlyList<int> RecommendInitialProbe(int minN, int maxN, int points = 6)
+    {
+        if (points < 2) throw new ArgumentException("points must be ≥ 2", nameof(points));
+        if (minN < 1) throw new ArgumentException("minN must be ≥ 1", nameof(minN));
+        if (maxN <= minN) throw new ArgumentException("maxN must be > minN", nameof(maxN));
+        if (points > maxN - minN + 1)
+            throw new ArgumentException("points exceeds available integer values in [minN, maxN]");
+
+        return SailfishRangeVariableAttribute.SpacedRange(minN, maxN, points, RangeSpacing.Geometric).ToArray();
+    }
+
+    /// <summary>
+    /// Given a prior ScaleFish run and a target upper bound, recommend the next probe set. Strategy:
+    /// extend the current max X geometrically up to <paramref name="targetMaxN"/> and add enough new
+    /// points so the curves diverge enough to flip the classification's <c>IsDistinguishable</c> flag.
+    /// </summary>
+    /// <param name="previousProbeXs">The X values that produced <paramref name="previous"/>.</param>
+    /// <param name="previous">The model fitted on <paramref name="previousProbeXs"/>.</param>
+    /// <param name="targetMaxN">Desired upper bound for the next probe set.</param>
+    /// <param name="extraPoints">How many *new* X values to add beyond the previous max. Defaults to 3.</param>
+    public static IReadOnlyList<int> RecommendRefinement(
+        IReadOnlyList<int> previousProbeXs,
+        ScaleFishModel previous,
+        int targetMaxN,
+        int extraPoints = 3)
+    {
+        if (previousProbeXs is null || previousProbeXs.Count == 0)
+            throw new ArgumentException("previousProbeXs must contain at least one X", nameof(previousProbeXs));
+        if (previous is null) throw new ArgumentNullException(nameof(previous));
+        if (extraPoints < 1) throw new ArgumentException("extraPoints must be ≥ 1", nameof(extraPoints));
+
+        var existing = previousProbeXs.OrderBy(x => x).Distinct().ToList();
+        var currentMax = existing[^1];
+        if (targetMaxN <= currentMax) return existing;
+
+        // If the previous run flagged a suggested next N, use it as a floor for where the extension
+        // begins so the geometric extension starts at the divergence point.
+        var floor = previous.SuggestedNextN.HasValue
+            ? Math.Max(currentMax + 1, previous.SuggestedNextN.Value)
+            : currentMax + 1;
+
+        if (floor > targetMaxN)
+            // The suggested next N already exceeds the target — extend from current max via geometric
+            // doubling, ignoring the suggestion. Caller can raise targetMaxN if desired.
+            floor = currentMax + 1;
+
+        var extras = SailfishRangeVariableAttribute
+            .SpacedRange(floor, targetMaxN, extraPoints, RangeSpacing.Geometric)
+            .ToList();
+
+        // Merge with existing, dedup, sort.
+        return existing.Concat(extras).Distinct().OrderBy(x => x).ToList();
+    }
+}

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityComputer.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityComputer.cs
@@ -8,6 +8,38 @@ namespace Sailfish.Analysis.ScaleFish;
 public interface IComplexityComputer
 {
     IEnumerable<ScalefishClassModel> AnalyzeComplexity(List<IClassExecutionSummary> executionSummaries);
+
+    /// <summary>
+    /// Same analysis as <see cref="AnalyzeComplexity(List{IClassExecutionSummary})"/> but additionally
+    /// returns the per-property <see cref="ComplexityMeasurement"/> arrays that fed the estimator,
+    /// keyed by <c>MethodName.PropertyName</c> to match <see cref="ScaleFishPropertyModel.PropertyName"/>.
+    /// Used by the HTML report renderer to plot empirical points alongside the fitted curves.
+    /// </summary>
+    ComplexityAnalysisResult AnalyzeComplexityWithMeasurements(List<IClassExecutionSummary> executionSummaries);
+}
+
+/// <summary>
+/// Bundles the analysis output (classifications) with the per-property measurement vectors that were
+/// passed to the estimator.
+/// </summary>
+public sealed class ComplexityAnalysisResult
+{
+    public ComplexityAnalysisResult(
+        IReadOnlyList<ScalefishClassModel> classes,
+        IReadOnlyDictionary<string, ComplexityMeasurement[]> measurementsByPropertyKey)
+    {
+        Classes = classes;
+        MeasurementsByPropertyKey = measurementsByPropertyKey;
+    }
+
+    /// <summary>Per-class classification models — same shape as <see cref="IComplexityComputer.AnalyzeComplexity"/>.</summary>
+    public IReadOnlyList<ScalefishClassModel> Classes { get; }
+
+    /// <summary>
+    /// Per-property measurements, keyed by <c>MethodName.PropertyName</c> (same string as
+    /// <see cref="ScaleFishPropertyModel.PropertyName"/>) so callers can join models to their inputs.
+    /// </summary>
+    public IReadOnlyDictionary<string, ComplexityMeasurement[]> MeasurementsByPropertyKey { get; }
 }
 
 public class ComplexityComputer : IComplexityComputer
@@ -24,26 +56,36 @@ public class ComplexityComputer : IComplexityComputer
 
     public IEnumerable<ScalefishClassModel> AnalyzeComplexity(List<IClassExecutionSummary> executionSummaries)
     {
+        return AnalyzeComplexityWithMeasurements(executionSummaries).Classes;
+    }
+
+    public ComplexityAnalysisResult AnalyzeComplexityWithMeasurements(List<IClassExecutionSummary> executionSummaries)
+    {
         var finalResult = new Dictionary<Type, ComplexityMethodResult>();
+        var measurementsByKey = new Dictionary<string, ComplexityMeasurement[]>(StringComparer.Ordinal);
+
         foreach (var testClassSummary in executionSummaries)
         {
             var observationSet = _scalefishObservationCompiler.CompileObservationSet(testClassSummary);
             if (observationSet is null) continue;
 
-            var resultsByMethod = ComputeComplexityMethodResult(observationSet);
+            var resultsByMethod = ComputeComplexityMethodResult(observationSet, measurementsByKey);
 
             finalResult.Add(testClassSummary.TestClass, resultsByMethod);
         }
 
-        return ScalefishClassModel.ParseResults(finalResult);
+        var classes = ScalefishClassModel.ParseResults(finalResult).ToList();
+        return new ComplexityAnalysisResult(classes, measurementsByKey);
     }
 
-    private ComplexityMethodResult ComputeComplexityMethodResult(ObservationSetFromSummaries observationSet)
+    private ComplexityMethodResult ComputeComplexityMethodResult(
+        ObservationSetFromSummaries observationSet,
+        Dictionary<string, ComplexityMeasurement[]> measurementsByKey)
     {
         var methodResult = new ComplexityMethodResult();
         foreach (var observationMethodGroup in observationSet.Observations.GroupBy(x => x.MethodName))
         {
-            var complexityResultMap = ComputeComplexityPropertyResult(observationMethodGroup);
+            var complexityResultMap = ComputeComplexityPropertyResult(observationMethodGroup, measurementsByKey);
 
             methodResult.Add(observationMethodGroup.Key, complexityResultMap);
         }
@@ -51,13 +93,18 @@ public class ComplexityComputer : IComplexityComputer
         return methodResult;
     }
 
-    private ComplexityProperty ComputeComplexityPropertyResult(IEnumerable<ScaleFishObservation> observationMethodGroup)
+    private ComplexityProperty ComputeComplexityPropertyResult(
+        IEnumerable<ScaleFishObservation> observationMethodGroup,
+        Dictionary<string, ComplexityMeasurement[]> measurementsByKey)
     {
         var complexityResultMap = new ComplexityProperty();
         foreach (var observationProperty in observationMethodGroup.ToList())
         {
             var complexityResult = _complexityEstimator.EstimateComplexity(observationProperty.ComplexityMeasurements);
-            if (complexityResult is not null) complexityResultMap.Add(observationProperty.ToString(), complexityResult);
+            if (complexityResult is null) continue;
+            var key = observationProperty.ToString();
+            complexityResultMap.Add(key, complexityResult);
+            measurementsByKey[key] = observationProperty.ComplexityMeasurements;
         }
 
         return complexityResultMap;

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
@@ -79,10 +79,35 @@ public class ComplexityEstimator : IComplexityEstimator
                 _settings.EnableParallelBootstrap);
         }
 
-        return Build(point, powerLog, bootstrap, measurements);
+        // Optional cross-validation — leave-one-X-out check against the all-data classification.
+        CrossValidationDiagnostic? crossValidation = null;
+        if (_settings.EnableCrossValidation)
+        {
+            crossValidation = RunCrossValidation(
+                measurements!,
+                point.Best.Function.Name,
+                _settings.DistinguishabilityDelta);
+        }
+
+        // Optional per-percentile fits — needs raw replicates at every X.
+        IReadOnlyList<TailFitResult> tailFits = Array.Empty<TailFitResult>();
+        if (_settings.EnableTailPercentileFits
+            && _settings.TailPercentiles is { Length: > 0 }
+            && measurements!.All(m => m.RawSamples is { Length: >= 2 }))
+        {
+            tailFits = RunTailPercentileFits(measurements!, _settings.TailPercentiles, _settings.DistinguishabilityDelta);
+        }
+
+        return Build(point, powerLog, bootstrap, crossValidation, tailFits, measurements);
     }
 
-    private ScaleFishModel Build(PointEstimate point, PowerLogResult? powerLog, BootstrapDiagnostic? bootstrap, ComplexityMeasurement[] measurements)
+    private ScaleFishModel Build(
+        PointEstimate point,
+        PowerLogResult? powerLog,
+        BootstrapDiagnostic? bootstrap,
+        CrossValidationDiagnostic? crossValidation,
+        IReadOnlyList<TailFitResult> tailFits,
+        ComplexityMeasurement[] measurements)
     {
         return new ScaleFishModel(
             point.Best.Function,
@@ -97,8 +122,152 @@ public class ComplexityEstimator : IComplexityEstimator
             powerLog: powerLog)
         {
             Bootstrap = bootstrap,
+            CrossValidation = crossValidation,
+            TailFits = tailFits,
             SuggestedNextN = SuggestNextN(point, measurements)
         };
+    }
+
+    /// <summary>
+    /// For each requested percentile, replace each X's mean with that percentile of its raw replicates
+    /// and re-run the family-ranking pipeline. Produces a slim per-percentile classification so the
+    /// caller can see whether the tail (p95/p99) scales differently from the mean.
+    /// </summary>
+    private static IReadOnlyList<TailFitResult> RunTailPercentileFits(
+        ComplexityMeasurement[] measurements,
+        double[] percentiles,
+        double distinguishabilityDelta)
+    {
+        var results = new List<TailFitResult>(percentiles.Length);
+        foreach (var p in percentiles)
+        {
+            if (!(p > 0 && p < 1)) continue;
+            var shaped = new ComplexityMeasurement[measurements.Length];
+            for (var i = 0; i < measurements.Length; i++)
+            {
+                var raw = measurements[i].RawSamples!;
+                var y = PercentileOf(raw, p);
+                // Slim measurement — y replaced with the percentile, retain X. Drop raw samples to
+                // keep the tail-fit recursion bounded (no nested bootstrap on tail fits).
+                shaped[i] = new ComplexityMeasurement(measurements[i].X, y);
+            }
+
+            var foldPoint = RankCandidates(shaped, distinguishabilityDelta);
+            if (foldPoint is null) continue;
+
+            var best = foldPoint.Best.Function;
+            var next = foldPoint.NextBest.Function;
+            var bestScale = best.FunctionParameters?.Scale ?? double.NaN;
+            var bestBias = best.FunctionParameters?.Bias ?? double.NaN;
+
+            results.Add(new TailFitResult(
+                percentile: p,
+                bestFamilyName: best.Name,
+                bestFamilyOName: best.OName,
+                bestRSquared: foldPoint.Best.Fitness.RSquared,
+                nextFamilyName: next.Name,
+                nextRSquared: foldPoint.NextBest.Fitness.RSquared,
+                bestAicc: foldPoint.Best.Aicc,
+                nextBestAicc: foldPoint.NextBest.Aicc,
+                akaikeWeight: foldPoint.AkaikeWeight,
+                isDistinguishable: foldPoint.IsDistinguishable,
+                sampleSize: foldPoint.SampleSize,
+                bestScale: bestScale,
+                bestBias: bestBias));
+        }
+        return results;
+    }
+
+    /// <summary>
+    /// Linear-interpolated percentile of an unsorted sample. <c>p</c> is in (0, 1).
+    /// </summary>
+    private static double PercentileOf(double[] samples, double p)
+    {
+        if (samples.Length == 0) return double.NaN;
+        if (samples.Length == 1) return samples[0];
+        var sorted = (double[])samples.Clone();
+        Array.Sort(sorted);
+        var rank = p * (sorted.Length - 1);
+        var lo = (int)Math.Floor(rank);
+        var hi = (int)Math.Ceiling(rank);
+        if (lo == hi) return sorted[lo];
+        var frac = rank - lo;
+        return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+    }
+
+    /// <summary>
+    /// Leave-one-X-out cross-validation. For each X, refit all candidates on the remaining points, record
+    /// whether the fold's best matches the all-data best (rank agreement), and predict at the held-out X
+    /// using the all-data winning family refit on the fold's training data (mean/median prediction error).
+    /// </summary>
+    private static CrossValidationDiagnostic? RunCrossValidation(
+        ComplexityMeasurement[] measurements,
+        string allDataBestFamilyName,
+        double distinguishabilityDelta)
+    {
+        // Need at least 4 X values so each fold trains on >= 3 (the minimum n for the OLS fit to be well-posed).
+        if (measurements is null || measurements.Length < 4) return null;
+
+        // Pre-filter the same way RankCandidates would, so n-counts align.
+        var cleaned = measurements.Where(m => double.IsFinite(m.Y) && double.IsFinite(m.X)).ToArray();
+        if (cleaned.Length < 4) return null;
+
+        var predErrors = new List<double>(cleaned.Length);
+        var agreements = 0;
+        var validFolds = 0;
+
+        for (var i = 0; i < cleaned.Length; i++)
+        {
+            var heldOut = cleaned[i];
+            var trainCount = cleaned.Length - 1;
+            var train = new ComplexityMeasurement[trainCount];
+            for (int src = 0, dst = 0; src < cleaned.Length; src++)
+            {
+                if (src == i) continue;
+                train[dst++] = cleaned[src];
+            }
+
+            var foldPoint = RankCandidates(train, distinguishabilityDelta);
+            if (foldPoint is null) continue;
+
+            if (string.Equals(foldPoint.Best.Function.Name, allDataBestFamilyName, StringComparison.Ordinal))
+                agreements++;
+
+            // Refit the all-data winning family on this fold's training data to get an honest prediction.
+            var ownInstance = ComplexityFunctionRegistry.CreateFitInstances()
+                .FirstOrDefault(f => f.Name == allDataBestFamilyName);
+            if (ownInstance is null) continue;
+
+            try
+            {
+                var fit = ownInstance.AnalyzeFitness(train);
+                if (!fit.IsValid || ownInstance.FunctionParameters is null) continue;
+                var predicted = ownInstance.Predict((int)heldOut.X);
+                if (!double.IsFinite(predicted)) continue;
+                var err = Math.Abs(predicted - heldOut.Y);
+                if (!double.IsFinite(err)) continue;
+                predErrors.Add(err);
+                validFolds++;
+            }
+            catch
+            {
+                // skip this fold
+            }
+        }
+
+        // Require at least 3 valid folds to report a CV signal — fewer is statistically meaningless.
+        if (validFolds < 3 || predErrors.Count < 3) return null;
+
+        var rankAgreement = agreements / (double)validFolds;
+        var mean = predErrors.Average();
+        var sorted = predErrors.OrderBy(v => v).ToArray();
+        double median;
+        if (sorted.Length % 2 == 0)
+            median = (sorted[sorted.Length / 2 - 1] + sorted[sorted.Length / 2]) / 2.0;
+        else
+            median = sorted[sorted.Length / 2];
+
+        return new CrossValidationDiagnostic(validFolds, rankAgreement, mean, median);
     }
 
     /// <summary>

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
@@ -213,8 +213,12 @@ public class ComplexityEstimator : IComplexityEstimator
         if (cleaned.Length < 4) return null;
 
         var predErrors = new List<double>(cleaned.Length);
-        var agreements = 0;
-        var validFolds = 0;
+        // Rank agreement and prediction error live on *independent* denominators: a fold can rank
+        // successfully but fail prediction (e.g. the all-data winner's Compute overflows on this
+        // fold's training data), or vice versa. Mixing them — using prediction-fold count as the
+        // rank denominator — can drive rankAgreement above 1.0, which is meaningless.
+        var rankFolds = 0;
+        var rankAgreements = 0;
 
         for (var i = 0; i < cleaned.Length; i++)
         {
@@ -230,8 +234,9 @@ public class ComplexityEstimator : IComplexityEstimator
             var foldPoint = RankCandidates(train, distinguishabilityDelta);
             if (foldPoint is null) continue;
 
+            rankFolds++;
             if (string.Equals(foldPoint.Best.Function.Name, allDataBestFamilyName, StringComparison.Ordinal))
-                agreements++;
+                rankAgreements++;
 
             // Refit the all-data winning family on this fold's training data to get an honest prediction.
             var ownInstance = ComplexityFunctionRegistry.CreateFitInstances()
@@ -247,18 +252,17 @@ public class ComplexityEstimator : IComplexityEstimator
                 var err = Math.Abs(predicted - heldOut.Y);
                 if (!double.IsFinite(err)) continue;
                 predErrors.Add(err);
-                validFolds++;
             }
             catch
             {
-                // skip this fold
+                // skip this fold's prediction contribution; rank-agreement is unaffected
             }
         }
 
-        // Require at least 3 valid folds to report a CV signal — fewer is statistically meaningless.
-        if (validFolds < 3 || predErrors.Count < 3) return null;
+        // Require at least 3 valid folds (rank-wise) to report a CV signal — fewer is statistically meaningless.
+        if (rankFolds < 3 || predErrors.Count < 3) return null;
 
-        var rankAgreement = agreements / (double)validFolds;
+        var rankAgreement = rankAgreements / (double)rankFolds;
         var mean = predErrors.Average();
         var sorted = predErrors.OrderBy(v => v).ToArray();
         double median;
@@ -267,7 +271,7 @@ public class ComplexityEstimator : IComplexityEstimator
         else
             median = sorted[sorted.Length / 2];
 
-        return new CrossValidationDiagnostic(validFolds, rankAgreement, mean, median);
+        return new CrossValidationDiagnostic(rankFolds, rankAgreement, mean, median);
     }
 
     /// <summary>

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityFunctionConverter.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityFunctionConverter.cs
@@ -59,6 +59,8 @@ public class ComplexityFunctionConverter : JsonConverter<List<ScalefishClassMode
                     var powerLog = ReadOptionalPowerLog(complexityResultJsonElement);
                     var bootstrap = ReadOptionalBootstrap(complexityResultJsonElement);
                     var suggestedNextN = ReadOptionalNullableInt(complexityResultJsonElement, nameof(ScaleFishModel.SuggestedNextN));
+                    var crossValidation = ReadOptionalCrossValidation(complexityResultJsonElement);
+                    var tailFits = ReadOptionalTailFits(complexityResultJsonElement);
 
                     var complexityResult = new ScaleFishModel(
                         complexityFunction,
@@ -73,7 +75,9 @@ public class ComplexityFunctionConverter : JsonConverter<List<ScalefishClassMode
                         powerLog: powerLog)
                     {
                         Bootstrap = bootstrap,
-                        SuggestedNextN = suggestedNextN
+                        SuggestedNextN = suggestedNextN,
+                        CrossValidation = crossValidation,
+                        TailFits = tailFits
                     };
 
                     testPropertyComplexityResults.Add(new ScaleFishPropertyModel(propertyName, complexityResult));
@@ -171,6 +175,45 @@ public class ComplexityFunctionConverter : JsonConverter<List<ScalefishClassMode
         var d = ReadOptionalDouble(prop, nameof(PowerLogResult.D), double.NaN);
         var r2 = ReadOptionalDouble(prop, nameof(PowerLogResult.RSquared), double.NaN);
         return new PowerLogResult(a, b, c, d, r2);
+    }
+
+    private static IReadOnlyList<TailFitResult> ReadOptionalTailFits(JsonElement parent)
+    {
+        if (!parent.TryGetProperty(nameof(ScaleFishModel.TailFits), out var prop)) return Array.Empty<TailFitResult>();
+        if (prop.ValueKind != JsonValueKind.Array) return Array.Empty<TailFitResult>();
+
+        var list = new List<TailFitResult>();
+        foreach (var item in prop.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            list.Add(new TailFitResult(
+                percentile: ReadOptionalDouble(item, nameof(TailFitResult.Percentile), double.NaN),
+                bestFamilyName: item.TryGetProperty(nameof(TailFitResult.BestFamilyName), out var bf) ? bf.GetString() ?? "" : "",
+                bestFamilyOName: item.TryGetProperty(nameof(TailFitResult.BestFamilyOName), out var bfo) ? bfo.GetString() ?? "" : "",
+                bestRSquared: ReadOptionalDouble(item, nameof(TailFitResult.BestRSquared), double.NaN),
+                nextFamilyName: item.TryGetProperty(nameof(TailFitResult.NextFamilyName), out var nf) ? nf.GetString() ?? "" : "",
+                nextRSquared: ReadOptionalDouble(item, nameof(TailFitResult.NextRSquared), double.NaN),
+                bestAicc: ReadOptionalDouble(item, nameof(TailFitResult.BestAicc), double.NaN),
+                nextBestAicc: ReadOptionalDouble(item, nameof(TailFitResult.NextBestAicc), double.NaN),
+                akaikeWeight: ReadOptionalDouble(item, nameof(TailFitResult.AkaikeWeight), double.NaN),
+                isDistinguishable: ReadOptionalBool(item, nameof(TailFitResult.IsDistinguishable), false),
+                sampleSize: ReadOptionalInt(item, nameof(TailFitResult.SampleSize), 0),
+                bestScale: ReadOptionalDouble(item, nameof(TailFitResult.BestScale), double.NaN),
+                bestBias: ReadOptionalDouble(item, nameof(TailFitResult.BestBias), double.NaN)));
+        }
+        return list;
+    }
+
+    private static CrossValidationDiagnostic? ReadOptionalCrossValidation(JsonElement parent)
+    {
+        if (!parent.TryGetProperty(nameof(ScaleFishModel.CrossValidation), out var prop)) return null;
+        if (prop.ValueKind == JsonValueKind.Null || prop.ValueKind != JsonValueKind.Object) return null;
+
+        var foldCount = ReadOptionalInt(prop, nameof(CrossValidationDiagnostic.FoldCount), 0);
+        var rankAgreement = ReadOptionalDouble(prop, nameof(CrossValidationDiagnostic.RankAgreement), double.NaN);
+        var meanError = ReadOptionalDouble(prop, nameof(CrossValidationDiagnostic.MeanPredictionError), double.NaN);
+        var medianError = ReadOptionalDouble(prop, nameof(CrossValidationDiagnostic.MedianPredictionError), double.NaN);
+        return new CrossValidationDiagnostic(foldCount, rankAgreement, meanError, medianError);
     }
 
     private static BootstrapDiagnostic? ReadOptionalBootstrap(JsonElement parent)

--- a/source/Sailfish/Analysis/ScaleFish/CurveFitting/CrossValidationDiagnostic.cs
+++ b/source/Sailfish/Analysis/ScaleFish/CurveFitting/CrossValidationDiagnostic.cs
@@ -1,0 +1,40 @@
+namespace Sailfish.Analysis.ScaleFish.CurveFitting;
+
+/// <summary>
+/// Leave-one-X-out cross-validation diagnostic. For each candidate family, each fold holds out one X value,
+/// refits on the remaining points, then scores the predictive error at the held-out point. Aggregating
+/// across folds gives both an out-of-sample fit quality (<see cref="MeanPredictionError"/>) and a stability
+/// signal (<see cref="RankAgreement"/>): the fraction of folds whose top-ranked family matched the
+/// all-data point estimate.
+///
+/// Complements AICc (which is in-sample) with a genuine hold-out check — particularly valuable at the
+/// small N counts ScaleFish typically runs at.
+/// </summary>
+public class CrossValidationDiagnostic
+{
+    public CrossValidationDiagnostic(int foldCount, double rankAgreement, double meanPredictionError, double medianPredictionError)
+    {
+        FoldCount = foldCount;
+        RankAgreement = rankAgreement;
+        MeanPredictionError = meanPredictionError;
+        MedianPredictionError = medianPredictionError;
+    }
+
+    /// <summary>Number of leave-one-out folds executed. Equals the number of usable X values.</summary>
+    public int FoldCount { get; init; }
+
+    /// <summary>
+    /// Fraction of folds that selected the same best family as the all-data point estimate.
+    /// 1.0 ⇒ perfectly stable across hold-outs; values near 1/k (k = candidate count) ⇒ effectively random.
+    /// </summary>
+    public double RankAgreement { get; init; }
+
+    /// <summary>
+    /// Mean absolute prediction error of the all-data winning family across hold-outs, in y-units.
+    /// Smaller is better; pair with <see cref="MedianPredictionError"/> to detect outlier folds.
+    /// </summary>
+    public double MeanPredictionError { get; init; }
+
+    /// <summary>Median absolute prediction error — robust complement to the mean.</summary>
+    public double MedianPredictionError { get; init; }
+}

--- a/source/Sailfish/Analysis/ScaleFish/CurveFitting/TailFitResult.cs
+++ b/source/Sailfish/Analysis/ScaleFish/CurveFitting/TailFitResult.cs
@@ -1,0 +1,65 @@
+namespace Sailfish.Analysis.ScaleFish.CurveFitting;
+
+/// <summary>
+/// Slim ScaleFish-style result for a single percentile (e.g. p50, p95, p99) of the raw replicates at each X.
+/// Carries the family classification and core diagnostics; deliberately omits nested bootstrap/CV/tail
+/// fits so the model file doesn't explode combinatorially.
+/// </summary>
+public class TailFitResult
+{
+    public TailFitResult(
+        double percentile,
+        string bestFamilyName,
+        string bestFamilyOName,
+        double bestRSquared,
+        string nextFamilyName,
+        double nextRSquared,
+        double bestAicc,
+        double nextBestAicc,
+        double akaikeWeight,
+        bool isDistinguishable,
+        int sampleSize,
+        double bestScale,
+        double bestBias)
+    {
+        Percentile = percentile;
+        BestFamilyName = bestFamilyName;
+        BestFamilyOName = bestFamilyOName;
+        BestRSquared = bestRSquared;
+        NextFamilyName = nextFamilyName;
+        NextRSquared = nextRSquared;
+        BestAicc = bestAicc;
+        NextBestAicc = nextBestAicc;
+        AkaikeWeight = akaikeWeight;
+        IsDistinguishable = isDistinguishable;
+        SampleSize = sampleSize;
+        BestScale = bestScale;
+        BestBias = bestBias;
+    }
+
+    /// <summary>Percentile in (0, 1), e.g. 0.95.</summary>
+    public double Percentile { get; init; }
+
+    public string BestFamilyName { get; init; }
+    public string BestFamilyOName { get; init; }
+    public double BestRSquared { get; init; }
+    public string NextFamilyName { get; init; }
+    public double NextRSquared { get; init; }
+
+    public double BestAicc { get; init; }
+    public double NextBestAicc { get; init; }
+    public double AkaikeWeight { get; init; }
+    public bool IsDistinguishable { get; init; }
+    public int SampleSize { get; init; }
+
+    /// <summary>Fitted <c>scale</c> coefficient of the best family at this percentile.</summary>
+    public double BestScale { get; init; }
+
+    /// <summary>Fitted <c>bias</c> intercept of the best family at this percentile.</summary>
+    public double BestBias { get; init; }
+
+    public double DeltaAicc =>
+        double.IsNaN(BestAicc) || double.IsNaN(NextBestAicc)
+            ? double.NaN
+            : NextBestAicc - BestAicc;
+}

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Sailfish.Analysis.ScaleFish.Trends;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Contracts.Public.Requests;
@@ -55,13 +58,129 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         {
             var complexityResults = _complexityComputer.AnalyzeComplexity(executionSummaries).ToList();
             var complexityMarkdown = _markdownTableConverter.ConvertScaleFishResultToMarkdown(complexityResults);
-            _consoleWriter.WriteString(complexityMarkdown);
 
-            await _mediator.Publish(new ScaleFishAnalysisCompleteNotification(complexityMarkdown, complexityResults), cancellationToken).ConfigureAwait(false);
+            // Optional trend tracking — persist a snapshot of every fit and diff against the most-recent
+            // prior snapshot. Failures here are swallowed so a missing tracking directory or a
+            // permission error never breaks the headline analysis output.
+            IReadOnlyList<ComplexityTransition> transitions = Array.Empty<ComplexityTransition>();
+            if (_runSettings.ScaleFishSettings.EnableTrendTracking)
+            {
+                try
+                {
+                    transitions = TrackAndDiff(complexityResults);
+                }
+                catch (Exception ex)
+                {
+                    _consoleWriter.WriteString($"ScaleFish trend tracking skipped: {ex.Message}");
+                }
+            }
+
+            var transitionMarkdown = FormatTransitions(transitions);
+            var fullMarkdown = string.IsNullOrEmpty(transitionMarkdown)
+                ? complexityMarkdown
+                : complexityMarkdown + Environment.NewLine + transitionMarkdown;
+
+            _consoleWriter.WriteString(fullMarkdown);
+
+            // Optional standalone HTML report — written alongside the markdown so users can open it
+            // directly. Wrapped in try/catch so a filesystem error here never kills the analysis.
+            if (_runSettings.ScaleFishSettings.EmitHtmlReport)
+            {
+                try
+                {
+                    EmitHtmlReport(complexityResults);
+                }
+                catch (Exception ex)
+                {
+                    _consoleWriter.WriteString($"ScaleFish HTML report skipped: {ex.Message}");
+                }
+            }
+
+            await _mediator.Publish(new ScaleFishAnalysisCompleteNotification(fullMarkdown, complexityResults), cancellationToken).ConfigureAwait(false);
+
+            // Surface complexity-regression transitions via a dedicated notification so downstream
+            // consumers (CI scripts, IDE plugins) can react without parsing markdown.
+            if (transitions.Any(t => t.IsRegression))
+            {
+                await _mediator.Publish(new ComplexityRegressionDetectedNotification(
+                        transitions.Where(t => t.IsRegression).ToList()),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
         }
         catch (Exception ex)
         {
             _consoleWriter.WriteString(ex.Message);
         }
+    }
+
+    private IReadOnlyList<ComplexityTransition> TrackAndDiff(IReadOnlyList<ScalefishClassModel> complexityResults)
+    {
+        var trackingDir = _runSettings.GetRunSettingsTrackingDirectoryPath();
+        var prior = ComplexityHistoryStore.LoadMostRecentPrior(trackingDir);
+        var commitSha = ComplexityHistoryStore.ResolveCommitSha();
+        var now = DateTime.UtcNow;
+
+        var entries = new List<ComplexityHistoryEntry>();
+        foreach (var classModel in complexityResults)
+        {
+            foreach (var methodModel in classModel.ScaleFishMethodModels)
+            {
+                foreach (var propModel in methodModel.ScaleFishPropertyModels)
+                {
+                    entries.Add(HistoryEntryFactory.Build(
+                        testClassFullName: $"{classModel.NameSpace}.{classModel.TestClassName}",
+                        methodName: methodModel.TestMethodName,
+                        propertyName: propModel.PropertyName,
+                        model: propModel.ScaleFishModel,
+                        commitSha: commitSha,
+                        timestampUtc: now));
+                }
+            }
+        }
+
+        if (entries.Count == 0) return Array.Empty<ComplexityTransition>();
+
+        ComplexityHistoryStore.Write(trackingDir, entries, now, commitSha);
+        if (prior.Count == 0) return Array.Empty<ComplexityTransition>();
+        return ComplexityHistoryDiffer.Diff(prior, entries);
+    }
+
+    private void EmitHtmlReport(IReadOnlyList<ScalefishClassModel> complexityResults)
+    {
+        // The renderer accepts a per-property measurements map for plotting empirical points. We don't
+        // currently surface measurements to ScaleFish.Analyze (the compiler shapes them per-property),
+        // so for now we emit a curves-only report. A future PR can plumb the per-property measurements
+        // through; the HTML still renders the metrics tables and tail-fit blocks meaningfully without
+        // the plotted points.
+        var html = Sailfish.Presentation.ScaleFishHtmlReportBuilder.Build(
+            complexityResults,
+            new System.Collections.Generic.Dictionary<string, Sailfish.Analysis.ScaleFish.ComplexityMeasurement[]>());
+
+        var outputDir = _runSettings.LocalOutputDirectory;
+        if (string.IsNullOrWhiteSpace(outputDir)) return;
+        if (!System.IO.Directory.Exists(outputDir)) System.IO.Directory.CreateDirectory(outputDir);
+
+        var fileName = $"ScaleFishReport_{DateTime.UtcNow:yyyyMMdd-HHmmss}.html";
+        var path = System.IO.Path.Combine(outputDir, fileName);
+        System.IO.File.WriteAllText(path, html);
+    }
+
+    private static string FormatTransitions(IReadOnlyList<ComplexityTransition> transitions)
+    {
+        if (transitions.Count == 0) return string.Empty;
+        var regressions = transitions.Where(t => t.IsRegression).ToList();
+        if (regressions.Count == 0) return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## ScaleFish complexity transitions");
+        sb.AppendLine();
+        sb.AppendLine("| Key | Kind | Summary |");
+        sb.AppendLine("| --- | --- | --- |");
+        foreach (var t in regressions)
+        {
+            sb.AppendLine($"| {t.Key} | {t.Kind} | {t.Summary} |");
+        }
+        return sb.ToString();
     }
 }

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
@@ -56,7 +56,8 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
 
         try
         {
-            var complexityResults = _complexityComputer.AnalyzeComplexity(executionSummaries).ToList();
+            var analysisResult = _complexityComputer.AnalyzeComplexityWithMeasurements(executionSummaries);
+            var complexityResults = analysisResult.Classes.ToList();
             var complexityMarkdown = _markdownTableConverter.ConvertScaleFishResultToMarkdown(complexityResults);
 
             // Optional trend tracking — persist a snapshot of every fit and diff against the most-recent
@@ -88,7 +89,7 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
             {
                 try
                 {
-                    EmitHtmlReport(complexityResults);
+                    EmitHtmlReport(complexityResults, analysisResult.MeasurementsByPropertyKey);
                 }
                 catch (Exception ex)
                 {
@@ -146,16 +147,11 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         return ComplexityHistoryDiffer.Diff(prior, entries);
     }
 
-    private void EmitHtmlReport(IReadOnlyList<ScalefishClassModel> complexityResults)
+    private void EmitHtmlReport(
+        IReadOnlyList<ScalefishClassModel> complexityResults,
+        IReadOnlyDictionary<string, ComplexityMeasurement[]> measurementsByKey)
     {
-        // The renderer accepts a per-property measurements map for plotting empirical points. We don't
-        // currently surface measurements to ScaleFish.Analyze (the compiler shapes them per-property),
-        // so for now we emit a curves-only report. A future PR can plumb the per-property measurements
-        // through; the HTML still renders the metrics tables and tail-fit blocks meaningfully without
-        // the plotted points.
-        var html = Sailfish.Presentation.ScaleFishHtmlReportBuilder.Build(
-            complexityResults,
-            new System.Collections.Generic.Dictionary<string, Sailfish.Analysis.ScaleFish.ComplexityMeasurement[]>());
+        var html = Sailfish.Presentation.ScaleFishHtmlReportBuilder.Build(complexityResults, measurementsByKey);
 
         var outputDir = _runSettings.LocalOutputDirectory;
         if (string.IsNullOrWhiteSpace(outputDir)) return;

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFishModel.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFishModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Sailfish.Analysis.ScaleFish.CurveFitting;
 
 namespace Sailfish.Analysis.ScaleFish;
@@ -95,6 +96,19 @@ public class ScaleFishModel
     /// (or when no measurements are available to derive a sensible value).
     /// </summary>
     public int? SuggestedNextN { get; init; }
+
+    /// <summary>
+    /// Leave-one-X-out cross-validation diagnostic. Null when CV is disabled or not enough data points
+    /// were available to run at least 3 folds.
+    /// </summary>
+    public CrossValidationDiagnostic? CrossValidation { get; init; }
+
+    /// <summary>
+    /// Per-percentile classification of the raw replicates (e.g. p50, p95, p99). Reveals when the tail
+    /// scales differently from the mean — typical for GC pauses or lock contention. Empty when tail
+    /// fits are disabled or no raw replicates are present.
+    /// </summary>
+    public IReadOnlyList<TailFitResult> TailFits { get; init; } = System.Array.Empty<TailFitResult>();
 
     /// <summary>
     /// Δ-AICc between the next-best and best model. Larger ⇒ more confidently distinguishable.

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFishSettings.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFishSettings.cs
@@ -37,5 +37,37 @@ public class ScaleFishSettings
     /// </summary>
     public double DistinguishabilityDelta { get; set; } = 2.0;
 
+    /// <summary>
+    /// When true, the estimator runs leave-one-X-out cross-validation as a hold-out check on the
+    /// AICc-based classification. Adds a <see cref="CurveFitting.CrossValidationDiagnostic"/> to the
+    /// result. Cheap for typical N counts (5–10 X values).
+    /// </summary>
+    public bool EnableCrossValidation { get; set; } = true;
+
+    /// <summary>
+    /// When true, additional ScaleFish fits are run on per-X percentiles (default p50/p95/p99) of the
+    /// raw replicates, surfaced via the model's <c>TailFits</c> dictionary. Useful for detecting tail
+    /// behaviour that diverges from the mean — GC pauses, contention scaling, etc.
+    /// </summary>
+    public bool EnableTailPercentileFits { get; set; } = true;
+
+    /// <summary>
+    /// Percentiles to fit when <see cref="EnableTailPercentileFits"/> is true. Values in (0, 1).
+    /// Defaults to { 0.50, 0.95, 0.99 }.
+    /// </summary>
+    public double[] TailPercentiles { get; set; } = new[] { 0.50, 0.95, 0.99 };
+
+    /// <summary>
+    /// When true, every ScaleFish run appends a snapshot to a history file in the tracking directory and
+    /// the markdown report includes a transition section if a previous snapshot existed for this method.
+    /// </summary>
+    public bool EnableTrendTracking { get; set; } = true;
+
+    /// <summary>
+    /// When true, the estimator writes a standalone HTML report next to the markdown one. Includes the
+    /// empirical points, best/runner-up curves, bootstrap CI band, residuals, and tail-percentile minis.
+    /// </summary>
+    public bool EmitHtmlReport { get; set; } = true;
+
     public static ScaleFishSettings Default => new();
 }

--- a/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryDiffer.cs
+++ b/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryDiffer.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sailfish.Analysis.ScaleFish.Trends;
+
+/// <summary>
+/// Compares two collections of <see cref="ComplexityHistoryEntry"/> snapshots and surfaces the
+/// per-key transitions: stable, parameter drift, class changed, distinguishability flipped.
+/// </summary>
+public static class ComplexityHistoryDiffer
+{
+    /// <summary>
+    /// Relative tolerance for declaring a fitted-parameter shift "material". Defaults to 25 %.
+    /// </summary>
+    public const double DefaultParameterDriftTolerance = 0.25;
+
+    /// <summary>
+    /// Returns one <see cref="ComplexityTransition"/> per key that appears in both snapshots, plus
+    /// (optionally) entries for keys that exist only in <paramref name="current"/> as "new" entries.
+    /// Keys present only in <paramref name="previous"/> are treated as removed and excluded.
+    /// </summary>
+    public static IReadOnlyList<ComplexityTransition> Diff(
+        IEnumerable<ComplexityHistoryEntry> previous,
+        IEnumerable<ComplexityHistoryEntry> current,
+        double parameterDriftTolerance = DefaultParameterDriftTolerance)
+    {
+        if (previous is null) throw new ArgumentNullException(nameof(previous));
+        if (current is null) throw new ArgumentNullException(nameof(current));
+
+        // For each key, keep the most-recent prior entry (highest TimestampUtc) so we always compare
+        // against the freshest known baseline.
+        var priorByKey = previous
+            .GroupBy(e => e.Key)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(e => e.TimestampUtc).First());
+
+        var transitions = new List<ComplexityTransition>();
+        foreach (var cur in current)
+        {
+            if (!priorByKey.TryGetValue(cur.Key, out var prior)) continue;
+            transitions.Add(Compare(prior, cur, parameterDriftTolerance));
+        }
+
+        return transitions;
+    }
+
+    private static ComplexityTransition Compare(ComplexityHistoryEntry prev, ComplexityHistoryEntry cur, double drift)
+    {
+        if (!string.Equals(prev.BestFamilyName, cur.BestFamilyName, StringComparison.Ordinal))
+        {
+            return new ComplexityTransition(
+                cur.Key,
+                ComplexityTransitionKind.ClassChanged,
+                prev, cur,
+                $"{prev.BestFamilyOName} → {cur.BestFamilyOName} (was {prev.BestFamilyName}, now {cur.BestFamilyName})");
+        }
+
+        var relScaleChange = RelativeChange(prev.BestScale, cur.BestScale);
+        if (double.IsFinite(relScaleChange) && relScaleChange > drift)
+        {
+            return new ComplexityTransition(
+                cur.Key,
+                ComplexityTransitionKind.ParameterDrift,
+                prev, cur,
+                $"scale drifted from {prev.BestScale:F4} to {cur.BestScale:F4} ({relScaleChange:P0})");
+        }
+
+        if (prev.IsDistinguishable != cur.IsDistinguishable)
+        {
+            return new ComplexityTransition(
+                cur.Key,
+                ComplexityTransitionKind.DistinguishabilityChanged,
+                prev, cur,
+                $"distinguishability flipped: was {(prev.IsDistinguishable ? "yes" : "no")}, now {(cur.IsDistinguishable ? "yes" : "no")}");
+        }
+
+        return new ComplexityTransition(cur.Key, ComplexityTransitionKind.Stable, prev, cur,
+            $"stable on {cur.BestFamilyOName}");
+    }
+
+    private static double RelativeChange(double previous, double current)
+    {
+        if (!double.IsFinite(previous) || !double.IsFinite(current)) return double.NaN;
+        if (previous == 0.0 && current == 0.0) return 0.0;
+        var denom = Math.Max(Math.Abs(previous), 1e-12);
+        return Math.Abs(current - previous) / denom;
+    }
+}

--- a/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryEntry.cs
+++ b/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryEntry.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace Sailfish.Analysis.ScaleFish.Trends;
+
+/// <summary>
+/// A single snapshot of a ScaleFish classification, persisted per (test class, method, property) and
+/// indexed by commit SHA + timestamp so trend tracking can diff across runs.
+/// </summary>
+public class ComplexityHistoryEntry
+{
+    public ComplexityHistoryEntry(
+        string testClassFullName,
+        string methodName,
+        string propertyName,
+        string commitSha,
+        DateTime timestampUtc,
+        string bestFamilyName,
+        string bestFamilyOName,
+        double bestScale,
+        double bestBias,
+        double bestRSquared,
+        double bestAicc,
+        double akaikeWeight,
+        bool isDistinguishable,
+        int sampleSize,
+        double? continuousExponentB,
+        double? continuousExponentC,
+        double? cvRankAgreement,
+        double? bootstrapSelectionAgreement)
+    {
+        TestClassFullName = testClassFullName;
+        MethodName = methodName;
+        PropertyName = propertyName;
+        CommitSha = commitSha;
+        TimestampUtc = timestampUtc;
+        BestFamilyName = bestFamilyName;
+        BestFamilyOName = bestFamilyOName;
+        BestScale = bestScale;
+        BestBias = bestBias;
+        BestRSquared = bestRSquared;
+        BestAicc = bestAicc;
+        AkaikeWeight = akaikeWeight;
+        IsDistinguishable = isDistinguishable;
+        SampleSize = sampleSize;
+        ContinuousExponentB = continuousExponentB;
+        ContinuousExponentC = continuousExponentC;
+        CvRankAgreement = cvRankAgreement;
+        BootstrapSelectionAgreement = bootstrapSelectionAgreement;
+    }
+
+    /// <summary>Default constructor for JSON deserialisation.</summary>
+    public ComplexityHistoryEntry()
+    {
+        TestClassFullName = string.Empty;
+        MethodName = string.Empty;
+        PropertyName = string.Empty;
+        CommitSha = string.Empty;
+        BestFamilyName = string.Empty;
+        BestFamilyOName = string.Empty;
+    }
+
+    public string TestClassFullName { get; set; }
+    public string MethodName { get; set; }
+    public string PropertyName { get; set; }
+    public string CommitSha { get; set; }
+    public DateTime TimestampUtc { get; set; }
+
+    public string BestFamilyName { get; set; }
+    public string BestFamilyOName { get; set; }
+    public double BestScale { get; set; }
+    public double BestBias { get; set; }
+    public double BestRSquared { get; set; }
+    public double BestAicc { get; set; }
+    public double AkaikeWeight { get; set; }
+    public bool IsDistinguishable { get; set; }
+    public int SampleSize { get; set; }
+
+    public double? ContinuousExponentB { get; set; }
+    public double? ContinuousExponentC { get; set; }
+    public double? CvRankAgreement { get; set; }
+    public double? BootstrapSelectionAgreement { get; set; }
+
+    /// <summary>Stable identity used to match entries across runs: class.method.property.</summary>
+    public string Key => $"{TestClassFullName}.{MethodName}.{PropertyName}";
+}

--- a/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryStore.cs
+++ b/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryStore.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Sailfish.Analysis.ScaleFish.Trends;
+
+/// <summary>
+/// File-system persistence for <see cref="ComplexityHistoryEntry"/> snapshots. Writes one JSON file per
+/// run in the tracking directory, indexed by a sortable filename so the diff process can pick up the
+/// most-recent prior file deterministically.
+/// </summary>
+public static class ComplexityHistoryStore
+{
+    /// <summary>
+    /// Subdirectory inside the tracking directory where history files live. Keeps them separate from
+    /// model files and execution-summary tracking files.
+    /// </summary>
+    public const string HistoryDirectoryName = "ComplexityHistory";
+
+    private const string FilePrefix = "ComplexityHistory_";
+
+    /// <summary>
+    /// Writes <paramref name="entries"/> to a new history file named with the timestamp + commit SHA so
+    /// the most-recent file sorts last alphabetically. Returns the path written.
+    /// </summary>
+    public static string Write(string trackingDirectory, IReadOnlyList<ComplexityHistoryEntry> entries, DateTime utcNow, string commitSha)
+    {
+        if (entries is null) throw new ArgumentNullException(nameof(entries));
+        if (string.IsNullOrWhiteSpace(trackingDirectory))
+            throw new ArgumentException("trackingDirectory must be non-empty", nameof(trackingDirectory));
+
+        var dir = Path.Combine(trackingDirectory, HistoryDirectoryName);
+        Directory.CreateDirectory(dir);
+
+        var fileName = $"{FilePrefix}{utcNow:yyyyMMdd-HHmmss}_{Sanitize(commitSha)}.json";
+        var path = Path.Combine(dir, fileName);
+
+        var json = JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    /// <summary>
+    /// Loads the most-recently-written history file (by filename ordering) from the tracking directory,
+    /// optionally excluding a specific filename. Returns an empty list if none exist.
+    /// </summary>
+    public static IReadOnlyList<ComplexityHistoryEntry> LoadMostRecentPrior(string trackingDirectory, string? excludeFilename = null)
+    {
+        var dir = Path.Combine(trackingDirectory, HistoryDirectoryName);
+        if (!Directory.Exists(dir)) return Array.Empty<ComplexityHistoryEntry>();
+
+        var candidates = Directory.GetFiles(dir, $"{FilePrefix}*.json")
+            .Where(p => excludeFilename is null || !string.Equals(Path.GetFileName(p), excludeFilename, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (candidates.Count == 0) return Array.Empty<ComplexityHistoryEntry>();
+
+        try
+        {
+            var json = File.ReadAllText(candidates[0]);
+            return JsonSerializer.Deserialize<List<ComplexityHistoryEntry>>(json) ?? new List<ComplexityHistoryEntry>();
+        }
+        catch
+        {
+            // Malformed or unreadable prior file shouldn't break the run — just skip the diff.
+            return Array.Empty<ComplexityHistoryEntry>();
+        }
+    }
+
+    /// <summary>
+    /// Resolves a commit SHA from common CI env vars, falling back to <c>git rev-parse HEAD</c> and
+    /// finally to "unknown" when nothing is available.
+    /// </summary>
+    public static string ResolveCommitSha()
+    {
+        string?[] envVars = { "GITHUB_SHA", "CI_COMMIT_SHA", "BUILD_SOURCEVERSION", "CIRCLE_SHA1", "GIT_COMMIT" };
+        foreach (var v in envVars)
+        {
+            var value = Environment.GetEnvironmentVariable(v!);
+            if (!string.IsNullOrWhiteSpace(value)) return value.Trim();
+        }
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = "rev-parse HEAD",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            if (process.WaitForExit(2000))
+            {
+                var sha = process.StandardOutput.ReadToEnd().Trim();
+                if (!string.IsNullOrWhiteSpace(sha) && sha.Length >= 7) return sha;
+            }
+        }
+        catch
+        {
+            // git not available — fall through
+        }
+
+        return "unknown";
+    }
+
+    private static string Sanitize(string sha)
+    {
+        if (string.IsNullOrWhiteSpace(sha)) return "unknown";
+        var safe = new char[Math.Min(sha.Length, 12)];
+        for (var i = 0; i < safe.Length; i++)
+        {
+            var c = sha[i];
+            safe[i] = char.IsLetterOrDigit(c) ? c : '-';
+        }
+        return new string(safe);
+    }
+}

--- a/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryStore.cs
+++ b/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityHistoryStore.cs
@@ -104,6 +104,12 @@ public static class ComplexityHistoryStore
                 var sha = process.StandardOutput.ReadToEnd().Trim();
                 if (!string.IsNullOrWhiteSpace(sha) && sha.Length >= 7) return sha;
             }
+            else
+            {
+                // Timeout — git is still running. `using` would dispose without terminating;
+                // kill it explicitly so we don't leak an orphaned child process.
+                try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            }
         }
         catch
         {

--- a/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityTransition.cs
+++ b/source/Sailfish/Analysis/ScaleFish/Trends/ComplexityTransition.cs
@@ -1,0 +1,51 @@
+namespace Sailfish.Analysis.ScaleFish.Trends;
+
+/// <summary>
+/// Categorises how a ScaleFish classification changed between two history snapshots for the same key.
+/// </summary>
+public enum ComplexityTransitionKind
+{
+    /// <summary>Best family unchanged and parameters within tolerance.</summary>
+    Stable,
+
+    /// <summary>Best family is the same but the fitted scale changed materially.</summary>
+    ParameterDrift,
+
+    /// <summary>Best family changed (e.g. Linear → Quadratic). The headline regression case.</summary>
+    ClassChanged,
+
+    /// <summary>
+    /// Best family is the same and parameters stable, but the result moved across the distinguishability
+    /// threshold (e.g. was distinguishable, no longer is, or vice versa).
+    /// </summary>
+    DistinguishabilityChanged
+}
+
+/// <summary>
+/// Describes a single difference between an older and newer history snapshot for the same key.
+/// </summary>
+public class ComplexityTransition
+{
+    public ComplexityTransition(
+        string key,
+        ComplexityTransitionKind kind,
+        ComplexityHistoryEntry previous,
+        ComplexityHistoryEntry current,
+        string summary)
+    {
+        Key = key;
+        Kind = kind;
+        Previous = previous;
+        Current = current;
+        Summary = summary;
+    }
+
+    public string Key { get; init; }
+    public ComplexityTransitionKind Kind { get; init; }
+    public ComplexityHistoryEntry Previous { get; init; }
+    public ComplexityHistoryEntry Current { get; init; }
+    public string Summary { get; init; }
+
+    /// <summary>True when this transition is worth flagging in CI (anything but Stable).</summary>
+    public bool IsRegression => Kind != ComplexityTransitionKind.Stable;
+}

--- a/source/Sailfish/Analysis/ScaleFish/Trends/HistoryEntryFactory.cs
+++ b/source/Sailfish/Analysis/ScaleFish/Trends/HistoryEntryFactory.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Sailfish.Analysis.ScaleFish.Trends;
+
+/// <summary>
+/// Projects a fitted <see cref="ScaleFishModel"/> down to a <see cref="ComplexityHistoryEntry"/> snapshot
+/// suitable for persisting and diffing.
+/// </summary>
+public static class HistoryEntryFactory
+{
+    public static ComplexityHistoryEntry Build(
+        string testClassFullName,
+        string methodName,
+        string propertyName,
+        ScaleFishModel model,
+        string commitSha,
+        DateTime timestampUtc)
+    {
+        if (model is null) throw new ArgumentNullException(nameof(model));
+        var bestFn = model.ScaleFishModelFunction;
+        var scale = bestFn?.FunctionParameters?.Scale ?? double.NaN;
+        var bias = bestFn?.FunctionParameters?.Bias ?? double.NaN;
+
+        return new ComplexityHistoryEntry(
+            testClassFullName: testClassFullName ?? string.Empty,
+            methodName: methodName ?? string.Empty,
+            propertyName: propertyName ?? string.Empty,
+            commitSha: string.IsNullOrWhiteSpace(commitSha) ? "unknown" : commitSha,
+            timestampUtc: timestampUtc,
+            bestFamilyName: bestFn?.Name ?? string.Empty,
+            bestFamilyOName: bestFn?.OName ?? string.Empty,
+            bestScale: scale,
+            bestBias: bias,
+            bestRSquared: model.GoodnessOfFit,
+            bestAicc: model.BestAicc,
+            akaikeWeight: model.AkaikeWeight,
+            isDistinguishable: model.IsDistinguishable,
+            sampleSize: model.SampleSize,
+            continuousExponentB: model.PowerLog?.B,
+            continuousExponentC: model.PowerLog?.C,
+            cvRankAgreement: model.CrossValidation?.RankAgreement,
+            bootstrapSelectionAgreement: model.Bootstrap?.SelectionAgreement);
+    }
+}

--- a/source/Sailfish/Contracts.Public/Notifications/ComplexityRegressionDetectedNotification.cs
+++ b/source/Sailfish/Contracts.Public/Notifications/ComplexityRegressionDetectedNotification.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using MediatR;
+using Sailfish.Analysis.ScaleFish.Trends;
+
+namespace Sailfish.Contracts.Public.Notifications;
+
+/// <summary>
+/// Published when ScaleFish's trend tracking detects one or more non-stable transitions between the
+/// current run and the most-recent prior snapshot. Consumers (CI scripts, IDE plugins, custom handlers)
+/// can subscribe to fail builds, post PR comments, or surface alerts.
+/// </summary>
+public record ComplexityRegressionDetectedNotification : INotification
+{
+    public ComplexityRegressionDetectedNotification(IReadOnlyList<ComplexityTransition> Regressions)
+    {
+        this.Regressions = Regressions;
+    }
+
+    public IReadOnlyList<ComplexityTransition> Regressions { get; init; }
+}

--- a/source/Sailfish/Presentation/MarkdownTableConverter.cs
+++ b/source/Sailfish/Presentation/MarkdownTableConverter.cs
@@ -311,6 +311,7 @@ public class MarkdownTableConverter : IMarkdownTableConverter
                             "",
                             "",
                             "",
+                            "",
                             ""
                         },
                         new List<string>
@@ -326,7 +327,8 @@ public class MarkdownTableConverter : IMarkdownTableConverter
                             "AkaikeWeight",
                             "Distinguishable",
                             "ContinuousExponent",
-                            "SuggestNextN"
+                            "SuggestNextN",
+                            "CvStability"
                         },
                         c => c.PropertyName,
                         c => c.ScaleFishModel.ScaleFishModelFunction.Name,
@@ -339,7 +341,8 @@ public class MarkdownTableConverter : IMarkdownTableConverter
                         c => FormatWeight(c.ScaleFishModel.AkaikeWeight),
                         c => c.ScaleFishModel.IsDistinguishable ? "yes" : "no",
                         c => FormatPowerLog(c.ScaleFishModel.PowerLog),
-                        c => FormatSuggestion(c.ScaleFishModel.SuggestedNextN)
+                        c => FormatSuggestion(c.ScaleFishModel.SuggestedNextN),
+                        c => FormatCvStability(c.ScaleFishModel.CrossValidation)
                     ));
                 tableBuilder.AppendLine();
             }
@@ -434,5 +437,12 @@ public class MarkdownTableConverter : IMarkdownTableConverter
     private static string FormatSuggestion(int? suggested)
     {
         return suggested is null ? "—" : suggested.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatCvStability(Sailfish.Analysis.ScaleFish.CurveFitting.CrossValidationDiagnostic? cv)
+    {
+        if (cv is null) return "n/a";
+        return string.Format(System.Globalization.CultureInfo.InvariantCulture,
+            "agree={0:F2} k={1}", cv.RankAgreement, cv.FoldCount);
     }
 }

--- a/source/Sailfish/Presentation/ScaleFishHtmlReportBuilder.cs
+++ b/source/Sailfish/Presentation/ScaleFishHtmlReportBuilder.cs
@@ -87,7 +87,9 @@ public static class ScaleFishHtmlReportBuilder
         var model = propModel.ScaleFishModel;
         sb.AppendLine("<div class=\"prop-block\">");
         sb.AppendLine($"<div><span class=\"prop-key\">{Escape(propModel.PropertyName)}</span>");
-        sb.AppendLine($"<span class=\"badge {(model.IsDistinguishable ? "badge-good" : "badge-warn")}\">{model.ScaleFishModelFunction.OName}{(model.IsDistinguishable ? "" : " (uncertain)")}</span></div>");
+        // OName comes from custom families' user-supplied strings — escape so an attacker-controlled
+        // value (or an accidental `<` / `&`) can't break the surrounding HTML.
+        sb.AppendLine($"<span class=\"badge {(model.IsDistinguishable ? "badge-good" : "badge-warn")}\">{Escape(model.ScaleFishModelFunction.OName)}{(model.IsDistinguishable ? "" : " (uncertain)")}</span></div>");
 
         AppendMetricsTable(sb, model);
 

--- a/source/Sailfish/Presentation/ScaleFishHtmlReportBuilder.cs
+++ b/source/Sailfish/Presentation/ScaleFishHtmlReportBuilder.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.CurveFitting;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Renders a standalone HTML report for a ScaleFish run. Pure server-side: no external libraries or
+/// browser-only JavaScript dependencies — everything is inline SVG + CSS so the file works offline.
+/// </summary>
+public static class ScaleFishHtmlReportBuilder
+{
+    private const int PlotWidth = 640;
+    private const int PlotHeight = 320;
+    private const int Padding = 50;
+
+    /// <summary>
+    /// Renders <paramref name="results"/> to an HTML string. Pass per-property X/Y measurements via
+    /// <paramref name="measurementsByKey"/> so the SVG can plot empirical points alongside the fitted
+    /// curve; pass an empty dictionary if measurements aren't available (curve-only rendering).
+    /// </summary>
+    public static string Build(
+        IReadOnlyList<ScalefishClassModel> results,
+        IReadOnlyDictionary<string, ComplexityMeasurement[]> measurementsByKey)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<!doctype html>");
+        sb.AppendLine("<html lang=\"en\"><head>");
+        sb.AppendLine("<meta charset=\"utf-8\">");
+        sb.AppendLine("<title>ScaleFish Report</title>");
+        AppendStyles(sb);
+        sb.AppendLine("</head><body>");
+        sb.AppendLine("<h1>ScaleFish complexity report</h1>");
+        sb.AppendLine($"<p class=\"meta\">Generated {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC</p>");
+
+        foreach (var classModel in results)
+        {
+            sb.AppendLine($"<h2>{Escape(classModel.NameSpace)}.{Escape(classModel.TestClassName)}</h2>");
+            foreach (var methodModel in classModel.ScaleFishMethodModels)
+            {
+                sb.AppendLine($"<h3>{Escape(methodModel.TestMethodName)}</h3>");
+                foreach (var propModel in methodModel.ScaleFishPropertyModels)
+                {
+                    var key = propModel.PropertyName;
+                    measurementsByKey.TryGetValue(key, out var measurements);
+                    AppendPropertyBlock(sb, propModel, measurements);
+                }
+            }
+        }
+
+        sb.AppendLine("</body></html>");
+        return sb.ToString();
+    }
+
+    private static void AppendStyles(StringBuilder sb)
+    {
+        sb.AppendLine("<style>");
+        sb.AppendLine("body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 980px; margin: 2em auto; color: #1a1a1a; padding: 0 1em; }");
+        sb.AppendLine("h1 { border-bottom: 2px solid #333; padding-bottom: .3em; }");
+        sb.AppendLine("h2 { color: #2a4d8f; margin-top: 1.4em; }");
+        sb.AppendLine("h3 { color: #444; }");
+        sb.AppendLine(".meta { color: #777; font-size: .9em; }");
+        sb.AppendLine(".prop-block { border: 1px solid #e0e0e0; border-radius: 6px; padding: 1em; margin: 1em 0; background: #fafafa; }");
+        sb.AppendLine(".prop-key { font-family: ui-monospace, monospace; font-weight: 600; color: #2a4d8f; }");
+        sb.AppendLine(".badge { display: inline-block; padding: .15em .55em; border-radius: 4px; font-size: .85em; margin-left: .5em; }");
+        sb.AppendLine(".badge-good { background: #d6f4d6; color: #2e6e2e; }");
+        sb.AppendLine(".badge-warn { background: #fef0c4; color: #7a5a00; }");
+        sb.AppendLine("table { border-collapse: collapse; margin: .5em 0; font-size: .92em; }");
+        sb.AppendLine("th, td { border: 1px solid #ddd; padding: .35em .8em; text-align: left; }");
+        sb.AppendLine("th { background: #f0f0f0; }");
+        sb.AppendLine("svg { background: white; border: 1px solid #ddd; border-radius: 4px; }");
+        sb.AppendLine(".empirical { fill: #2a4d8f; }");
+        sb.AppendLine(".curve-best { stroke: #2a4d8f; fill: none; stroke-width: 2; }");
+        sb.AppendLine(".curve-next { stroke: #a06030; fill: none; stroke-width: 1.5; stroke-dasharray: 4 3; }");
+        sb.AppendLine(".axis { stroke: #999; stroke-width: 1; }");
+        sb.AppendLine(".axis-label { font-size: 11px; fill: #555; }");
+        sb.AppendLine(".legend-text { font-size: 11px; fill: #333; }");
+        sb.AppendLine("</style>");
+    }
+
+    private static void AppendPropertyBlock(StringBuilder sb, ScaleFishPropertyModel propModel, ComplexityMeasurement[]? measurements)
+    {
+        var model = propModel.ScaleFishModel;
+        sb.AppendLine("<div class=\"prop-block\">");
+        sb.AppendLine($"<div><span class=\"prop-key\">{Escape(propModel.PropertyName)}</span>");
+        sb.AppendLine($"<span class=\"badge {(model.IsDistinguishable ? "badge-good" : "badge-warn")}\">{model.ScaleFishModelFunction.OName}{(model.IsDistinguishable ? "" : " (uncertain)")}</span></div>");
+
+        AppendMetricsTable(sb, model);
+
+        if (measurements is { Length: > 0 })
+        {
+            AppendPlot(sb, model, measurements);
+        }
+
+        if (model.TailFits is { Count: > 0 })
+        {
+            AppendTailFitsBlock(sb, model.TailFits);
+        }
+
+        sb.AppendLine("</div>");
+    }
+
+    private static void AppendMetricsTable(StringBuilder sb, ScaleFishModel model)
+    {
+        sb.AppendLine("<table>");
+        sb.AppendLine("<tr><th>Metric</th><th>Value</th></tr>");
+        sb.AppendLine($"<tr><td>Best fit</td><td>{Escape(model.ScaleFishModelFunction.Name)} — {Escape(model.ScaleFishModelFunction.OName)} (R²={F2(model.GoodnessOfFit)})</td></tr>");
+        sb.AppendLine($"<tr><td>Runner-up</td><td>{Escape(model.NextClosestScaleFishModelFunction.Name)} — {Escape(model.NextClosestScaleFishModelFunction.OName)} (R²={F2(model.NextClosestGoodnessOfFit)})</td></tr>");
+        sb.AppendLine($"<tr><td>Δ AICc</td><td>{F2(model.DeltaAicc)} (weight={F3(model.AkaikeWeight)})</td></tr>");
+        sb.AppendLine($"<tr><td>Distinguishable</td><td>{(model.IsDistinguishable ? "yes" : "no")}</td></tr>");
+        if (model.PowerLog is not null)
+        {
+            sb.AppendLine($"<tr><td>Continuous exponent</td><td>{Escape(model.PowerLog.Describe())} (R²={F2(model.PowerLog.RSquared)})</td></tr>");
+        }
+        if (model.CrossValidation is not null)
+        {
+            sb.AppendLine($"<tr><td>CV rank agreement</td><td>{F2(model.CrossValidation.RankAgreement)} ({model.CrossValidation.FoldCount} folds)</td></tr>");
+        }
+        if (model.Bootstrap is not null)
+        {
+            sb.AppendLine($"<tr><td>Bootstrap (n={model.Bootstrap.Iterations})</td><td>selection agreement {F2(model.Bootstrap.SelectionAgreement)} · scale 95 % CI [{F3(model.Bootstrap.ScaleCiLower)}, {F3(model.Bootstrap.ScaleCiUpper)}]</td></tr>");
+        }
+        if (model.SuggestedNextN.HasValue)
+        {
+            sb.AppendLine($"<tr><td>Suggested next N</td><td>{model.SuggestedNextN.Value}</td></tr>");
+        }
+        sb.AppendLine("</table>");
+    }
+
+    private static void AppendTailFitsBlock(StringBuilder sb, IReadOnlyList<TailFitResult> tailFits)
+    {
+        sb.AppendLine("<details><summary>Tail-percentile fits</summary>");
+        sb.AppendLine("<table>");
+        sb.AppendLine("<tr><th>Percentile</th><th>Best</th><th>R²</th><th>Δ AICc</th><th>Distinguishable</th></tr>");
+        foreach (var t in tailFits.OrderBy(t => t.Percentile))
+        {
+            sb.AppendLine($"<tr><td>p{(int)Math.Round(t.Percentile * 100)}</td><td>{Escape(t.BestFamilyOName)}</td><td>{F2(t.BestRSquared)}</td><td>{F2(t.DeltaAicc)}</td><td>{(t.IsDistinguishable ? "yes" : "no")}</td></tr>");
+        }
+        sb.AppendLine("</table>");
+        sb.AppendLine("</details>");
+    }
+
+    private static void AppendPlot(StringBuilder sb, ScaleFishModel model, ComplexityMeasurement[] measurements)
+    {
+        var xs = measurements.Select(m => m.X).Where(double.IsFinite).ToArray();
+        var ys = measurements.Select(m => m.Y).Where(double.IsFinite).ToArray();
+        if (xs.Length == 0 || ys.Length == 0) return;
+
+        var xMin = xs.Min();
+        var xMax = xs.Max();
+        var yMin = Math.Min(0, ys.Min());
+        var yMax = ys.Max();
+        var bestFn = model.ScaleFishModelFunction;
+        var nextFn = model.NextClosestScaleFishModelFunction;
+
+        // Extend Y range to include both fitted curves so they don't clip.
+        var allYs = new List<double>(ys);
+        if (bestFn.FunctionParameters is not null) allYs.AddRange(SampleCurve(bestFn, xMin, xMax));
+        if (nextFn?.FunctionParameters is not null) allYs.AddRange(SampleCurve(nextFn, xMin, xMax));
+        var finiteYs = allYs.Where(double.IsFinite).ToArray();
+        if (finiteYs.Length > 0)
+        {
+            yMin = Math.Min(yMin, finiteYs.Min());
+            yMax = Math.Max(yMax, finiteYs.Max());
+        }
+        if (yMax <= yMin) yMax = yMin + 1;
+
+        double XPix(double x) => Padding + (PlotWidth - 2 * Padding) * (x - xMin) / Math.Max(xMax - xMin, 1e-12);
+        double YPix(double y) => PlotHeight - Padding - (PlotHeight - 2 * Padding) * (y - yMin) / Math.Max(yMax - yMin, 1e-12);
+
+        sb.AppendLine($"<svg width=\"{PlotWidth}\" height=\"{PlotHeight}\" xmlns=\"http://www.w3.org/2000/svg\">");
+        // Axes
+        sb.AppendLine($"<line class=\"axis\" x1=\"{Padding}\" y1=\"{PlotHeight - Padding}\" x2=\"{PlotWidth - Padding}\" y2=\"{PlotHeight - Padding}\"/>");
+        sb.AppendLine($"<line class=\"axis\" x1=\"{Padding}\" y1=\"{Padding}\" x2=\"{Padding}\" y2=\"{PlotHeight - Padding}\"/>");
+        sb.AppendLine($"<text class=\"axis-label\" x=\"{PlotWidth / 2}\" y=\"{PlotHeight - 10}\" text-anchor=\"middle\">X (input scale)</text>");
+        sb.AppendLine($"<text class=\"axis-label\" x=\"15\" y=\"{PlotHeight / 2}\" transform=\"rotate(-90, 15, {PlotHeight / 2})\" text-anchor=\"middle\">Y (mean, ms)</text>");
+
+        // Fitted curves
+        if (bestFn.FunctionParameters is not null) AppendCurvePath(sb, bestFn, xMin, xMax, XPix, YPix, "curve-best");
+        if (nextFn?.FunctionParameters is not null) AppendCurvePath(sb, nextFn, xMin, xMax, XPix, YPix, "curve-next");
+
+        // Empirical points
+        foreach (var m in measurements.Where(m => double.IsFinite(m.X) && double.IsFinite(m.Y)))
+        {
+            sb.AppendLine($"<circle class=\"empirical\" cx=\"{F2(XPix(m.X))}\" cy=\"{F2(YPix(m.Y))}\" r=\"3.5\"/>");
+        }
+
+        // Legend
+        sb.AppendLine($"<rect x=\"{PlotWidth - Padding - 140}\" y=\"{Padding - 10}\" width=\"135\" height=\"42\" fill=\"white\" stroke=\"#ccc\" rx=\"3\"/>");
+        sb.AppendLine($"<line class=\"curve-best\" x1=\"{PlotWidth - Padding - 130}\" y1=\"{Padding + 0}\" x2=\"{PlotWidth - Padding - 105}\" y2=\"{Padding + 0}\"/>");
+        sb.AppendLine($"<text class=\"legend-text\" x=\"{PlotWidth - Padding - 100}\" y=\"{Padding + 3}\">{Escape(bestFn.OName)}</text>");
+        sb.AppendLine($"<line class=\"curve-next\" x1=\"{PlotWidth - Padding - 130}\" y1=\"{Padding + 18}\" x2=\"{PlotWidth - Padding - 105}\" y2=\"{Padding + 18}\"/>");
+        sb.AppendLine($"<text class=\"legend-text\" x=\"{PlotWidth - Padding - 100}\" y=\"{Padding + 21}\">{Escape(nextFn?.OName ?? "next")}</text>");
+
+        sb.AppendLine("</svg>");
+    }
+
+    private static IEnumerable<double> SampleCurve(ScaleFishModelFunction fn, double xMin, double xMax, int samples = 50)
+    {
+        if (fn.FunctionParameters is null) yield break;
+        for (var i = 0; i <= samples; i++)
+        {
+            var x = xMin + (xMax - xMin) * i / (double)samples;
+            yield return fn.Compute(fn.FunctionParameters.Bias, fn.FunctionParameters.Scale, x);
+        }
+    }
+
+    private static void AppendCurvePath(StringBuilder sb, ScaleFishModelFunction fn, double xMin, double xMax,
+        Func<double, double> xPix, Func<double, double> yPix, string cssClass)
+    {
+        if (fn.FunctionParameters is null) return;
+        const int samples = 80;
+        var pathSb = new StringBuilder();
+        var moved = false;
+        for (var i = 0; i <= samples; i++)
+        {
+            var x = xMin + (xMax - xMin) * i / (double)samples;
+            var y = fn.Compute(fn.FunctionParameters.Bias, fn.FunctionParameters.Scale, x);
+            if (!double.IsFinite(y)) continue;
+            var px = xPix(x);
+            var py = yPix(y);
+            pathSb.Append(moved ? "L" : "M");
+            pathSb.AppendFormat(CultureInfo.InvariantCulture, "{0:F2},{1:F2} ", px, py);
+            moved = true;
+        }
+        sb.AppendLine($"<path class=\"{cssClass}\" d=\"{pathSb}\"/>");
+    }
+
+    private static string F2(double v)
+    {
+        if (double.IsNaN(v)) return "n/a";
+        if (double.IsInfinity(v)) return "∞";
+        return v.ToString("F2", CultureInfo.InvariantCulture);
+    }
+
+    private static string F3(double v)
+    {
+        if (double.IsNaN(v)) return "n/a";
+        if (double.IsInfinity(v)) return "∞";
+        return v.ToString("F3", CultureInfo.InvariantCulture);
+    }
+
+    private static string Escape(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return string.Empty;
+        return s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+    }
+}

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishAdaptiveXTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishAdaptiveXTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+/// <summary>
+/// Verifies the <see cref="AdaptiveXRecommender"/> planning utility: geometric initial probe, refinement
+/// against a prior model, and the input-validation contracts.
+/// </summary>
+public class ScaleFishAdaptiveXTests
+{
+    [Fact]
+    public void InitialProbe_IsGeometric()
+    {
+        var xs = AdaptiveXRecommender.RecommendInitialProbe(8, 256, points: 6);
+        xs.ShouldBe(new[] { 8, 16, 32, 64, 128, 256 });
+    }
+
+    [Fact]
+    public void InitialProbe_DefaultPointCount()
+    {
+        var xs = AdaptiveXRecommender.RecommendInitialProbe(4, 128);
+        xs.Count.ShouldBe(6);
+        xs[0].ShouldBe(4);
+        xs[^1].ShouldBe(128);
+    }
+
+    [Fact]
+    public void InitialProbe_RejectsImpossibleRequests()
+    {
+        Should.Throw<ArgumentException>(() => AdaptiveXRecommender.RecommendInitialProbe(1, 2, points: 5));
+        Should.Throw<ArgumentException>(() => AdaptiveXRecommender.RecommendInitialProbe(0, 100));
+        Should.Throw<ArgumentException>(() => AdaptiveXRecommender.RecommendInitialProbe(100, 50));
+    }
+
+    [Fact]
+    public void Refinement_ExtendsPastCurrentMax()
+    {
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(),
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6));
+        var prior = new ComplexityEstimator().EstimateComplexity(measurements);
+        prior.ShouldNotBeNull();
+
+        var existing = new[] { 8, 16, 32, 64, 128, 256 };
+        var refined = AdaptiveXRecommender.RecommendRefinement(existing, prior, targetMaxN: 2048, extraPoints: 3);
+
+        // Existing values preserved, sorted, with extras added past the current max.
+        refined.Take(6).ShouldBe(existing);
+        refined[^1].ShouldBeLessThanOrEqualTo(2048);
+        refined[^1].ShouldBeGreaterThan(256);
+        refined.Count.ShouldBeGreaterThan(existing.Length);
+    }
+
+    [Fact]
+    public void Refinement_TargetBelowMax_ReturnsExisting()
+    {
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(),
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6));
+        var prior = new ComplexityEstimator().EstimateComplexity(measurements);
+        prior.ShouldNotBeNull();
+
+        var existing = new[] { 8, 16, 32, 64, 128, 256 };
+        var refined = AdaptiveXRecommender.RecommendRefinement(existing, prior, targetMaxN: 100);
+        // 100 < 256 → no extension; return the existing set sorted/deduped.
+        refined.ShouldBe(existing);
+    }
+
+    [Fact]
+    public void Refinement_RejectsEmptyPrior()
+    {
+        var dummy = new ComplexityEstimator().EstimateComplexity(
+            ScaleFishTestHelpers.BuildExact(new Linear(), new[] { 1, 2, 3, 4 }));
+        dummy.ShouldNotBeNull();
+        Should.Throw<ArgumentException>(
+            () => AdaptiveXRecommender.RecommendRefinement(Array.Empty<int>(), dummy, 100));
+    }
+}

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishAdaptiveXTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishAdaptiveXTests.cs
@@ -78,4 +78,37 @@ public class ScaleFishAdaptiveXTests
         Should.Throw<ArgumentException>(
             () => AdaptiveXRecommender.RecommendRefinement(Array.Empty<int>(), dummy, 100));
     }
+
+    [Fact]
+    public void Refinement_NarrowExtensionRange_DegradesInsteadOfThrowing()
+    {
+        // Regression: when targetMaxN is only one or two integers past currentMax, the underlying
+        // SpacedRange would refuse to emit `extraPoints` distinct integers. The recommender should
+        // cap extraPoints to what's feasible rather than throwing.
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(), new[] { 4, 8, 16, 32 });
+        var prior = new ComplexityEstimator().EstimateComplexity(measurements);
+        prior.ShouldNotBeNull();
+
+        var existing = new[] { 4, 8, 16, 32 };
+
+        // Only one available integer past currentMax (33), but the caller asks for 3 extras —
+        // recommender should append the single available point rather than throw.
+        var refined = AdaptiveXRecommender.RecommendRefinement(existing, prior, targetMaxN: 33, extraPoints: 3);
+        refined[^1].ShouldBeLessThanOrEqualTo(33);
+        refined[^1].ShouldBeGreaterThan(32);
+    }
+
+    [Fact]
+    public void Refinement_TwoIntegerExtension_ProducesPair()
+    {
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(), new[] { 4, 8, 16, 32 });
+        var prior = new ComplexityEstimator().EstimateComplexity(measurements);
+        prior.ShouldNotBeNull();
+
+        var existing = new[] { 4, 8, 16, 32 };
+        // Range of 2 available integers (33, 34) — should cap extraPoints from 3 to 2.
+        var refined = AdaptiveXRecommender.RecommendRefinement(existing, prior, targetMaxN: 34, extraPoints: 3);
+        refined.Count(x => x > 32).ShouldBeGreaterThanOrEqualTo(1);
+        refined[^1].ShouldBeLessThanOrEqualTo(34);
+    }
 }

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishCrossValidationTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishCrossValidationTests.cs
@@ -1,0 +1,85 @@
+using System;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+/// <summary>
+/// Verifies the leave-one-X-out cross-validation diagnostic: it engages by default, agrees with the
+/// all-data estimate on clean data, and reflects ambiguity when the data really is ambiguous.
+/// </summary>
+public class ScaleFishCrossValidationTests
+{
+    [Fact]
+    public void CV_OnByDefault_ProducesDiagnostic()
+    {
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(),
+            ScaleFishTestHelpers.LogSpacedX(8, 1024, 6));
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+
+        result.ShouldNotBeNull();
+        result.CrossValidation.ShouldNotBeNull();
+        result.CrossValidation.FoldCount.ShouldBeGreaterThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public void CV_PerfectLinearData_FullAgreement()
+    {
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(),
+            ScaleFishTestHelpers.LogSpacedX(8, 1024, 6));
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+
+        result.ShouldNotBeNull();
+        result.CrossValidation.ShouldNotBeNull();
+        // Every fold should pick Linear when the data is exactly linear.
+        result.CrossValidation.RankAgreement.ShouldBe(1.0, tolerance: 1e-9);
+        // Prediction error should be effectively zero for noise-free linear data.
+        result.CrossValidation.MeanPredictionError.ShouldBeLessThan(1e-6);
+    }
+
+    [Fact]
+    public void CV_NoisyQuadratic_AgreesAndHasSmallError()
+    {
+        var rng = new Random(7);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => x * x,
+            ScaleFishTestHelpers.LogSpacedX(4, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.03,
+            rng);
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.ScaleFishModelFunction.Name.ShouldBe(nameof(Quadratic));
+        result.CrossValidation.ShouldNotBeNull();
+        result.CrossValidation.RankAgreement.ShouldBeGreaterThanOrEqualTo(0.8);
+    }
+
+    [Fact]
+    public void CV_TooFewPoints_ReturnsNull()
+    {
+        var measurements = new[]
+        {
+            new ComplexityMeasurement(2, 2),
+            new ComplexityMeasurement(4, 4),
+            new ComplexityMeasurement(8, 8)
+        };
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.CrossValidation.ShouldBeNull("CV requires at least 4 X values");
+    }
+
+    [Fact]
+    public void CV_Disabled_OmitsDiagnostic()
+    {
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(),
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6));
+        var settings = new ScaleFishSettings { EnableCrossValidation = false };
+        var result = new ComplexityEstimator(settings).EstimateComplexity(measurements);
+
+        result.ShouldNotBeNull();
+        result.CrossValidation.ShouldBeNull();
+    }
+}

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishCrossValidationTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishCrossValidationTests.cs
@@ -82,4 +82,29 @@ public class ScaleFishCrossValidationTests
         result.ShouldNotBeNull();
         result.CrossValidation.ShouldBeNull();
     }
+
+    [Fact]
+    public void RankAgreement_NeverExceedsOne()
+    {
+        // Regression for a subtle bug: rank-agreement and prediction-error live on independent fold
+        // denominators. Mixing them would let rankAgreement = agreements / predictionFolds drift above
+        // 1.0 whenever a rank-match fold's prediction step failed. Exercise a noisy run and assert the
+        // invariant for every reasonable seed.
+        for (var seed = 1; seed <= 5; seed++)
+        {
+            var rng = new Random(seed);
+            var measurements = ScaleFishTestHelpers.BuildNoisy(
+                x => x,
+                ScaleFishTestHelpers.LogSpacedX(8, 256, 6),
+                sampleSize: 25,
+                relativeNoise: 0.08,
+                rng);
+
+            var result = new ComplexityEstimator().EstimateComplexity(measurements);
+            result.ShouldNotBeNull();
+            result.CrossValidation.ShouldNotBeNull();
+            result.CrossValidation.RankAgreement.ShouldBeLessThanOrEqualTo(1.0, $"seed {seed}");
+            result.CrossValidation.RankAgreement.ShouldBeGreaterThanOrEqualTo(0.0, $"seed {seed}");
+        }
+    }
 }

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishHtmlReportTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishHtmlReportTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Sailfish.Analysis.ScaleFish.CurveFitting;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+/// <summary>
+/// Smoke tests for the HTML report renderer: structure, content, and graceful handling of missing data.
+/// We assert on substrings rather than exact output to keep the tests robust against cosmetic CSS tweaks.
+/// </summary>
+public class ScaleFishHtmlReportTests
+{
+    [Fact]
+    public void Build_EmptyResults_ProducesValidHtmlSkeleton()
+    {
+        var html = ScaleFishHtmlReportBuilder.Build(
+            new List<ScalefishClassModel>(),
+            new Dictionary<string, ComplexityMeasurement[]>());
+
+        html.ShouldStartWith("<!doctype html>");
+        html.ShouldContain("<title>ScaleFish Report</title>");
+        html.ShouldContain("</html>");
+        html.ShouldContain("ScaleFish complexity report");
+    }
+
+    [Fact]
+    public void Build_WithModel_IncludesClassAndPropertyHeadings()
+    {
+        var (results, measurementsByKey) = BuildSingleEntryResults();
+
+        var html = ScaleFishHtmlReportBuilder.Build(results, measurementsByKey);
+
+        html.ShouldContain("Tests.Ns.Cls");
+        html.ShouldContain("DoWork");
+        html.ShouldContain("N");
+        html.ShouldContain("Linear");
+        html.ShouldContain("O(n)");
+        html.ShouldContain("<svg"); // measurements present ⇒ plot rendered
+    }
+
+    [Fact]
+    public void Build_WithoutMeasurements_OmitsPlotButKeepsTable()
+    {
+        var (results, _) = BuildSingleEntryResults();
+
+        var html = ScaleFishHtmlReportBuilder.Build(results, new Dictionary<string, ComplexityMeasurement[]>());
+
+        html.ShouldContain("Linear");
+        html.ShouldNotContain("<svg");
+        html.ShouldContain("Δ AICc"); // metrics table still rendered
+    }
+
+    [Fact]
+    public void Build_Distinguishable_RendersGoodBadge()
+    {
+        var (results, measurementsByKey) = BuildSingleEntryResults(isDistinguishable: true);
+        var html = ScaleFishHtmlReportBuilder.Build(results, measurementsByKey);
+        html.ShouldContain("badge-good");
+        html.ShouldNotContain("(uncertain)");
+    }
+
+    [Fact]
+    public void Build_NotDistinguishable_RendersWarnBadge()
+    {
+        var (results, measurementsByKey) = BuildSingleEntryResults(isDistinguishable: false);
+        var html = ScaleFishHtmlReportBuilder.Build(results, measurementsByKey);
+        html.ShouldContain("badge-warn");
+        html.ShouldContain("(uncertain)");
+    }
+
+    [Fact]
+    public void Build_EscapesUnsafeContent()
+    {
+        var results = new List<ScalefishClassModel>
+        {
+            new("Ns.With<script>", "C&C", new List<ScaleFishMethodModel>
+            {
+                new("M\"1", new List<ScaleFishPropertyModel>
+                {
+                    new("N>0", BuildModel())
+                })
+            })
+        };
+        var html = ScaleFishHtmlReportBuilder.Build(results, new Dictionary<string, ComplexityMeasurement[]>());
+
+        // Unsafe characters in identifiers should not be rendered raw.
+        html.ShouldNotContain("<script>");
+        html.ShouldContain("&lt;script&gt;");
+        html.ShouldContain("C&amp;C");
+    }
+
+    private static (List<ScalefishClassModel> results, Dictionary<string, ComplexityMeasurement[]> measurements)
+        BuildSingleEntryResults(bool isDistinguishable = true)
+    {
+        var prop = new ScaleFishPropertyModel("Tests.Ns.Cls.DoWork.N", BuildModel(isDistinguishable));
+        var method = new ScaleFishMethodModel("DoWork", new List<ScaleFishPropertyModel> { prop });
+        var cls = new ScalefishClassModel("Tests.Ns", "Cls", new List<ScaleFishMethodModel> { method });
+
+        var measurements = new[]
+        {
+            new ComplexityMeasurement(8, 8),
+            new ComplexityMeasurement(16, 16),
+            new ComplexityMeasurement(32, 32),
+            new ComplexityMeasurement(64, 64),
+            new ComplexityMeasurement(128, 128)
+        };
+        return (
+            new List<ScalefishClassModel> { cls },
+            new Dictionary<string, ComplexityMeasurement[]> { [prop.PropertyName] = measurements });
+    }
+
+    private static ScaleFishModel BuildModel(bool isDistinguishable = true)
+    {
+        var best = new Linear { FunctionParameters = new FittedCurve(scale: 1.0, bias: 0.0) };
+        var next = new NLogN { FunctionParameters = new FittedCurve(scale: 0.5, bias: 0.0) };
+        return new ScaleFishModel(
+            scaleFishModelFunction: best,
+            goodnessOfFit: 0.99,
+            nextClosestScaleFishModelFunction: next,
+            nextClosestGoodnessOfFit: 0.95,
+            bestAicc: -50,
+            nextBestAicc: -25,
+            akaikeWeight: 0.999,
+            isDistinguishable: isDistinguishable,
+            sampleSize: 5,
+            powerLog: new PowerLogResult(1.0, 1.0, 0.0, 0.0, 0.99));
+    }
+}

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishTailFitTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishTailFitTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+/// <summary>
+/// Per-X percentile fits: when raw replicates are present, ScaleFish should classify p50/p95/p99 separately
+/// so users can see whether the tail scales differently from the mean.
+/// </summary>
+public class ScaleFishTailFitTests
+{
+    [Fact]
+    public void DefaultSettings_ProduceP50P95P99()
+    {
+        var rng = new Random(101);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => x,
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6),
+            sampleSize: 50,
+            relativeNoise: 0.05,
+            rng);
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.TailFits.Count.ShouldBe(3);
+        var pcts = result.TailFits.Select(t => t.Percentile).OrderBy(p => p).ToArray();
+        pcts[0].ShouldBe(0.50, tolerance: 1e-9);
+        pcts[1].ShouldBe(0.95, tolerance: 1e-9);
+        pcts[2].ShouldBe(0.99, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void Disabled_OmitsTailFits()
+    {
+        var rng = new Random(102);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => x,
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.05,
+            rng);
+
+        var settings = new ScaleFishSettings { EnableTailPercentileFits = false };
+        var result = new ComplexityEstimator(settings).EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.TailFits.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void NoRawSamples_OmitsTailFits()
+    {
+        // Exact synthetic measurements have no RawSamples — tail fits should skip.
+        var measurements = ScaleFishTestHelpers.BuildExact(new Linear(),
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6));
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.TailFits.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CustomPercentiles_Honored()
+    {
+        var rng = new Random(103);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => x * x,
+            ScaleFishTestHelpers.LogSpacedX(4, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.05,
+            rng);
+
+        var settings = new ScaleFishSettings { TailPercentiles = new[] { 0.25, 0.75 } };
+        var result = new ComplexityEstimator(settings).EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.TailFits.Count.ShouldBe(2);
+        result.TailFits.Select(t => t.Percentile).ShouldBe(new[] { 0.25, 0.75 });
+    }
+
+    [Fact]
+    public void TailFit_OfLinearData_ClassifiesAsLinear()
+    {
+        var rng = new Random(104);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => 3.0 * x,
+            ScaleFishTestHelpers.LogSpacedX(8, 1024, 6),
+            sampleSize: 50,
+            relativeNoise: 0.03,
+            rng);
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        foreach (var fit in result.TailFits)
+        {
+            fit.BestFamilyName.ShouldBe(nameof(Linear), $"p{fit.Percentile:F2} should classify as Linear");
+        }
+    }
+
+    [Fact]
+    public void OutOfRangePercentiles_Skipped()
+    {
+        var rng = new Random(105);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => x,
+            ScaleFishTestHelpers.LogSpacedX(8, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.05,
+            rng);
+
+        var settings = new ScaleFishSettings { TailPercentiles = new[] { -0.1, 0.5, 1.1, 0.95 } };
+        var result = new ComplexityEstimator(settings).EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.TailFits.Count.ShouldBe(2);
+        result.TailFits.Select(t => t.Percentile).ShouldBe(new[] { 0.5, 0.95 });
+    }
+}

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishTrendTrackingTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishTrendTrackingTests.cs
@@ -9,9 +9,19 @@ using Xunit;
 namespace Tests.Library.Analysis.ScaleFish;
 
 /// <summary>
+/// Collection definition that serialises tests touching process-wide state (environment variables,
+/// the file system at fixed paths). xUnit guarantees no two tests in the same Collection run in
+/// parallel — critical for the env-var test below that would otherwise race with itself or with
+/// other env-mutating tests.
+/// </summary>
+[CollectionDefinition("ScaleFishEnvVarSerial", DisableParallelization = true)]
+public class ScaleFishEnvVarSerialCollection { }
+
+/// <summary>
 /// Verifies the trend-tracking primitives: history persistence, commit-SHA resolution, and the diff
 /// engine that surfaces class transitions, parameter drift, and distinguishability flips.
 /// </summary>
+[Collection("ScaleFishEnvVarSerial")]
 public class ScaleFishTrendTrackingTests
 {
     [Fact]

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishTrendTrackingTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishTrendTrackingTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Sailfish.Analysis.ScaleFish.Trends;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+/// <summary>
+/// Verifies the trend-tracking primitives: history persistence, commit-SHA resolution, and the diff
+/// engine that surfaces class transitions, parameter drift, and distinguishability flips.
+/// </summary>
+public class ScaleFishTrendTrackingTests
+{
+    [Fact]
+    public void HistoryStore_WriteAndReadRoundTrip()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var entry = new ComplexityHistoryEntry(
+                testClassFullName: "Test.Ns.Cls",
+                methodName: "M",
+                propertyName: "N",
+                commitSha: "abc1234",
+                timestampUtc: DateTime.UtcNow,
+                bestFamilyName: "Linear",
+                bestFamilyOName: "O(n)",
+                bestScale: 1.5,
+                bestBias: 0.1,
+                bestRSquared: 0.999,
+                bestAicc: -100,
+                akaikeWeight: 0.999,
+                isDistinguishable: true,
+                sampleSize: 6,
+                continuousExponentB: 1.0,
+                continuousExponentC: 0.0,
+                cvRankAgreement: 1.0,
+                bootstrapSelectionAgreement: 1.0);
+
+            var path = ComplexityHistoryStore.Write(dir, new[] { entry }, DateTime.UtcNow, "abc1234");
+            File.Exists(path).ShouldBeTrue();
+
+            var loaded = ComplexityHistoryStore.LoadMostRecentPrior(dir);
+            loaded.Count.ShouldBe(1);
+            loaded[0].BestFamilyName.ShouldBe("Linear");
+            loaded[0].BestScale.ShouldBe(1.5, tolerance: 1e-9);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HistoryStore_LoadMostRecent_PicksLatestByFilename()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var older = new ComplexityHistoryEntry { BestFamilyName = "Linear" };
+            var newer = new ComplexityHistoryEntry { BestFamilyName = "Quadratic" };
+
+            ComplexityHistoryStore.Write(dir, new[] { older }, new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc), "old1234");
+            // Ensure filenames differ (timestamp resolution is seconds)
+            System.Threading.Thread.Sleep(50);
+            ComplexityHistoryStore.Write(dir, new[] { newer }, new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc), "new1234");
+
+            var loaded = ComplexityHistoryStore.LoadMostRecentPrior(dir);
+            loaded.Count.ShouldBe(1);
+            loaded[0].BestFamilyName.ShouldBe("Quadratic");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HistoryStore_MissingDir_ReturnsEmpty()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"sf-trend-missing-{Guid.NewGuid():N}");
+        // Don't create — make sure load is a no-op
+        ComplexityHistoryStore.LoadMostRecentPrior(dir).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ResolveCommitSha_RespectsEnvironment()
+    {
+        var key = "GITHUB_SHA";
+        var prior = Environment.GetEnvironmentVariable(key);
+        try
+        {
+            Environment.SetEnvironmentVariable(key, "deadbeefcafe");
+            ComplexityHistoryStore.ResolveCommitSha().ShouldBe("deadbeefcafe");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, prior);
+        }
+    }
+
+    [Fact]
+    public void Diff_Stable_NoRegression()
+    {
+        var prev = MakeEntry("Linear", scale: 1.0, isDistinguishable: true);
+        var cur = MakeEntry("Linear", scale: 1.05, isDistinguishable: true); // 5 % drift, below default 25 %
+        var diff = ComplexityHistoryDiffer.Diff(new[] { prev }, new[] { cur });
+        diff.Count.ShouldBe(1);
+        diff[0].Kind.ShouldBe(ComplexityTransitionKind.Stable);
+        diff[0].IsRegression.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Diff_ClassChanged_FlaggedAsRegression()
+    {
+        var prev = MakeEntry("Linear");
+        var cur = MakeEntry("Quadratic");
+        var diff = ComplexityHistoryDiffer.Diff(new[] { prev }, new[] { cur });
+        diff.Count.ShouldBe(1);
+        diff[0].Kind.ShouldBe(ComplexityTransitionKind.ClassChanged);
+        diff[0].IsRegression.ShouldBeTrue();
+        diff[0].Summary.ShouldContain("Linear");
+        diff[0].Summary.ShouldContain("Quadratic");
+    }
+
+    [Fact]
+    public void Diff_ParameterDrift_FlaggedWhenAboveTolerance()
+    {
+        var prev = MakeEntry("Linear", scale: 1.0);
+        var cur = MakeEntry("Linear", scale: 2.0); // 100 % drift, well above 25 % default
+        var diff = ComplexityHistoryDiffer.Diff(new[] { prev }, new[] { cur });
+        diff.Count.ShouldBe(1);
+        diff[0].Kind.ShouldBe(ComplexityTransitionKind.ParameterDrift);
+    }
+
+    [Fact]
+    public void Diff_DistinguishabilityFlip_FlaggedWhenFamilyAndParamsStable()
+    {
+        var prev = MakeEntry("Linear", scale: 1.0, isDistinguishable: true);
+        var cur = MakeEntry("Linear", scale: 1.05, isDistinguishable: false); // tiny drift, flag flipped
+        var diff = ComplexityHistoryDiffer.Diff(new[] { prev }, new[] { cur });
+        diff.Count.ShouldBe(1);
+        diff[0].Kind.ShouldBe(ComplexityTransitionKind.DistinguishabilityChanged);
+    }
+
+    [Fact]
+    public void Diff_PrioritisesClassChangeOverParameterDrift()
+    {
+        var prev = MakeEntry("Linear", scale: 1.0);
+        var cur = MakeEntry("Quadratic", scale: 10.0);
+        var diff = ComplexityHistoryDiffer.Diff(new[] { prev }, new[] { cur });
+        diff[0].Kind.ShouldBe(ComplexityTransitionKind.ClassChanged);
+    }
+
+    [Fact]
+    public void Diff_KeyOnlyInCurrent_Skipped()
+    {
+        var diff = ComplexityHistoryDiffer.Diff(
+            new List<ComplexityHistoryEntry>(),
+            new[] { MakeEntry("Linear", key: "Brand.New.Test") });
+        diff.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Diff_KeyOnlyInPrevious_Skipped()
+    {
+        var diff = ComplexityHistoryDiffer.Diff(
+            new[] { MakeEntry("Linear", key: "Removed.Test") },
+            new List<ComplexityHistoryEntry>());
+        diff.Count.ShouldBe(0);
+    }
+
+    private static ComplexityHistoryEntry MakeEntry(
+        string family = "Linear",
+        double scale = 1.0,
+        bool isDistinguishable = true,
+        string key = "Test.Ns.Cls.M.N")
+    {
+        var parts = key.Split('.');
+        var prop = parts[^1];
+        var method = parts[^2];
+        var cls = string.Join(".", parts.Take(parts.Length - 2));
+        return new ComplexityHistoryEntry
+        {
+            TestClassFullName = cls,
+            MethodName = method,
+            PropertyName = prop,
+            CommitSha = "test1234",
+            TimestampUtc = DateTime.UtcNow,
+            BestFamilyName = family,
+            BestFamilyOName = family,
+            BestScale = scale,
+            BestBias = 0,
+            BestRSquared = 0.99,
+            BestAicc = 0,
+            AkaikeWeight = 0.99,
+            IsDistinguishable = isDistinguishable,
+            SampleSize = 6
+        };
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"sf-trend-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}


### PR DESCRIPTION
## Summary

Five additive features that complete the ScaleFish hardening arc. All defaults are on; everything is opt-out via `ScaleFishSettings`.

### What changed

**Cross-validation rank stability**
Leave-one-X-out: every candidate is refit on `n-1` points per fold; the fold's winner is compared to the all-data winner (rank agreement) and the all-data winner is refit per fold to score honest prediction error. Attached to `ScaleFishModel.CrossValidation`. Catches overfitting that AICc (in-sample) can't.

**Tail-percentile complexity**
When raw replicates are present, ScaleFish runs the full family-ranking pipeline on per-X p50/p95/p99 separately. Each percentile gets its own slim classification (`TailFitResult` — family, R², AICc, distinguishability, fitted scale/bias). Reveals "my mean is linear, but my p99 is quadratic" cases that mean-only analysis hides.

**Adaptive X recommender**
`AdaptiveXRecommender.RecommendInitialProbe(minN, maxN, points)` and `RecommendRefinement(previousXs, priorModel, targetMaxN)` — pure planning helpers that return geometric probe sets. Users copy the values into a `SailfishVariableAttribute` for the next run. No execution-pipeline change.

**Trend tracking + complexity regression detection**
Every ScaleFish run writes a slim snapshot to `<TrackingDir>/ComplexityHistory/`, indexed by timestamp + commit SHA (resolved from `GITHUB_SHA`, `CI_COMMIT_SHA`, `BUILD_SOURCEVERSION`, `CIRCLE_SHA1`, `GIT_COMMIT`, or `git rev-parse HEAD`). On subsequent runs the snapshot is diffed against the most-recent prior; non-stable transitions are:

| Kind | Meaning |
| --- | --- |
| `ParameterDrift` | Same best family, but `scale` shifted &gt; ±25 %. |
| `ClassChanged` | Best family flipped — e.g. `O(n)` → `O(n²)`. The headline regression. |
| `DistinguishabilityChanged` | Family + parameters stable, but `Distinguishable` flag flipped. |

Transitions appear in a new section of the markdown report and fire a new `ComplexityRegressionDetectedNotification` via MediatR for CI consumers (PR commenters, build gates, IDE plugins).

**HTML/SVG visual report**
Server-side renderer produces `ScaleFishReport_yyyyMMdd-HHmmss.html` next to the markdown output. Inline SVG plots empirical points + best/runner-up fitted curves; per-property metrics table; expandable tail-fit blocks. Zero external dependencies — opens offline.

### New settings

| Setting | Default | Effect |
|---|---|---|
| `EnableCrossValidation` | `true` | Skip CV when off |
| `EnableTailPercentileFits` | `true` | Skip tail fits when off |
| `TailPercentiles` | `[0.50, 0.95, 0.99]` | Percentiles to classify |
| `EnableTrendTracking` | `true` | Skip history write + diff when off |
| `EmitHtmlReport` | `true` | Skip HTML emit when off |

All five are wired through `.sailfish.json`, `RunSettingsBuilder.WithScaleFish(settings)`, and the `ComplexityEstimator` constructor.

### Backwards compatibility

- All `ScaleFishModel` fields added as optional inits with sensible defaults
- JSON model files round-trip the new fields; older files load with NaN/null/false fallbacks
- No changes to the execution pipeline (no `[SailfishVariable]` semantics changed)
- Built-in family catalog unchanged

### Test bar

| Suite | Before | After |
|---|---|---|
| Tests.Library (net9 + net10) | 1257 | **1291** |
| ScaleFish-specific | 167 | **201** |
| Tests.Analyzers | 54 | 54 |
| Tests.TestAdapter | 554 | 554 |

34 new tests across five new files:
- **ScaleFishCrossValidationTests** (5) — engages by default, perfect-data agreement, noisy convergence, too-few-points, opt-out.
- **ScaleFishTailFitTests** (6) — default percentiles, custom percentiles, skip-when-no-replicates, classification correctness, out-of-range filtering, opt-out.
- **ScaleFishAdaptiveXTests** (5) — geometric initial, refinement extension, input validation, target-below-max no-op, empty-prior rejection.
- **ScaleFishTrendTrackingTests** (11) — write/read round trip, most-recent picker, missing-dir handling, env-var resolution, every transition kind, key-only-in-current/previous handling, family-change priority over parameter drift.
- **ScaleFishHtmlReportTests** (6) — empty-input skeleton, full render with plot, no-measurements fallback, distinguishability badge, HTML escaping.

## Test plan

- [x] `dotnet build source/Sailfish.sln -c Release` — clean
- [x] `dotnet test source/Tests.Library` — 1291/1291 on net9 + net10
- [x] `dotnet test source/Tests.Analyzers` — 54/54
- [x] `dotnet test source/Tests.TestAdapter` — 554/554
- [x] CV produces RankAgreement = 1.0 on noise-free linear data
- [x] Tail-fit on linear data classifies every percentile as Linear
- [x] Trend tracking detects ClassChanged transitions and fires the regression notification
- [x] HTML report renders inline SVG with no external dependencies
- [x] Adaptive recommender returns geometric `{8, 16, 32, 64, 128, 256}` for the example range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-validation and tail-percentile diagnostics added to ScaleFish results (configurable percentiles).
  * Trend tracking with persisted history and regression detection; emits notifications and optional HTML reports.
  * Adaptive probe recommender suggests geometric probe sets and safe refinements.
  * Markdown output now shows cross-validation stability (CvStability) and models expose these diagnostics.

* **Tests**
  * Expanded tests covering cross-validation, tail fits, trend tracking, HTML reports, and adaptive probing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->