### PR TITLE
Queue: address 5 tech-debt items in the test completion queue

### DIFF
--- a/source/Sailfish.TestAdapter/Queue/Contracts/MessageMetadata.cs
+++ b/source/Sailfish.TestAdapter/Queue/Contracts/MessageMetadata.cs
@@ -1,0 +1,146 @@
+using System;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Sailfish.Logging;
+
+namespace Sailfish.TestAdapter.Queue.Contracts;
+
+/// <summary>
+/// Single source of truth for keys and extraction helpers used to read auxiliary
+/// data from <see cref="TestCompletionQueueMessage.Metadata"/>. Both producers
+/// (TestCompletionMessageMapper) and consumers (FrameworkPublishingProcessor,
+/// BatchTimeoutHandler) must go through here to stay in sync.
+/// </summary>
+internal static class MessageMetadata
+{
+    public static class Keys
+    {
+        public const string TestCase = "TestCase";
+        public const string FormattedMessage = "FormattedMessage";
+        public const string StartTime = "StartTime";
+        public const string EndTime = "EndTime";
+        public const string Exception = "Exception";
+        public const string ComparisonGroup = "ComparisonGroup";
+    }
+
+    /// <summary>
+    /// Reads the original <see cref="TestCase"/> from message metadata, falling back
+    /// to a synthetic test case so framework publishing can always proceed.
+    /// </summary>
+    public static TestCase ExtractTestCase(TestCompletionQueueMessage message, ILogger logger)
+    {
+        if (message.Metadata.TryGetValue(Keys.TestCase, out var testCaseObj) && testCaseObj is TestCase testCase)
+        {
+            return testCase;
+        }
+
+        logger.Log(LogLevel.Warning,
+            "TestCase not found in metadata for test case '{0}'. Creating fallback TestCase.",
+            message.TestCaseId);
+
+        return new TestCase(message.TestCaseId, new Uri("executor://sailfish"), "Sailfish");
+    }
+
+    /// <summary>
+    /// Reads the formatted output message, falling back to a generated description.
+    /// </summary>
+    public static string ExtractFormattedMessage(TestCompletionQueueMessage message, ILogger logger)
+    {
+        if (message.Metadata.TryGetValue(Keys.FormattedMessage, out var messageObj) && messageObj is string outputMessage)
+        {
+            return outputMessage;
+        }
+
+        logger.Log(LogLevel.Warning,
+            "Test output message not found in metadata for test case '{0}'. Using default message.",
+            message.TestCaseId);
+
+        return $"Test case '{message.TestCaseId}' completed with status: {(message.TestResult.IsSuccess ? "Success" : "Failed")}";
+    }
+
+    /// <summary>
+    /// Reads the test start time, falling back to a value derived from the message's
+    /// completion time and median duration.
+    /// </summary>
+    public static DateTimeOffset ExtractStartTime(TestCompletionQueueMessage message, ILogger logger)
+    {
+        if (message.Metadata.TryGetValue(Keys.StartTime, out var startTimeObj) && startTimeObj is DateTimeOffset startTime)
+        {
+            return startTime;
+        }
+
+        logger.Log(LogLevel.Warning,
+            "Start time not found in metadata for test case '{0}'. Calculating fallback start time.",
+            message.TestCaseId);
+
+        return message.CompletedAt.AddMilliseconds(-message.PerformanceMetrics.MedianMs);
+    }
+
+    /// <summary>
+    /// Reads the test end time, falling back to <see cref="TestCompletionQueueMessage.CompletedAt"/>.
+    /// </summary>
+    public static DateTimeOffset ExtractEndTime(TestCompletionQueueMessage message)
+    {
+        if (message.Metadata.TryGetValue(Keys.EndTime, out var endTimeObj) && endTimeObj is DateTimeOffset endTime)
+        {
+            return endTime;
+        }
+
+        return message.CompletedAt;
+    }
+
+    /// <summary>
+    /// Reads the original exception from metadata for failed tests; falls back to one
+    /// reconstructed from <see cref="TestCompletionQueueMessage.TestResult"/>.
+    /// Returns null for successful tests.
+    /// </summary>
+    public static Exception? ExtractException(TestCompletionQueueMessage message)
+    {
+        if (message.TestResult.IsSuccess)
+        {
+            return null;
+        }
+
+        if (message.Metadata.TryGetValue(Keys.Exception, out var exceptionObj) && exceptionObj is Exception originalException)
+        {
+            return originalException;
+        }
+
+        if (!string.IsNullOrEmpty(message.TestResult.ExceptionMessage))
+        {
+            return new Exception(message.TestResult.ExceptionMessage);
+        }
+
+        return new Exception("Test failed without specific exception details");
+    }
+
+    /// <summary>
+    /// Returns the test execution duration in milliseconds, preferring the recorded
+    /// median timing and falling back to (end - start).
+    /// </summary>
+    public static double CalculateDuration(TestCompletionQueueMessage message, DateTimeOffset startTime, DateTimeOffset endTime)
+    {
+        if (message.PerformanceMetrics.MedianMs > 0)
+        {
+            return message.PerformanceMetrics.MedianMs;
+        }
+
+        var duration = (endTime - startTime).TotalMilliseconds;
+        return Math.Max(0, duration);
+    }
+
+    /// <summary>
+    /// True when the message belongs to a comparison group and the test succeeded
+    /// (failed comparison members are always published immediately).
+    /// </summary>
+    public static bool IsComparisonMember(TestCompletionQueueMessage message)
+    {
+        if (!message.TestResult.IsSuccess)
+        {
+            return false;
+        }
+
+        return message.Metadata.TryGetValue(Keys.ComparisonGroup, out var groupObj)
+               && groupObj is string group
+               && !string.IsNullOrEmpty(group);
+    }
+}

--- a/source/Sailfish.TestAdapter/Queue/Implementation/BatchTimeoutHandler.cs
+++ b/source/Sailfish.TestAdapter/Queue/Implementation/BatchTimeoutHandler.cs
@@ -49,6 +49,7 @@ internal class BatchTimeoutHandler : IBatchTimeoutHandler, IDisposable
     private Timer? _monitoringTimer;
     private bool _isRunning;
     private bool _isDisposed;
+    private int _sweepInProgress;
     private readonly object _lockObject = new();
     
     /// <summary>
@@ -235,10 +236,22 @@ internal class BatchTimeoutHandler : IBatchTimeoutHandler, IDisposable
     /// Timer callback method that periodically checks for and processes timed-out batches.
     /// </summary>
     /// <param name="state">Timer state (not used).</param>
+    /// <remarks>
+    /// `async void` is required by the Timer callback signature. The method swallows all
+    /// exceptions to keep the timer alive, and uses <see cref="_sweepInProgress"/> as a
+    /// non-blocking reentrancy guard so a slow sweep can't overlap with the next tick
+    /// and double-publish framework notifications for the same batch.
+    /// </remarks>
     private async void MonitorBatchTimeouts(object? state)
     {
         if (_isDisposed || !_isRunning)
         {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _sweepInProgress, 1, 0) != 0)
+        {
+            // Previous sweep is still running; skip this tick.
             return;
         }
 
@@ -251,6 +264,10 @@ internal class BatchTimeoutHandler : IBatchTimeoutHandler, IDisposable
             _logger.Log(LogLevel.Error, ex,
                 "Error occurred during batch timeout monitoring: {0}", ex.Message);
             // Don't re-throw in timer callback to prevent timer from stopping
+        }
+        finally
+        {
+            Volatile.Write(ref _sweepInProgress, 0);
         }
     }
 
@@ -323,14 +340,13 @@ internal class BatchTimeoutHandler : IBatchTimeoutHandler, IDisposable
     {
         try
         {
-            // Extract required data from the message metadata (similar to FrameworkPublishingProcessor)
-            var testCase = ExtractTestCase(message);
-            var testOutputMessage = ExtractTestOutputMessage(message);
-            var startTime = ExtractStartTime(message);
-            var endTime = ExtractEndTime(message);
-            var duration = CalculateDuration(message, startTime, endTime);
-            var statusCode = DetermineStatusCode(message);
-            var exception = ExtractException(message);
+            var testCase = MessageMetadata.ExtractTestCase(message, _logger);
+            var testOutputMessage = MessageMetadata.ExtractFormattedMessage(message, _logger);
+            var startTime = MessageMetadata.ExtractStartTime(message, _logger);
+            var endTime = MessageMetadata.ExtractEndTime(message);
+            var duration = MessageMetadata.CalculateDuration(message, startTime, endTime);
+            var statusCode = message.TestResult.IsSuccess ? StatusCode.Success : StatusCode.Failure;
+            var exception = MessageMetadata.ExtractException(message);
 
             // Create the framework notification
             var frameworkNotification = new FrameworkTestCaseEndNotification(
@@ -357,119 +373,6 @@ internal class BatchTimeoutHandler : IBatchTimeoutHandler, IDisposable
                 message.TestCaseId, ex.Message);
             throw;
         }
-    }
-
-    /// <summary>
-    /// Extracts the TestCase object from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The TestCase object.</returns>
-    private static Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase ExtractTestCase(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue("TestCase", out var testCaseObj) &&
-            testCaseObj is Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase testCase)
-        {
-            return testCase;
-        }
-
-        throw new InvalidOperationException($"TestCase not found in message metadata for test case '{message.TestCaseId}'");
-    }
-
-    /// <summary>
-    /// Extracts the test output message from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The test output message string.</returns>
-    private static string ExtractTestOutputMessage(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue("FormattedMessage", out var outputObj) &&
-            outputObj is string outputMessage)
-        {
-            return outputMessage;
-        }
-
-        return string.Empty; // Default to empty string if not found
-    }
-
-    /// <summary>
-    /// Extracts the start time from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The test start time.</returns>
-    private static DateTimeOffset ExtractStartTime(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue("StartTime", out var startTimeObj) &&
-            startTimeObj is DateTimeOffset startTime)
-        {
-            return startTime;
-        }
-
-        // Default to message completion time if start time not found
-        return message.CompletedAt;
-    }
-
-    /// <summary>
-    /// Extracts the end time from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The test end time.</returns>
-    private static DateTimeOffset ExtractEndTime(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue("EndTime", out var endTimeObj) &&
-            endTimeObj is DateTimeOffset endTime)
-        {
-            return endTime;
-        }
-
-        // Default to message completion time if end time not found
-        return message.CompletedAt;
-    }
-
-    /// <summary>
-    /// Calculates the test execution duration in milliseconds.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <param name="startTime">The test start time.</param>
-    /// <param name="endTime">The test end time.</param>
-    /// <returns>The test execution duration in milliseconds.</returns>
-    private static double CalculateDuration(TestCompletionQueueMessage message, DateTimeOffset startTime, DateTimeOffset endTime)
-    {
-        // Prefer the median from performance metrics if available
-        if (message.PerformanceMetrics.MedianMs > 0)
-        {
-            return message.PerformanceMetrics.MedianMs;
-        }
-
-        // Fallback to time difference calculation
-        var duration = (endTime - startTime).TotalMilliseconds;
-        return Math.Max(0, duration); // Ensure non-negative duration
-    }
-
-    /// <summary>
-    /// Determines the test status code from the message.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The test status code.</returns>
-    private static StatusCode DetermineStatusCode(TestCompletionQueueMessage message)
-    {
-        // Use the test result from the message to determine status
-        return message.TestResult.IsSuccess ? StatusCode.Success : StatusCode.Failure;
-    }
-
-    /// <summary>
-    /// Extracts the exception from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The exception if present, null otherwise.</returns>
-    private static Exception? ExtractException(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue("Exception", out var exceptionObj) &&
-            exceptionObj is Exception exception)
-        {
-            return exception;
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/source/Sailfish.TestAdapter/Queue/Implementation/InMemoryTestCompletionQueue.cs
+++ b/source/Sailfish.TestAdapter/Queue/Implementation/InMemoryTestCompletionQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -26,24 +26,13 @@ namespace Sailfish.TestAdapter.Queue.Implementation;
 /// - Proper lifecycle management with start/stop/complete operations
 /// - Graceful shutdown with completion detection
 /// - Comprehensive error handling for invalid operations
-/// - Configuration-aware with support for queue settings
-///
-/// Configuration Support:
-/// The queue accepts a QueueConfiguration object that controls various aspects of its behavior:
-/// - MaxQueueCapacity: Applied to the underlying channel capacity
-/// - EnableBatchProcessing, MaxBatchSize: Stored for future use by queue consumers
-/// - Other settings: Available via Configuration property for processors and consumers
-///
-/// The implementation is designed to be lightweight and efficient for the test adapter
-/// runtime environment where queue operations must not impact test execution performance.
 /// </remarks>
 public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
 {
     private readonly Channel<TestCompletionQueueMessage> _channel;
     private readonly ChannelWriter<TestCompletionQueueMessage> _writer;
     private readonly ChannelReader<TestCompletionQueueMessage> _reader;
-    private readonly int _maxCapacity;
-    private readonly QueueConfiguration? _configuration;
+    private readonly QueueConfiguration _configuration;
 
     private volatile bool _isRunning;
     private volatile bool _isCompleted;
@@ -79,77 +68,21 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
         }
 
         _configuration = configuration;
-        _maxCapacity = configuration.MaxQueueCapacity;
 
-        // Create a bounded channel with the configured capacity
-        _channel = Channel.CreateBounded<TestCompletionQueueMessage>(_maxCapacity);
+        _channel = Channel.CreateBounded<TestCompletionQueueMessage>(configuration.MaxQueueCapacity);
         _writer = _channel.Writer;
         _reader = _channel.Reader;
-
-        _isRunning = false;
-        _isCompleted = false;
-        _isDisposed = false;
-        _queueDepth = 0;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="InMemoryTestCompletionQueue"/> class.
-    /// Creates a bounded channel with the specified capacity for controlled memory usage.
-    /// </summary>
-    /// <param name="maxCapacity">
-    /// The maximum number of messages that can be queued. Must be greater than 0.
-    /// </param>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="maxCapacity"/> is less than or equal to 0.
-    /// </exception>
-    /// <remarks>
-    /// This constructor is provided for backward compatibility. For full configuration support,
-    /// use the constructor that accepts a <see cref="QueueConfiguration"/> parameter.
-    /// </remarks>
-    public InMemoryTestCompletionQueue(int maxCapacity)
-    {
-        if (maxCapacity <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxCapacity),
-                "Maximum capacity must be greater than 0.");
-        }
-
-        _configuration = null;
-        _maxCapacity = maxCapacity;
-
-        // Create a bounded channel with the specified capacity
-        _channel = Channel.CreateBounded<TestCompletionQueueMessage>(maxCapacity);
-        _writer = _channel.Writer;
-        _reader = _channel.Reader;
-
-        _isRunning = false;
-        _isCompleted = false;
-        _isDisposed = false;
-        _queueDepth = 0;
     }
 
     /// <summary>
     /// Gets the queue configuration used to initialize this queue instance.
-    /// Returns null if the queue was created using the legacy constructor.
     /// </summary>
-    /// <value>
-    /// The <see cref="QueueConfiguration"/> used to create this queue, or null if created
-    /// with the legacy constructor that only accepts capacity.
-    /// </value>
-    /// <remarks>
-    /// This property provides access to the full configuration for queue consumers and processors
-    /// that need to access batch processing settings, timeouts, and other configuration values.
-    /// When null, consumers should use appropriate default values.
-    /// </remarks>
-    public QueueConfiguration? Configuration => _configuration;
+    public QueueConfiguration Configuration => _configuration;
 
     /// <summary>
     /// Gets the maximum capacity of the queue as configured during initialization.
     /// </summary>
-    /// <value>
-    /// The maximum number of messages that can be queued simultaneously.
-    /// </value>
-    public int MaxCapacity => _maxCapacity;
+    public int MaxCapacity => _configuration.MaxQueueCapacity;
 
     /// <inheritdoc />
     public bool IsRunning => _isRunning && !_isDisposed;
@@ -171,19 +104,19 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
     public Task StartAsync(CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
-        
+
         if (_isRunning)
         {
             throw new InvalidOperationException("Queue is already running.");
         }
-        
+
         if (_isCompleted)
         {
             throw new InvalidOperationException("Queue has been completed and cannot be restarted.");
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        
+
         _isRunning = true;
         return Task.CompletedTask;
     }
@@ -193,7 +126,7 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
     {
         ThrowIfDisposed();
         cancellationToken.ThrowIfCancellationRequested();
-        
+
         _isRunning = false;
         return Task.CompletedTask;
     }
@@ -203,13 +136,13 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
     {
         ThrowIfDisposed();
         cancellationToken.ThrowIfCancellationRequested();
-        
+
         _isCompleted = true;
         _isRunning = false;
-        
+
         // Complete the writer to signal no more messages will be added
         _writer.Complete();
-        
+
         return Task.CompletedTask;
     }
 
@@ -220,14 +153,14 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
         {
             throw new ArgumentNullException(nameof(message));
         }
-        
+
         ThrowIfDisposed();
-        
+
         if (!_isRunning)
         {
             throw new InvalidOperationException("Queue is not running. Call StartAsync before enqueuing messages.");
         }
-        
+
         if (_isCompleted)
         {
             throw new InvalidOperationException("Queue has been completed and cannot accept new messages.");
@@ -263,7 +196,7 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
                     return message;
                 }
             }
-            
+
             // Channel is completed and no more messages are available
             return null;
         }
@@ -286,14 +219,11 @@ public class InMemoryTestCompletionQueue : ITestCompletionQueue, IDisposable
             Interlocked.Decrement(ref _queueDepth);
             return Task.FromResult<TestCompletionQueueMessage?>(message);
         }
-        
+
         // No message available immediately
         return Task.FromResult<TestCompletionQueueMessage?>(null);
     }
 
-    /// <summary>
-    /// Throws an <see cref="ObjectDisposedException"/> if the queue has been disposed.
-    /// </summary>
     private void ThrowIfDisposed()
     {
         if (_isDisposed)

--- a/source/Sailfish.TestAdapter/Queue/Implementation/TestCompletionQueueConsumer.cs
+++ b/source/Sailfish.TestAdapter/Queue/Implementation/TestCompletionQueueConsumer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -49,9 +49,12 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
 {
     private readonly ITestCompletionQueue _queue;
     private readonly ILogger _logger;
-    private readonly ConcurrentBag<ITestCompletionQueueProcessor> _processors;
     private readonly IProcessingMetricsCollector? _metricsCollector;
-    
+
+    // Atomically-updated immutable list preserves registration order and lets the
+    // processing loop read a stable snapshot without locking.
+    private ImmutableList<ITestCompletionQueueProcessor> _processors = ImmutableList<ITestCompletionQueueProcessor>.Empty;
+
     private Task? _processingTask;
     private CancellationTokenSource? _cancellationTokenSource;
     private volatile bool _isRunning;
@@ -85,7 +88,6 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
         _queue = queue ?? throw new ArgumentNullException(nameof(queue));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _metricsCollector = metricsCollector;
-        _processors = new ConcurrentBag<ITestCompletionQueueProcessor>();
 
         _isRunning = false;
         _isDisposed = false;
@@ -106,15 +108,15 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
     /// <value>
     /// The number of processors currently registered to receive test completion messages.
     /// </value>
-    public int ProcessorCount => _processors.Count;
+    public int ProcessorCount => Volatile.Read(ref _processors).Count;
 
     /// <summary>
-    /// Gets a snapshot of all registered processors.
+    /// Gets a snapshot of all registered processors in registration order.
     /// </summary>
     /// <returns>An array of all currently registered processors.</returns>
     public ITestCompletionQueueProcessor[] GetProcessors()
     {
-        return _processors.ToArray();
+        return Volatile.Read(ref _processors).ToArray();
     }
 
     /// <summary>
@@ -145,12 +147,12 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
         {
             throw new ArgumentNullException(nameof(processor));
         }
-        
+
         ThrowIfDisposed();
-        
-        _processors.Add(processor);
-        _logger.Log(LogLevel.Information, 
-            $"Registered processor '{processor.GetType().Name}' with queue consumer. Total processors: {_processors.Count}");
+
+        var updated = AtomicUpdate(list => list.Add(processor));
+        _logger.Log(LogLevel.Information,
+            $"Registered processor '{processor.GetType().Name}' with queue consumer. Total processors: {updated.Count}");
     }
 
     /// <summary>
@@ -181,21 +183,43 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
         {
             throw new ArgumentNullException(nameof(processor));
         }
-        
+
         ThrowIfDisposed();
-        
-        // Create a new bag without the processor to remove
-        var remainingProcessors = _processors.Where(p => !ReferenceEquals(p, processor)).ToList();
-        
-        // Clear the current bag and add back the remaining processors
-        while (_processors.TryTake(out _)) { }
-        foreach (var remainingProcessor in remainingProcessors)
+
+        // Remove the first occurrence by reference identity so that registering the same
+        // instance twice and then unregistering once preserves the duplicate (matches the
+        // documented "one registration removed per call" behavior).
+        var updated = AtomicUpdate(list =>
         {
-            _processors.Add(remainingProcessor);
+            var index = -1;
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (ReferenceEquals(list[i], processor))
+                {
+                    index = i;
+                    break;
+                }
+            }
+            return index < 0 ? list : list.RemoveAt(index);
+        });
+
+        _logger.Log(LogLevel.Information,
+            $"Unregistered processor '{processor.GetType().Name}' from queue consumer. Total processors: {updated.Count}");
+    }
+
+    private ImmutableList<ITestCompletionQueueProcessor> AtomicUpdate(
+        Func<ImmutableList<ITestCompletionQueueProcessor>, ImmutableList<ITestCompletionQueueProcessor>> mutator)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _processors);
+            var next = mutator(current);
+            if (ReferenceEquals(next, current) ||
+                ReferenceEquals(Interlocked.CompareExchange(ref _processors, next, current), current))
+            {
+                return next;
+            }
         }
-        
-        _logger.Log(LogLevel.Information, 
-            $"Unregistered processor '{processor.GetType().Name}' from queue consumer. Total processors: {_processors.Count}");
     }
 
     /// <summary>
@@ -371,9 +395,9 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
     /// <returns>A task representing the asynchronous processing operation.</returns>
     private async Task ProcessMessageWithProcessors(TestCompletionQueueMessage message, CancellationToken cancellationToken)
     {
-        var processors = _processors.ToArray(); // Snapshot for thread safety
+        var processors = Volatile.Read(ref _processors);
 
-        if (processors.Length == 0)
+        if (processors.Count == 0)
         {
             _logger.Log(LogLevel.Warning,
                 $"No processors registered - message for test case '{message.TestCaseId}' will not be processed");
@@ -381,9 +405,9 @@ internal class TestCompletionQueueConsumer : IDisposable, IAsyncDisposable
         }
 
         _logger.Log(LogLevel.Debug,
-            $"Processing message for test case '{message.TestCaseId}' with {processors.Length} processors");
+            $"Processing message for test case '{message.TestCaseId}' with {processors.Count} processors");
 
-        // Process with each registered processor sequentially
+        // Process with each registered processor sequentially, in registration order.
         foreach (var processor in processors)
         {
             await ProcessMessageWithSingleProcessor(message, processor, cancellationToken).ConfigureAwait(false);

--- a/source/Sailfish.TestAdapter/Queue/Implementation/TestCompletionQueueManager.cs
+++ b/source/Sailfish.TestAdapter/Queue/Implementation/TestCompletionQueueManager.cs
@@ -51,7 +51,7 @@ namespace Sailfish.TestAdapter.Queue.Implementation;
 /// can be registered as a service in the DI container. It uses the standard ILogger
 /// interface for comprehensive diagnostic information and error reporting.
 /// </remarks>
-internal class TestCompletionQueueManager : IDisposable
+internal class TestCompletionQueueManager : IDisposable, IAsyncDisposable
 {
     private readonly ITestCompletionQueue _queue;
     private readonly ITestCompletionQueueProcessor[] _processors;
@@ -500,14 +500,11 @@ internal class TestCompletionQueueManager : IDisposable
         }
 
         // Dispose queue
-        if (queue != null)
+        if (queue is IDisposable disposableQueue)
         {
             try
             {
-                if (queue is IDisposable disposableQueue)
-                {
-                    disposableQueue.Dispose();
-                }
+                disposableQueue.Dispose();
             }
             catch (Exception ex)
             {
@@ -515,8 +512,6 @@ internal class TestCompletionQueueManager : IDisposable
                     "Error occurred while disposing queue service: {0}", ex.Message);
             }
         }
-
-        await Task.CompletedTask.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -569,14 +564,11 @@ internal class TestCompletionQueueManager : IDisposable
     }
 
     /// <summary>
-    /// Releases all resources used by the <see cref="TestCompletionQueueManager"/>.
+    /// Asynchronously releases all resources used by the <see cref="TestCompletionQueueManager"/>.
+    /// This is the preferred disposal path — it properly awaits the underlying consumer's
+    /// background processing task instead of blocking the calling thread.
     /// </summary>
-    /// <remarks>
-    /// This method ensures proper cleanup of all queue manager resources by stopping
-    /// the manager if it's running and disposing of all managed resources. The method
-    /// is safe to call multiple times and will not throw exceptions during disposal.
-    /// </remarks>
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (_isDisposed)
         {
@@ -584,31 +576,29 @@ internal class TestCompletionQueueManager : IDisposable
         }
 
         _logger.Log(LogLevel.Information,
-            "Disposing test completion queue manager");
+            "Disposing test completion queue manager asynchronously");
 
-        // Stop the manager if it's running
         if (_isRunning)
         {
             try
             {
-                StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+                await StopAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.Log(LogLevel.Warning, ex,
-                    "Error occurred while stopping queue manager during disposal: {0}", ex.Message);
+                    "Error occurred while stopping queue manager during async disposal: {0}", ex.Message);
             }
         }
 
-        // Clean up any remaining resources
         try
         {
-            CleanupResourcesAsync().GetAwaiter().GetResult();
+            await CleanupResourcesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.Log(LogLevel.Warning, ex,
-                "Error occurred while cleaning up resources during disposal: {0}", ex.Message);
+                "Error occurred while cleaning up resources during async disposal: {0}", ex.Message);
         }
 
         lock (_lock)
@@ -618,5 +608,58 @@ internal class TestCompletionQueueManager : IDisposable
 
         _logger.Log(LogLevel.Information,
             "Test completion queue manager disposed successfully");
+    }
+
+    /// <summary>
+    /// Releases the manager's resources synchronously. Prefer <see cref="DisposeAsync"/>;
+    /// this overload only requests cancellation of the consumer's background work so the
+    /// container teardown thread is not blocked waiting on async work (which previously
+    /// risked a deadlock via <c>GetAwaiter().GetResult()</c>). Outstanding work will
+    /// complete on its own once cancellation is observed.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _logger.Log(LogLevel.Information,
+            "Disposing test completion queue manager synchronously - requesting cancellation only");
+
+        TestCompletionQueueConsumer? consumer;
+        lock (_lock)
+        {
+            _isRunning = false;
+            consumer = _consumer;
+            _consumer = null;
+            _isDisposed = true;
+        }
+
+        try
+        {
+            consumer?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Warning, ex,
+                "Error occurred while disposing consumer during synchronous disposal: {0}", ex.Message);
+        }
+
+        if (_queue is IDisposable disposableQueue)
+        {
+            try
+            {
+                disposableQueue.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Warning, ex,
+                    "Error occurred while disposing queue during synchronous disposal: {0}", ex.Message);
+            }
+        }
+
+        _logger.Log(LogLevel.Information,
+            "Test completion queue manager disposed synchronously (background processing may still be completing)");
     }
 }

--- a/source/Sailfish.TestAdapter/Queue/Mapping/TestCompletionMessageMapper.cs
+++ b/source/Sailfish.TestAdapter/Queue/Mapping/TestCompletionMessageMapper.cs
@@ -528,7 +528,7 @@ internal class TestCompletionMessageMapper : ITestCompletionMessageMapper
             var comparisonGroupId = ExtractComparisonGroupId(currentTestCase);
             if (!string.IsNullOrEmpty(comparisonGroupId))
             {
-                metadata["ComparisonGroup"] = comparisonGroupId;
+                metadata[MessageMetadata.Keys.ComparisonGroup] = comparisonGroupId;
             }
 
             // Comparison role information for method comparison processing
@@ -728,15 +728,15 @@ internal class TestCompletionMessageMapper : ITestCompletionMessageMapper
         var metadata = new Dictionary<string, object>
         {
             // Core data required for framework publishing
-            ["TestCase"] = coreData.CurrentTestCase,
-            ["FormattedMessage"] = formattedMessage,
-            ["StartTime"] = performanceTimer.GetIterationStartTime(),
-            ["EndTime"] = performanceTimer.GetIterationStopTime(),
+            [MessageMetadata.Keys.TestCase] = coreData.CurrentTestCase,
+            [MessageMetadata.Keys.FormattedMessage] = formattedMessage,
+            [MessageMetadata.Keys.StartTime] = performanceTimer.GetIterationStartTime(),
+            [MessageMetadata.Keys.EndTime] = performanceTimer.GetIterationStopTime(),
             ["MedianRuntime"] = executionResult.MedianRuntime,
             ["StatusCode"] = executionResult.StatusCode,
 
             // Exception data (if any)
-            ["Exception"] = executionResult.Exception as object ?? DBNull.Value,
+            [MessageMetadata.Keys.Exception] = executionResult.Exception as object ?? DBNull.Value,
 
             // Additional context for processors
             ["ClassExecutionSummaries"] = coreData.ClassExecutionSummaries,

--- a/source/Sailfish.TestAdapter/Queue/Processors/FrameworkPublishingProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/FrameworkPublishingProcessor.cs
@@ -56,30 +56,6 @@ namespace Sailfish.TestAdapter.Queue.Processors;
 /// </remarks>
 public class FrameworkPublishingProcessor : TestCompletionQueueProcessorBase
 {
-    #region Constants
-
-    /// <summary>
-    /// Metadata key for storing the TestCase object in test completion messages.
-    /// </summary>
-    private const string TestCaseMetadataKey = "TestCase";
-
-    /// <summary>
-    /// Metadata key for storing the formatted test output message.
-    /// </summary>
-    private const string TestOutputMessageMetadataKey = "FormattedMessage";
-
-    /// <summary>
-    /// Metadata key for storing the test execution start time.
-    /// </summary>
-    private const string StartTimeMetadataKey = "StartTime";
-
-    /// <summary>
-    /// Metadata key for storing the original exception object for failed tests.
-    /// </summary>
-    private const string ExceptionMetadataKey = "Exception";
-
-    #endregion
-
     #region Fields
 
     private readonly IMediator _mediator;
@@ -126,7 +102,7 @@ public class FrameworkPublishingProcessor : TestCompletionQueueProcessorBase
         {
             // Check if this is a comparison method - if so, skip publishing here
             // The MethodComparisonBatchProcessor will handle publishing enhanced results
-            if (IsComparisonMethod(message))
+            if (MessageMetadata.IsComparisonMember(message))
             {
                 Logger.Log(LogLevel.Debug,
                     "Skipping framework publishing for comparison method '{0}' - will be handled by MethodComparisonBatchProcessor",
@@ -135,13 +111,13 @@ public class FrameworkPublishingProcessor : TestCompletionQueueProcessorBase
             }
 
             // Extract required data from the message and metadata
-            var testCase = ExtractTestCase(message);
-            var testOutputMessage = ExtractTestOutputMessage(message);
-            var startTime = ExtractStartTime(message);
-            var endTime = ExtractEndTime(message);
-            var duration = CalculateDuration(message, startTime, endTime);
-            var statusCode = DetermineStatusCode(message);
-            var exception = ExtractException(message);
+            var testCase = MessageMetadata.ExtractTestCase(message, Logger);
+            var testOutputMessage = MessageMetadata.ExtractFormattedMessage(message, Logger);
+            var startTime = MessageMetadata.ExtractStartTime(message, Logger);
+            var endTime = MessageMetadata.ExtractEndTime(message);
+            var duration = MessageMetadata.CalculateDuration(message, startTime, endTime);
+            var statusCode = message.TestResult.IsSuccess ? StatusCode.Success : StatusCode.Failure;
+            var exception = MessageMetadata.ExtractException(message);
 
             // Create the framework notification
             var frameworkNotification = new FrameworkTestCaseEndNotification(
@@ -170,163 +146,6 @@ public class FrameworkPublishingProcessor : TestCompletionQueueProcessorBase
             // Re-throw to maintain error contract, but this will be handled by base class
             throw;
         }
-    }
-
-    #endregion
-
-    #region Data Extraction Methods
-
-    /// <summary>
-    /// Extracts the TestCase object from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The TestCase object, or a fallback TestCase if not found.</returns>
-    private TestCase ExtractTestCase(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue(TestCaseMetadataKey, out var testCaseObj) && testCaseObj is TestCase testCase)
-        {
-            return testCase;
-        }
-
-        Logger.Log(LogLevel.Warning,
-            "TestCase not found in metadata for test case '{0}'. Creating fallback TestCase.",
-            message.TestCaseId);
-
-        // Create a fallback TestCase to ensure framework publishing continues
-        return new TestCase(message.TestCaseId, new Uri("executor://sailfish"), "Sailfish");
-    }
-
-    /// <summary>
-    /// Extracts the formatted test output message from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The test output message, or a default message if not found.</returns>
-    private string ExtractTestOutputMessage(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue(TestOutputMessageMetadataKey, out var messageObj) && messageObj is string outputMessage)
-        {
-            return outputMessage;
-        }
-
-        Logger.Log(LogLevel.Warning,
-            "Test output message not found in metadata for test case '{0}'. Using default message.",
-            message.TestCaseId);
-
-        // Provide a basic fallback message
-        return $"Test case '{message.TestCaseId}' completed with status: {(message.TestResult.IsSuccess ? "Success" : "Failed")}";
-    }
-
-    /// <summary>
-    /// Extracts the test execution start time from the message metadata.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The start time, or a calculated fallback time if not found.</returns>
-    private DateTimeOffset ExtractStartTime(TestCompletionQueueMessage message)
-    {
-        if (message.Metadata.TryGetValue(StartTimeMetadataKey, out var startTimeObj) && startTimeObj is DateTimeOffset startTime)
-        {
-            return startTime;
-        }
-
-        Logger.Log(LogLevel.Warning,
-            "Start time not found in metadata for test case '{0}'. Calculating fallback start time.",
-            message.TestCaseId);
-
-        // Calculate fallback start time based on completion time and median duration
-        var medianDuration = message.PerformanceMetrics.MedianMs;
-        return message.CompletedAt.AddMilliseconds(-medianDuration);
-    }
-
-    /// <summary>
-    /// Extracts the test execution end time from the message.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The end time from the CompletedAt field.</returns>
-    private DateTimeOffset ExtractEndTime(TestCompletionQueueMessage message)
-    {
-        return message.CompletedAt;
-    }
-
-    /// <summary>
-    /// Calculates the test execution duration.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <param name="startTime">The test start time.</param>
-    /// <param name="endTime">The test end time.</param>
-    /// <returns>The duration in milliseconds.</returns>
-    private double CalculateDuration(TestCompletionQueueMessage message, DateTimeOffset startTime, DateTimeOffset endTime)
-    {
-        // Prefer the median from performance metrics if available
-        if (message.PerformanceMetrics.MedianMs > 0)
-        {
-            return message.PerformanceMetrics.MedianMs;
-        }
-
-        // Fallback to time difference calculation
-        var duration = (endTime - startTime).TotalMilliseconds;
-        return Math.Max(0, duration); // Ensure non-negative duration
-    }
-
-    /// <summary>
-    /// Determines the status code based on the test result.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The appropriate StatusCode value.</returns>
-    private StatusCode DetermineStatusCode(TestCompletionQueueMessage message)
-    {
-        return message.TestResult.IsSuccess ? StatusCode.Success : StatusCode.Failure;
-    }
-
-    /// <summary>
-    /// Extracts the original exception from the message metadata or creates one from test result data.
-    /// </summary>
-    /// <param name="message">The test completion message.</param>
-    /// <returns>The exception object, or null if the test was successful.</returns>
-    private Exception? ExtractException(TestCompletionQueueMessage message)
-    {
-        // Return null for successful tests
-        if (message.TestResult.IsSuccess)
-        {
-            return null;
-        }
-
-        // Try to get the original exception from metadata
-        if (message.Metadata.TryGetValue(ExceptionMetadataKey, out var exceptionObj) && exceptionObj is Exception originalException)
-        {
-            return originalException;
-        }
-
-        // Create an exception from the test result data if original is not available
-        if (!string.IsNullOrEmpty(message.TestResult.ExceptionMessage))
-        {
-            return new Exception(message.TestResult.ExceptionMessage);
-        }
-
-        // Fallback for failed tests without exception details
-        return new Exception("Test failed without specific exception details");
-    }
-
-    /// <summary>
-    /// Determines if a test case is a comparison method that should be handled by MethodComparisonBatchProcessor.
-    /// </summary>
-    /// <param name="message">The test completion queue message to check.</param>
-    /// <returns>True if this is a comparison method, false otherwise.</returns>
-    private static bool IsComparisonMethod(TestCompletionQueueMessage message)
-    {
-        // A failed [SailfishComparison] test case can never contribute to an N×N
-        // comparison: there are no usable timing samples and no sibling will ever
-        // arrive that "completes" the batch. Treating it as a comparison method
-        // would defer publishing to MethodComparisonBatchProcessor, where it
-        // could get stranded — VSTest/Rider would then see TestOutcome.None
-        // ("Outcome value None is not understood"). Publish the failure here
-        // immediately and let the batch processor handle only successful members.
-        if (!message.TestResult.IsSuccess) return false;
-
-        // Check if the message has comparison metadata
-        var hasComparisonGroup = message.Metadata.TryGetValue("ComparisonGroup", out var groupObj) &&
-                                 groupObj is string group && !string.IsNullOrEmpty(group);
-
-        return hasComparisonGroup;
     }
 
     #endregion

--- a/source/Sailfish.TestAdapter/Registrations/TestAdapterRegistrations.cs
+++ b/source/Sailfish.TestAdapter/Registrations/TestAdapterRegistrations.cs
@@ -130,14 +130,9 @@ internal class TestAdapterRegistrations : IProvideAdditionalRegistrations
     private static void RegisterCoreQueueServices(ContainerBuilder builder)
     {
         // Core queue implementation - singleton to maintain state during test execution
-        // Use factory registration to inject the MaxQueueCapacity configuration parameter
-        builder.Register(context =>
-        {
-            var configuration = context.Resolve<QueueConfiguration>();
-            return new InMemoryTestCompletionQueue(configuration.MaxQueueCapacity);
-        })
-        .As<ITestCompletionQueue>()
-        .SingleInstance();
+        builder.Register(context => new InMemoryTestCompletionQueue(context.Resolve<QueueConfiguration>()))
+            .As<ITestCompletionQueue>()
+            .SingleInstance();
 
         // Queue publisher - transient as it's a lightweight service
         builder.RegisterType<TestCompletionQueuePublisher>()

--- a/source/Tests.TestAdapter/Queue/BatchTimeoutHandlerTests.cs
+++ b/source/Tests.TestAdapter/Queue/BatchTimeoutHandlerTests.cs
@@ -365,7 +365,8 @@ public class BatchTimeoutHandlerTests : IDisposable
         var timedOutBatch = CreateTestBatch("batch1", DateTime.UtcNow.AddMinutes(-10));
         timedOutBatch.CompletionTimeout = null;
 
-        // Remove TestCase metadata to trigger exception path
+        // Remove all metadata: the publish path should still succeed with synthetic fallbacks
+        // (a missing TestCase no longer drops the notification — it falls back to a synthetic one).
         timedOutBatch.TestCases.First().Metadata.Clear();
 
         _batchingService.GetPendingBatchesAsync(Arg.Any<CancellationToken>())
@@ -374,11 +375,10 @@ public class BatchTimeoutHandlerTests : IDisposable
         // Act
         var result = await _timeoutHandler.ProcessTimedOutBatchesAsync(CancellationToken.None);
 
-        // Assert - Should process 0 batches successfully (batch is timed out but processing individual test case fails)
-        // The implementation catches exceptions per test case and continues, so the batch itself is marked as processed
-        // but individual test case failures are logged
-        result.ShouldBe(1); // Batch is processed even though test case publication fails
-        _logger.Received().Log(LogLevel.Error, Arg.Any<Exception>(), Arg.Any<string>(), Arg.Any<object[]>());
+        // Assert
+        result.ShouldBe(1);
+        await _mediator.Received(1).Publish(Arg.Any<FrameworkTestCaseEndNotification>(), Arg.Any<CancellationToken>());
+        _logger.Received().Log(LogLevel.Warning, Arg.Any<string>(), Arg.Any<object[]>());
     }
 
     [Fact]
@@ -407,7 +407,8 @@ public class BatchTimeoutHandlerTests : IDisposable
 
         var batch1 = CreateTestBatch("batch1", DateTime.UtcNow.AddMinutes(-10));
         batch1.CompletionTimeout = null;
-        batch1.TestCases.First().Metadata.Clear(); // This will cause failure in test case processing
+        // Strip metadata: publish still succeeds via synthetic fallbacks.
+        batch1.TestCases.First().Metadata.Clear();
 
         var batch2 = CreateTestBatch("batch2", DateTime.UtcNow.AddMinutes(-10));
         batch2.CompletionTimeout = null;
@@ -418,11 +419,9 @@ public class BatchTimeoutHandlerTests : IDisposable
         // Act
         var result = await _timeoutHandler.ProcessTimedOutBatchesAsync(CancellationToken.None);
 
-        // Assert - Both batches should be processed (batch processing succeeds even if individual test case fails)
-        // batch1 processes but test case publication fails (caught and logged)
-        // batch2 processes successfully
+        // Assert
         result.ShouldBe(2);
-        await _mediator.Received(1).Publish(Arg.Any<FrameworkTestCaseEndNotification>(), Arg.Any<CancellationToken>());
+        await _mediator.Received(2).Publish(Arg.Any<FrameworkTestCaseEndNotification>(), Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/source/Tests.TestAdapter/Queue/QueueExtensionsTests.cs
+++ b/source/Tests.TestAdapter/Queue/QueueExtensionsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
+using Sailfish.TestAdapter.Queue.Configuration;
 using Sailfish.TestAdapter.Queue.Contracts;
 using Sailfish.TestAdapter.Queue.Extensions;
 using Sailfish.TestAdapter.Queue.Implementation;
@@ -93,7 +94,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task EnqueueBatchAsync_WithValidMessages_ShouldEnqueueAll()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         
         var messages = new[]
@@ -126,7 +127,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task EnqueueBatchAsync_WithNullMessages_ShouldThrowArgumentNullException()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act & Assert
@@ -138,7 +139,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task EnqueueBatchAsync_WithCancellation_ShouldThrowOperationCanceledException()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         var messages = new[] { CreateTestMessage() };
         using var cts = new CancellationTokenSource();
@@ -157,7 +158,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task IsHealthy_WhenRunningAndNotCompleted_ShouldReturnTrue()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act
@@ -171,7 +172,7 @@ public class QueueExtensionsTests : IDisposable
     public void IsHealthy_WhenNotRunning_ShouldReturnFalse()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         // Don't start the queue
 
         // Act
@@ -185,7 +186,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task IsHealthy_WhenCompleted_ShouldReturnFalse()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         await queue.CompleteAsync(CancellationToken.None);
 
@@ -214,7 +215,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task GetQueueStatus_WithRunningQueue_ShouldReturnCorrectStatus()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         var message = CreateTestMessage();
         await queue.EnqueueAsync(message, CancellationToken.None);
@@ -248,7 +249,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task WaitForEmptyAsync_WithEmptyQueue_ShouldReturnTrueImmediately()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act
@@ -262,7 +263,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task WaitForEmptyAsync_WithTimeout_ShouldReturnFalse()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         await queue.EnqueueAsync(CreateTestMessage(), CancellationToken.None);
 
@@ -534,7 +535,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task LogQueueStatus_WithHealthyQueue_ShouldLogInfo()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act
@@ -558,7 +559,7 @@ public class QueueExtensionsTests : IDisposable
     public async Task ToHealthCheckResult_WithHealthyQueue_ShouldReturnHealthyResult()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act
@@ -581,7 +582,7 @@ public class QueueExtensionsTests : IDisposable
     public void ToHealthCheckResult_WithUnhealthyQueue_ShouldReturnUnhealthyResult()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         // Don't start the queue
 
         // Act

--- a/source/Tests.TestAdapter/Queue/QueueHealthCheckAsyncDisposalTests.cs
+++ b/source/Tests.TestAdapter/Queue/QueueHealthCheckAsyncDisposalTests.cs
@@ -138,7 +138,7 @@ public class QueueHealthCheckAsyncDisposalTests
 
     private TestCompletionQueueManager CreateMockQueueManager()
     {
-        var queue = new InMemoryTestCompletionQueue(1000);
+        var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         var processors = Array.Empty<ITestCompletionQueueProcessor>();
         return new TestCompletionQueueManager(queue, processors, _logger);
     }

--- a/source/Tests.TestAdapter/Queue/QueueHealthCheckComprehensiveTests.cs
+++ b/source/Tests.TestAdapter/Queue/QueueHealthCheckComprehensiveTests.cs
@@ -25,7 +25,7 @@ public class QueueHealthCheckComprehensiveTests : IDisposable
 
     public QueueHealthCheckComprehensiveTests()
     {
-        var queue = new InMemoryTestCompletionQueue(1000);
+        var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         var processors = Array.Empty<ITestCompletionQueueProcessor>();
         _logger = Substitute.For<ILogger>();
         _queueManager = new TestCompletionQueueManager(queue, processors, _logger);

--- a/source/Tests.TestAdapter/Queue/QueueHealthCheckProcessingTimeTests.cs
+++ b/source/Tests.TestAdapter/Queue/QueueHealthCheckProcessingTimeTests.cs
@@ -128,7 +128,7 @@ public class QueueHealthCheckProcessingTimeTests
 
     private TestCompletionQueueManager CreateMockQueueManager()
     {
-        var queue = new InMemoryTestCompletionQueue(1000);
+        var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         var processors = Array.Empty<ITestCompletionQueueProcessor>();
         return new TestCompletionQueueManager(queue, processors, _logger);
     }

--- a/source/Tests.TestAdapter/Queue/QueueInfrastructureTests.cs
+++ b/source/Tests.TestAdapter/Queue/QueueInfrastructureTests.cs
@@ -210,7 +210,7 @@ public class QueueInfrastructureTests
     public async Task InMemoryTestCompletionQueue_Start_ShouldSetRunningState()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
 
         // Act
         await queue.StartAsync(CancellationToken.None);
@@ -227,7 +227,7 @@ public class QueueInfrastructureTests
     public async Task InMemoryTestCompletionQueue_StartTwice_ShouldThrowInvalidOperationException()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act & Assert
@@ -242,7 +242,7 @@ public class QueueInfrastructureTests
     public async Task InMemoryTestCompletionQueue_EnqueueDequeue_ShouldWorkCorrectly()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         var message = CreateTestMessage();
 
@@ -263,7 +263,7 @@ public class QueueInfrastructureTests
     public async Task InMemoryTestCompletionQueue_EnqueueAfterStop_ShouldThrowInvalidOperationException()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         await queue.StopAsync(CancellationToken.None);
         var message = CreateTestMessage();
@@ -271,33 +271,6 @@ public class QueueInfrastructureTests
         // Act & Assert
         await Should.ThrowAsync<InvalidOperationException>(
             () => queue.EnqueueAsync(message, CancellationToken.None));
-    }
-
-    /// <summary>
-    /// Tests that InMemoryTestCompletionQueue throws when constructed with invalid capacity.
-    /// </summary>
-    [Fact]
-    public void InMemoryTestCompletionQueue_InvalidCapacity_ShouldThrowArgumentOutOfRangeException()
-    {
-        // Act & Assert
-        Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryTestCompletionQueue(0));
-        Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryTestCompletionQueue(-1));
-    }
-
-    /// <summary>
-    /// Tests that InMemoryTestCompletionQueue accepts valid capacity values.
-    /// </summary>
-    [Fact]
-    public void InMemoryTestCompletionQueue_ValidCapacity_ShouldCreateSuccessfully()
-    {
-        // Act & Assert
-        using var queue1 = new InMemoryTestCompletionQueue(1);
-        using var queue2 = new InMemoryTestCompletionQueue(1000);
-        using var queue3 = new InMemoryTestCompletionQueue(int.MaxValue);
-
-        queue1.ShouldNotBeNull();
-        queue2.ShouldNotBeNull();
-        queue3.ShouldNotBeNull();
     }
 
     /// <summary>
@@ -349,20 +322,6 @@ public class QueueInfrastructureTests
         // Act & Assert
         Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryTestCompletionQueue(config1));
         Should.Throw<ArgumentOutOfRangeException>(() => new InMemoryTestCompletionQueue(config2));
-    }
-
-    /// <summary>
-    /// Tests that legacy constructor sets Configuration property to null.
-    /// </summary>
-    [Fact]
-    public void InMemoryTestCompletionQueue_LegacyConstructor_ShouldHaveNullConfiguration()
-    {
-        // Act
-        using var queue = new InMemoryTestCompletionQueue(1000);
-
-        // Assert
-        queue.Configuration.ShouldBeNull();
-        queue.MaxCapacity.ShouldBe(1000);
     }
 
     #endregion
@@ -649,7 +608,7 @@ public class QueueInfrastructureTests
     public async Task QueueOperations_WithCancellationToken_ShouldRespectCancellation()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         using var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -693,7 +652,7 @@ public class QueueInfrastructureTests
     public void QueueComponents_Disposal_ShouldCleanupResources()
     {
         // Arrange & Act
-        var queue = new InMemoryTestCompletionQueue(1000);
+        var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         queue.Dispose();
 
         // Assert
@@ -710,7 +669,7 @@ public class QueueInfrastructureTests
     public async Task InMemoryTestCompletionQueue_QueueDepth_ShouldTrackAccurately()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Assert initial depth
@@ -752,7 +711,7 @@ public class QueueInfrastructureTests
     public async Task InMemoryTestCompletionQueue_QueueDepth_WithTryDequeue_ShouldTrackAccurately()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Assert initial depth
@@ -791,7 +750,7 @@ public class QueueInfrastructureTests
     public async Task GetDiagnosticInfo_ShouldReturnNullUptime()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
 
         // Act
@@ -816,7 +775,7 @@ public class QueueInfrastructureTests
     public async Task GetDiagnosticInfo_ShouldIncludeCorrectAdditionalInfo()
     {
         // Arrange
-        using var queue = new InMemoryTestCompletionQueue(1000);
+        using var queue = new InMemoryTestCompletionQueue(new QueueConfiguration());
         await queue.StartAsync(CancellationToken.None);
         var message = CreateTestMessage();
         await queue.EnqueueAsync(message, CancellationToken.None);

--- a/source/Tests.TestAdapter/Queue/TestCompletionQueueConsumerTests.cs
+++ b/source/Tests.TestAdapter/Queue/TestCompletionQueueConsumerTests.cs
@@ -154,6 +154,44 @@ public class TestCompletionQueueConsumerTests : IDisposable
         Should.Throw<ObjectDisposedException>(() => _consumer.UnregisterProcessor(processor));
     }
 
+    [Fact]
+    public void GetProcessors_ShouldReturnInRegistrationOrder()
+    {
+        // Arrange
+        _consumer = new TestCompletionQueueConsumer(_queue, _logger);
+        var first = Substitute.For<ITestCompletionQueueProcessor>();
+        var second = Substitute.For<ITestCompletionQueueProcessor>();
+        var third = Substitute.For<ITestCompletionQueueProcessor>();
+
+        // Act
+        _consumer.RegisterProcessor(first);
+        _consumer.RegisterProcessor(second);
+        _consumer.RegisterProcessor(third);
+        var snapshot = _consumer.GetProcessors();
+
+        // Assert
+        snapshot.ShouldBe(new[] { first, second, third });
+    }
+
+    [Fact]
+    public void UnregisterProcessor_ShouldPreserveOrderOfRemainingProcessors()
+    {
+        // Arrange
+        _consumer = new TestCompletionQueueConsumer(_queue, _logger);
+        var first = Substitute.For<ITestCompletionQueueProcessor>();
+        var second = Substitute.For<ITestCompletionQueueProcessor>();
+        var third = Substitute.For<ITestCompletionQueueProcessor>();
+        _consumer.RegisterProcessor(first);
+        _consumer.RegisterProcessor(second);
+        _consumer.RegisterProcessor(third);
+
+        // Act
+        _consumer.UnregisterProcessor(second);
+
+        // Assert
+        _consumer.GetProcessors().ShouldBe(new[] { first, third });
+    }
+
     #endregion
 
     #region StartAsync Tests

--- a/source/Tests.TestAdapter/Queue/TestCompletionQueueManagerTests.cs
+++ b/source/Tests.TestAdapter/Queue/TestCompletionQueueManagerTests.cs
@@ -316,10 +316,37 @@ public class TestCompletionQueueManagerTests : IDisposable
 
         // Assert
         _logger.Received(1).Log(LogLevel.Information,
-            Arg.Is<string>(s => s.Contains("Test completion queue manager disposed successfully")));
+            Arg.Is<string>(s => s.Contains("disposed synchronously")));
     }
 
-    // TestCompletionQueueManager doesn't implement IAsyncDisposable
+    [Fact]
+    public async Task DisposeAsync_ShouldDisposeResourcesProperly()
+    {
+        // Arrange
+        _manager = new TestCompletionQueueManager(_queue, _processors, _logger);
+
+        // Act
+        await _manager.DisposeAsync();
+
+        // Assert
+        _logger.Received(1).Log(LogLevel.Information,
+            Arg.Is<string>(s => s.Contains("disposed successfully")));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WhenRunning_ShouldStopFirst()
+    {
+        // Arrange
+        _manager = new TestCompletionQueueManager(_queue, _processors, _logger);
+        var configuration = new QueueConfiguration { IsEnabled = true };
+        await _manager.StartAsync(configuration, CancellationToken.None);
+
+        // Act
+        await _manager.DisposeAsync();
+
+        // Assert
+        _manager.IsRunning.ShouldBeFalse();
+    }
 
     [Fact]
     public async Task Dispose_WhenRunning_ShouldStopFirst()


### PR DESCRIPTION
## Summary

Cleans up five concrete tech-debt items in the test adapter queue subsystem identified during review:

1. **Dropped the dead `InMemoryTestCompletionQueue(int)` "backward-compat" constructor.** The queue subsystem is new — there was no shipped legacy caller. `_configuration` is now non-nullable, the legacy nullable code paths in tests are gone.
2. **Fixed processor registration ordering + atomicity.** `TestCompletionQueueConsumer` used `ConcurrentBag` which (a) doesn't preserve insertion order despite the docstring claiming sequential-in-registration-order execution and (b) had a non-atomic drain-then-refill `UnregisterProcessor` that briefly dropped processors. Replaced with `ImmutableList` updated via `Interlocked.CompareExchange`.
3. **Added re-entrancy guard to `BatchTimeoutHandler` timer callback.** The `async void` timer callback could overlap with itself under load (slow sweep + same-interval `Timer` period), double-publishing framework notifications. An `Interlocked.CompareExchange`-based gate makes overlapping ticks skip instead of pile up.
4. **Consolidated metadata extraction.** The `TestCase` / `FormattedMessage` / `StartTime` / `EndTime` / `Exception` / `ComparisonGroup` keys were duplicated across `FrameworkPublishingProcessor` (constants), `BatchTimeoutHandler` (raw strings), and `TestCompletionMessageMapper` (raw strings) — guaranteed to drift. All three now go through a new `MessageMetadata` class with shared keys and tolerant extraction helpers. As a side benefit, `BatchTimeoutHandler` now publishes notifications with synthetic fallbacks (matching the framework processor's behaviour) instead of dropping them when a metadata field is missing.
5. **`TestCompletionQueueManager` now implements `IAsyncDisposable`.** The old sync `Dispose()` blocked on `StopAsync().GetAwaiter().GetResult()` and `CleanupResourcesAsync().GetAwaiter().GetResult()` — a deadlock risk during container teardown on threads with a `SynchronizationContext`. `DisposeAsync()` awaits properly; sync `Dispose()` now just signals cancellation and disposes the consumer/queue without blocking on background work.

Net diff: **+424 / −540** — most of the reduction comes from removing the duplicated extraction methods.

## Test plan
- [x] `dotnet test Tests.TestAdapter` on `net9.0` — 555/555 pass
- [x] `dotnet test Tests.TestAdapter` on `net10.0` — 555/555 pass
- [x] Queue-only filter on both frameworks — 432 pass (was 431, +4 new tests, −3 dead legacy-ctor tests)
- [x] Whole solution still builds clean (`Sailfish.sln` Debug)
- [ ] One end-to-end run inside Rider/VS Test Explorer to verify intercepting publish still flows for both normal and `[SailfishComparison]` runs (reviewer to spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)