### PR TITLE
Method comparison: fold SailfishComparison into SailfishMethod with baselines

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/MethodComparisonExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/MethodComparisonExample.cs
@@ -1,4 +1,4 @@
-﻿using Sailfish.Attributes;
+using Sailfish.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,18 +7,20 @@ using System.Threading;
 namespace PerformanceTests.ExamplePerformanceTests;
 
 /// <summary>
-/// Example test class demonstrating the new method comparison feature.
-/// This class shows how to use SailfishComparisonAttribute to mark methods
-/// for "before and after" performance comparisons.
+/// Example test class demonstrating the method comparison feature.
+/// Comparison configuration lives on <see cref="SailfishMethodAttribute"/> itself:
+/// set <c>ComparisonGroup</c> to opt a method into a named comparison, and optionally
+/// set <c>IsBaseline = true</c> on one method per group to switch from the default N×N
+/// matrix to N−1 baseline-vs-contender comparisons.
 /// </summary>
 /// <remarks>
-/// When running individual methods, only that method's results are displayed.
-/// When running the entire class, SailDiff comparisons are performed between
-/// methods in the same comparison group and displayed in the test output.
-/// 
-/// Usage:
-/// - Run individual methods: Only method results shown
-/// - Run entire class: Method results + SailDiff comparison results shown
+/// - Run individual methods: only that method's results are displayed.
+/// - Run the whole class: comparisons are emitted to the consolidated markdown and CSV.
+///
+/// This example exercises both modes:
+/// - <c>SumCalculation</c> has no baseline → full N×N matrix is rendered.
+/// - <c>SortingAlgorithm</c> nominates <c>SortWithQuickSort</c> as the baseline → the
+///   table reports each contender's ratio vs. quicksort (N−1 rows).
 /// </remarks>
 [WriteToMarkdown]
 [WriteToCsv]
@@ -26,7 +28,7 @@ namespace PerformanceTests.ExamplePerformanceTests;
 public class MethodComparisonExample
 {
     private readonly List<int> _data = new();
- 
+
     [SailfishGlobalSetup]
     public void Setup()
     {
@@ -39,10 +41,9 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// LINQ-based sum calculation algorithm.
+    /// LINQ-based sum calculation algorithm. Part of the SumCalculation group (no baseline → N×N).
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SumCalculation")]
+    [SailfishMethod(ComparisonGroup = "SumCalculation")]
     public void CalculateSumWithLinq()
     {
         var sum = _data.Sum();
@@ -51,10 +52,9 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Loop-based sum calculation algorithm.
+    /// Loop-based sum calculation algorithm. Part of the SumCalculation group (no baseline → N×N).
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SumCalculation")]
+    [SailfishMethod(ComparisonGroup = "SumCalculation")]
     public void CalculateSumWithLoop()
     {
         var sum = 0;
@@ -67,10 +67,9 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Bubble sort algorithm implementation.
+    /// Bubble sort algorithm — contender in the SortingAlgorithm group.
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
     public void SortWithBubbleSort()
     {
         var array = _data.ToArray();
@@ -88,20 +87,20 @@ public class MethodComparisonExample
         }
     }
 
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
+    /// <summary>
+    /// Another contender — kept slow on purpose to show non-baseline contender behavior.
+    /// </summary>
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
     public void SortWithOtherSort()
     {
-        // Simple bubble sort implementation
         Thread.Sleep(10);
     }
-    
-    
+
     /// <summary>
-    /// Optimized sorting algorithm using Array.Sort.
+    /// Optimized sorting algorithm — declared as the baseline of SortingAlgorithm.
+    /// All other methods in this group are reported as ratios vs. this one.
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm", IsBaseline = true)]
     public void SortWithQuickSort()
     {
         var array = _data.ToArray();
@@ -109,7 +108,7 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Regular method without comparison - will not participate in comparisons.
+    /// Regular method without comparison — will not participate in any comparison group.
     /// </summary>
     [SailfishMethod]
     public void RegularMethod()
@@ -119,7 +118,7 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Another regular method - demonstrates that non-comparison methods work normally.
+    /// Another regular method — demonstrates that non-comparison methods coexist with comparison ones.
     /// </summary>
     [SailfishMethod]
     public void AnotherRegularMethod()

--- a/source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md
@@ -16,5 +16,8 @@ SF1015 | Sailfish.Usage | Error | Properties assigned in the global setup must h
 SF1020 | Sailfish.Usage | Error | Sailfish lifecycle methods must be public
 SF1021 | Sailfish.Usage | Error | Only one Sailfish lifecycle attribute is allowed per method
 SF7000 | Sailfish.Suppression | Hidden | Suppresses warnings when a non nullable property is set in the global setup method
+SF1300 | Sailfish.Usage | Error | IsBaseline=true requires a ComparisonGroup on the SailfishMethod attribute
+SF1301 | Sailfish.Usage | Error | At most one method per ComparisonGroup may set IsBaseline=true
+SF1302 | Sailfish.Usage | Warning | A ComparisonGroup must contain at least two methods to produce a comparison
 
 

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/BaselineRequiresComparisonGroupAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/BaselineRequiresComparisonGroupAnalyzer.cs
@@ -1,0 +1,45 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+
+/// <summary>
+/// SF1300 — When a method sets <c>IsBaseline = true</c>, it must also set
+/// <c>ComparisonGroup</c>. A baseline outside a group is meaningless.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class BaselineRequiresComparisonGroupAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        "SF1300",
+        "IsBaseline=true requires a ComparisonGroup",
+        "Method '{0}' sets IsBaseline = true but does not specify a ComparisonGroup. Add 'ComparisonGroup = \"...\"' to the SailfishMethod attribute, or remove IsBaseline.",
+        AnalyzerGroups.EssentialAnalyzers.Category,
+        isEnabledByDefault: AnalyzerGroups.EssentialAnalyzers.IsEnabledByDefault,
+        defaultSeverity: DiagnosticSeverity.Error,
+        description: "IsBaseline only makes sense within a named ComparisonGroup; declaring a baseline without one is invalid.",
+        helpLinkUri: AnalyzerGroups.EssentialAnalyzers.HelpLink);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    protected override void AnalyzeNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        foreach (var method in classDeclaration.Members.OfType<MethodDeclarationSyntax>())
+        {
+            var info = MethodComparisonAttributeReader.TryRead(method);
+            if (info is null) continue;
+            if (!info.IsBaseline) continue;
+            if (!string.IsNullOrEmpty(info.ComparisonGroup)) continue;
+
+            // Report at the IsBaseline argument if we can locate it; otherwise at the attribute.
+            var location = info.IsBaselineArgument?.GetLocation() ?? info.Attribute.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, method.Identifier.Text));
+        }
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/ComparisonGroupNeedsTwoMethodsAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/ComparisonGroupNeedsTwoMethodsAnalyzer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+
+/// <summary>
+/// SF1302 — A ComparisonGroup with only one method has nothing to compare against and
+/// produces no comparison output. The user probably meant to add a second member, or
+/// remove the ComparisonGroup if the method shouldn't participate.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ComparisonGroupNeedsTwoMethodsAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        "SF1302",
+        "ComparisonGroup needs at least two methods",
+        "ComparisonGroup '{0}' has only one method ('{1}'); add another method to the group or remove the ComparisonGroup",
+        AnalyzerGroups.EssentialAnalyzers.Category,
+        isEnabledByDefault: AnalyzerGroups.EssentialAnalyzers.IsEnabledByDefault,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        description: "A comparison group with fewer than two methods produces no output; either add a peer or drop the group.",
+        helpLinkUri: AnalyzerGroups.EssentialAnalyzers.HelpLink);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    protected override void AnalyzeNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        var infos = classDeclaration.Members
+            .OfType<MethodDeclarationSyntax>()
+            .Select(MethodComparisonAttributeReader.TryRead)
+            .Where(info => info is not null && !string.IsNullOrEmpty(info.ComparisonGroup))
+            .Cast<MethodComparisonInfo>();
+
+        foreach (var group in infos.GroupBy(i => i.ComparisonGroup!))
+        {
+            var members = group.ToList();
+            if (members.Count >= 2) continue;
+
+            var only = members[0];
+            var location = only.ComparisonGroupArgument?.GetLocation() ?? only.Attribute.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, group.Key, only.Method.Identifier.Text));
+        }
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/MethodComparisonInfo.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/MethodComparisonInfo.cs
@@ -1,0 +1,85 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+
+/// <summary>
+/// Parsed view of the comparison-related arguments on a method's <c>[SailfishMethod]</c> attribute.
+/// Returned by <see cref="MethodComparisonAttributeReader.TryRead"/>.
+/// </summary>
+internal sealed class MethodComparisonInfo
+{
+    public MethodComparisonInfo(
+        MethodDeclarationSyntax method,
+        AttributeSyntax attribute,
+        string? comparisonGroup,
+        bool isBaseline,
+        AttributeArgumentSyntax? comparisonGroupArgument,
+        AttributeArgumentSyntax? isBaselineArgument)
+    {
+        Method = method;
+        Attribute = attribute;
+        ComparisonGroup = comparisonGroup;
+        IsBaseline = isBaseline;
+        ComparisonGroupArgument = comparisonGroupArgument;
+        IsBaselineArgument = isBaselineArgument;
+    }
+
+    public MethodDeclarationSyntax Method { get; }
+    public AttributeSyntax Attribute { get; }
+    public string? ComparisonGroup { get; }
+    public bool IsBaseline { get; }
+    public AttributeArgumentSyntax? ComparisonGroupArgument { get; }
+    public AttributeArgumentSyntax? IsBaselineArgument { get; }
+}
+
+internal static class MethodComparisonAttributeReader
+{
+    public static MethodComparisonInfo? TryRead(MethodDeclarationSyntax method)
+    {
+        var sailfishMethodAttr = method.AttributeLists
+            .SelectMany(list => list.Attributes)
+            .FirstOrDefault(attr =>
+                attr.Name.ToString() == "SailfishMethod" ||
+                attr.Name.ToString() == "SailfishMethodAttribute");
+
+        if (sailfishMethodAttr is null) return null;
+
+        string? comparisonGroup = null;
+        var isBaseline = false;
+        AttributeArgumentSyntax? comparisonGroupArg = null;
+        AttributeArgumentSyntax? isBaselineArg = null;
+
+        if (sailfishMethodAttr.ArgumentList?.Arguments != null)
+        {
+            foreach (var arg in sailfishMethodAttr.ArgumentList.Arguments)
+            {
+                var argName = arg.NameEquals?.Name.Identifier.ValueText;
+                if (argName == "ComparisonGroup")
+                {
+                    comparisonGroupArg = arg;
+                    if (arg.Expression is LiteralExpressionSyntax stringLit &&
+                        // RS1034 wants IsKind on SyntaxToken, but that extension isn't available in this Roslyn target.
+#pragma warning disable RS1034
+                        stringLit.Token.Kind() == SyntaxKind.StringLiteralToken)
+#pragma warning restore RS1034
+                    {
+                        comparisonGroup = stringLit.Token.ValueText;
+                    }
+                }
+                else if (argName == "IsBaseline")
+                {
+                    isBaselineArg = arg;
+                    if (arg.Expression is LiteralExpressionSyntax boolLit)
+                    {
+                        var kind = boolLit.Token.Kind();
+                        if (kind == SyntaxKind.TrueKeyword) isBaseline = true;
+                        else if (kind == SyntaxKind.FalseKeyword) isBaseline = false;
+                    }
+                }
+            }
+        }
+
+        return new MethodComparisonInfo(method, sailfishMethodAttr, comparisonGroup, isBaseline, comparisonGroupArg, isBaselineArg);
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/SingleBaselinePerGroupAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/SingleBaselinePerGroupAnalyzer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+
+/// <summary>
+/// SF1301 — At most one method per <c>(class, ComparisonGroup)</c> may set
+/// <c>IsBaseline = true</c>. When multiple are present the runtime falls back to N×N
+/// comparison and emits a warning; the user almost certainly meant to pick one.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class SingleBaselinePerGroupAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        "SF1301",
+        "Only one IsBaseline per ComparisonGroup is allowed",
+        "ComparisonGroup '{0}' has {1} methods marked IsBaseline = true; exactly one is allowed. The runtime will fall back to N×N comparison.",
+        AnalyzerGroups.EssentialAnalyzers.Category,
+        isEnabledByDefault: AnalyzerGroups.EssentialAnalyzers.IsEnabledByDefault,
+        defaultSeverity: DiagnosticSeverity.Error,
+        description: "A comparison group can have zero baselines (N×N matrix) or exactly one baseline (N−1 comparisons). Two or more baselines is ambiguous.",
+        helpLinkUri: AnalyzerGroups.EssentialAnalyzers.HelpLink);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    protected override void AnalyzeNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        var infos = classDeclaration.Members
+            .OfType<MethodDeclarationSyntax>()
+            .Select(MethodComparisonAttributeReader.TryRead)
+            .Where(info => info is not null && !string.IsNullOrEmpty(info.ComparisonGroup))
+            .Cast<MethodComparisonInfo>();
+
+        foreach (var group in infos.GroupBy(i => i.ComparisonGroup!))
+        {
+            var baselines = group.Where(i => i.IsBaseline).ToList();
+            if (baselines.Count < 2) continue;
+
+            foreach (var b in baselines)
+            {
+                var location = b.IsBaselineArgument?.GetLocation() ?? b.Attribute.GetLocation();
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, group.Key, baselines.Count));
+            }
+        }
+    }
+}

--- a/source/Sailfish.TestAdapter/Discovery/DiscoveryAnalysisMethods.cs
+++ b/source/Sailfish.TestAdapter/Discovery/DiscoveryAnalysisMethods.cs
@@ -146,39 +146,61 @@ public static class DiscoveryAnalysisMethods
 
     /// <summary>
     /// Extracts comparison group information from a method declaration's attributes.
+    /// Prefers the new <c>[SailfishMethod(ComparisonGroup = "...")]</c> shape and falls back
+    /// to the obsolete <c>[SailfishComparison("...")]</c> attribute during the deprecation window.
     /// </summary>
     /// <param name="methodDeclaration">The method declaration to analyze.</param>
     /// <returns>The comparison group name, or null if no comparison attribute is found.</returns>
     private static string? ExtractComparisonInfo(MethodDeclarationSyntax methodDeclaration)
     {
-        // Look for SailfishComparison attribute
-        var comparisonAttribute = methodDeclaration.AttributeLists
-            .SelectMany(attrList => attrList.Attributes)
-            .FirstOrDefault(attr =>
-                attr.Name.ToString() == "SailfishComparison" ||
-                attr.Name.ToString() == "SailfishComparisonAttribute");
-
-        if (comparisonAttribute?.ArgumentList?.Arguments == null || comparisonAttribute.ArgumentList.Arguments.Count < 1)
-        {
-            return null;
-        }
-
         try
         {
-            // Extract comparison group (first and only argument)
+            // Preferred: SailfishMethod attribute with a named ComparisonGroup argument.
+            var sailfishMethodAttr = methodDeclaration.AttributeLists
+                .SelectMany(attrList => attrList.Attributes)
+                .FirstOrDefault(attr =>
+                    attr.Name.ToString() == "SailfishMethod" ||
+                    attr.Name.ToString() == "SailfishMethodAttribute");
+
+            if (sailfishMethodAttr?.ArgumentList?.Arguments != null)
+            {
+                foreach (var arg in sailfishMethodAttr.ArgumentList.Arguments)
+                {
+                    if (arg.NameEquals?.Name.Identifier.ValueText == "ComparisonGroup")
+                    {
+                        var value = ExtractStringLiteralValue(arg.Expression);
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            return value;
+                        }
+                    }
+                }
+            }
+
+            // Legacy fallback: standalone SailfishComparison attribute.
+            var comparisonAttribute = methodDeclaration.AttributeLists
+                .SelectMany(attrList => attrList.Attributes)
+                .FirstOrDefault(attr =>
+                    attr.Name.ToString() == "SailfishComparison" ||
+                    attr.Name.ToString() == "SailfishComparisonAttribute");
+
+            if (comparisonAttribute?.ArgumentList?.Arguments == null || comparisonAttribute.ArgumentList.Arguments.Count < 1)
+            {
+                return null;
+            }
+
+            // Extract comparison group (first positional argument).
             var groupArgument = comparisonAttribute.ArgumentList.Arguments[0];
             return ExtractStringLiteralValue(groupArgument.Expression);
         }
         catch (ArgumentException ex)
         {
-            // If we can't parse the attribute arguments due to invalid argument format, return null
-            Debug.WriteLine($"[Sailfish.TestAdapter] Failed to parse SailfishComparison attribute arguments: {ex.Message}");
+            Debug.WriteLine($"[Sailfish.TestAdapter] Failed to parse comparison attribute arguments: {ex.Message}");
             return null;
         }
         catch (InvalidOperationException ex)
         {
-            // If we can't access the expression due to invalid syntax tree state, return null
-            Debug.WriteLine($"[Sailfish.TestAdapter] Failed to access SailfishComparison attribute expression: {ex.Message}");
+            Debug.WriteLine($"[Sailfish.TestAdapter] Failed to access comparison attribute expression: {ex.Message}");
             return null;
         }
     }

--- a/source/Sailfish/Attributes/SailfishComparisonAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishComparisonAttribute.cs
@@ -1,33 +1,33 @@
-﻿using System;
+using System;
 
 namespace Sailfish.Attributes;
 
 /// <summary>
 /// Specifies that a method should be included in performance comparisons.
-/// Methods with the same comparison group will be compared against each other
-/// when the full test class is executed.
 /// </summary>
 /// <remarks>
-/// This attribute enables performance comparisons between methods in the same test class.
-/// When individual methods are run, only their results are shown with comparison info.
-/// When the full class is run, statistical comparisons are performed between methods
-/// in the same comparison group and displayed in the test output.
+/// This attribute is obsolete. Comparison configuration has been folded into
+/// <see cref="SailfishMethodAttribute"/>:
 ///
-/// Example usage:
 /// <code>
-/// [SailfishComparison("SortingAlgorithms")]
-/// public void BubbleSort() { /* implementation */ }
+/// // Before:
+/// [SailfishMethod]
+/// [SailfishComparison("Sort")]
+/// public void QuickSort() { /* ... */ }
 ///
-/// [SailfishComparison("SortingAlgorithms")]
-/// public void QuickSort() { /* implementation */ }
-///
-/// [SailfishComparison("SortingAlgorithms")]
-/// public void MergeSort() { /* implementation */ }
+/// // After:
+/// [SailfishMethod(ComparisonGroup = "Sort", IsBaseline = true)]
+/// public void QuickSort() { /* ... */ }
 /// </code>
 ///
-/// This creates an N×N comparison matrix between all methods in the group.
+/// During the deprecation window, this attribute is still honoured by the runtime as a fallback,
+/// but the analyzer will warn at build time and the type will be removed in the next major release.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
+[Obsolete(
+    "Use SailfishMethod(ComparisonGroup = \"...\", IsBaseline = true|false) instead. " +
+    "SailfishComparisonAttribute will be removed in the next major release.",
+    error: false)]
 public sealed class SailfishComparisonAttribute : Attribute
 {
     /// <summary>
@@ -60,5 +60,3 @@ public sealed class SailfishComparisonAttribute : Attribute
     /// </summary>
     public bool Disabled { get; set; }
 }
-
-

--- a/source/Sailfish/Attributes/SailfishMethodAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodAttribute.cs
@@ -57,4 +57,39 @@ public sealed class SailfishMethodAttribute : Attribute
     ///     - Sailfish is not particularly well suited for micro-measurements
     /// </summary>
     public bool DisableOverheadEstimation { get; set; }
+
+    /// <summary>
+    ///     Opts this method into a named comparison group. All methods in the same group
+    ///     within a single test class are compared against each other when the class runs.
+    ///     Leave <c>null</c> (default) to exclude the method from comparison entirely.
+    /// </summary>
+    /// <remarks>
+    ///     Comparison is always opt-in. A method without <see cref="ComparisonGroup"/> set
+    ///     simply runs as a normal Sailfish method with no comparison output.
+    ///
+    ///     Combine with <see cref="IsBaseline"/> to designate a baseline; without one, all
+    ///     methods in the group are compared pairwise (N×N matrix).
+    ///
+    ///     Example:
+    ///     <code>
+    ///     [SailfishMethod(ComparisonGroup = "Sort", IsBaseline = true)]
+    ///     public void QuickSort() { /* ... */ }
+    ///
+    ///     [SailfishMethod(ComparisonGroup = "Sort")]
+    ///     public void BubbleSort() { /* ... */ }
+    ///     </code>
+    /// </remarks>
+    public string? ComparisonGroup { get; set; }
+
+    /// <summary>
+    ///     When <c>true</c>, marks this method as the baseline of its <see cref="ComparisonGroup"/>.
+    ///     All other methods in the group are compared against the baseline (N−1 comparisons).
+    ///     When no method in a group sets <see cref="IsBaseline"/>, every pair is compared (N×N).
+    /// </summary>
+    /// <remarks>
+    ///     At most one method per <c>(class, ComparisonGroup)</c> may set <c>IsBaseline = true</c>;
+    ///     the SF1301 analyzer enforces this at build time and the runtime falls back to N×N if violated.
+    ///     <see cref="IsBaseline"/> requires <see cref="ComparisonGroup"/> to be set (enforced by SF1300).
+    /// </remarks>
+    public bool IsBaseline { get; set; }
 }

--- a/source/Sailfish/DefaultHandlers/Sailfish/ComparisonGroupKey.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/ComparisonGroupKey.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Sailfish.DefaultHandlers.Sailfish;
+
+/// <summary>
+/// Composite key used to group comparison-method results during result-aggregation.
+/// Comparison semantics (baseline vs. N×N) are scoped to a single test class, so the
+/// key must include the class type — grouping by <c>GroupName</c> alone would merge
+/// same-named groups across classes and miscount baselines.
+/// </summary>
+internal readonly struct ComparisonGroupKey : IEquatable<ComparisonGroupKey>
+{
+    public ComparisonGroupKey(Type testClass, string? groupName)
+    {
+        TestClass = testClass;
+        GroupName = groupName;
+    }
+
+    public Type TestClass { get; }
+    public string? GroupName { get; }
+
+    public bool Equals(ComparisonGroupKey other)
+        => TestClass == other.TestClass && string.Equals(GroupName, other.GroupName, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is ComparisonGroupKey other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var h = TestClass?.GetHashCode() ?? 0;
+            h = (h * 397) ^ (GroupName?.GetHashCode() ?? 0);
+            return h;
+        }
+    }
+}

--- a/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
@@ -204,70 +204,99 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
 
             foreach (var group in comparisonGroups)
             {
-                var methods = group.Select(g => g.TestResult).ToList();
+                var members = group.ToList();
+                var methods = members.Select(g => g.TestResult).ToList();
                 if (methods.Count < 2) continue;
 
-                // Build stats for each method in the group
-                var stats = methods.Select(m =>
-                {
-                    var pr = m.PerformanceRunResult;
-                    var mean = pr?.Mean ?? 0.0;
-                    var n = pr?.DataWithOutliersRemoved?.Length ?? pr?.SampleSize ?? 0;
-                    var stdDev = pr?.StdDev ?? 0.0;
-                    var se = n > 0 ? stdDev / Math.Sqrt(n) : 0.0;
-                    var name = GetMethodName(m.TestCaseId?.DisplayName ?? "Unknown");
-                    var id = m.TestCaseId?.DisplayName ?? name;
-                    return new { Name = name, Id = id, Mean = mean, SE = se, N = n };
-                })
-                .Where(s => s.Mean > 0)
-                .ToList();
+                // Build stats for each method in the group, tagging baseline membership.
+                var stats = members
+                    .Select(m =>
+                    {
+                        var tr = m.TestResult;
+                        var pr = tr.PerformanceRunResult;
+                        var mean = pr?.Mean ?? 0.0;
+                        var n = pr?.DataWithOutliersRemoved?.Length ?? pr?.SampleSize ?? 0;
+                        var stdDev = pr?.StdDev ?? 0.0;
+                        var se = n > 0 ? stdDev / Math.Sqrt(n) : 0.0;
+                        var name = GetMethodName(tr.TestCaseId?.DisplayName ?? "Unknown");
+                        var id = tr.TestCaseId?.DisplayName ?? name;
+                        var isBaseline = GetComparisonInfoForResult(tr, m.TestClass).IsBaseline;
+                        return new { Name = name, Id = id, Mean = mean, SE = se, N = n, IsBaseline = isBaseline };
+                    })
+                    .Where(s => s.Mean > 0)
+                    .ToList();
 
                 if (stats.Count < 2) continue;
 
-                // Compute pairwise p-values on log-ratio and apply BH-FDR
-                var pMap = new Dictionary<(string A, string B), double>();
-                for (var i = 0; i < stats.Count; i++)
+                var baselineStats = stats.Where(s => s.IsBaseline).ToList();
+                var baselineMode = baselineStats.Count == 1;
+                if (baselineStats.Count > 1)
                 {
-                    for (var j = i + 1; j < stats.Count; j++)
+                    _logger.Log(LogLevel.Warning,
+                        "Comparison group '{0}' has {1} methods marked IsBaseline=true; expected at most one. " +
+                        "Falling back to N×N comparison rows. The SF1301 analyzer should catch this at build time.",
+                        group.Key!, baselineStats.Count);
+                }
+
+                // Build the (i, j) pair list — baseline-vs-contender when one baseline, otherwise full N×N.
+                var pairs = new List<(int I, int J)>();
+                if (baselineMode)
+                {
+                    var baselineIdx = stats.IndexOf(baselineStats[0]);
+                    for (var k = 0; k < stats.Count; k++)
                     {
-                        var a = stats[i];
-                        var b = stats[j];
-                        var p = ComputeLogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
-                        if (!double.IsNaN(p) && p > 0)
+                        if (k == baselineIdx) continue;
+                        pairs.Add((baselineIdx, k));
+                    }
+                }
+                else
+                {
+                    for (var i = 0; i < stats.Count; i++)
+                    {
+                        for (var j = i + 1; j < stats.Count; j++)
                         {
-                            pMap[MultipleComparisons.NormalizePair(a.Id, b.Id)] = p;
+                            pairs.Add((i, j));
                         }
+                    }
+                }
+
+                // Compute p-values over the selected pairs and apply BH-FDR
+                var pMap = new Dictionary<(string A, string B), double>();
+                foreach (var (i, j) in pairs)
+                {
+                    var a = stats[i];
+                    var b = stats[j];
+                    var p = ComputeLogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
+                    if (!double.IsNaN(p) && p > 0)
+                    {
+                        pMap[MultipleComparisons.NormalizePair(a.Id, b.Id)] = p;
                     }
                 }
                 var qMap = pMap.Count > 0
                     ? MultipleComparisons.BenjaminiHochbergAdjust(pMap)
                     : new Dictionary<(string A, string B), double>();
 
-                // Emit one row per unique pair i<j
-                for (var i = 0; i < stats.Count; i++)
+                // Emit one row per selected pair
+                foreach (var (i, j) in pairs)
                 {
-                    for (var j = i + 1; j < stats.Count; j++)
-                    {
-                        var row = stats[i];
-                        var col = stats[j];
+                    var row = stats[i];
+                    var col = stats[j];
 
-                        var ci = MultipleComparisons.ComputeRatioCi(row.Mean, row.SE, row.N, col.Mean, col.SE, col.N, 0.95);
-                        var ratio = ci.Ratio;
-                        var lo = ci.Lower;
-                        var hi = ci.Upper;
+                    var ci = MultipleComparisons.ComputeRatioCi(row.Mean, row.SE, row.N, col.Mean, col.SE, col.N, 0.95);
+                    var ratio = ci.Ratio;
+                    var lo = ci.Lower;
+                    var hi = ci.Upper;
 
-                        double q;
-                        qMap.TryGetValue(MultipleComparisons.NormalizePair(row.Id, col.Id), out q);
-                        var sig = q > 0 && q <= 0.05;
-                        var label = sig ? (ratio < 1.0 ? "Improved" : "Slower") : "Similar";
+                    qMap.TryGetValue(MultipleComparisons.NormalizePair(row.Id, col.Id), out var q);
+                    var sig = q > 0 && q <= 0.05;
+                    var label = sig ? (ratio < 1.0 ? "Improved" : "Slower") : "Similar";
 
-                        var loStr = lo.HasValue ? lo.Value.ToString("0.###") : "";
-                        var hiStr = hi.HasValue ? hi.Value.ToString("0.###") : "";
-                        var qStr = q > 0 ? FormatP(q) : "";
+                    var loStr = lo.HasValue ? lo.Value.ToString("0.###") : "";
+                    var hiStr = hi.HasValue ? hi.Value.ToString("0.###") : "";
+                    var qStr = q > 0 ? FormatP(q) : "";
 
-                        var changeDesc = label == "Improved" ? "Improved" : label == "Slower" ? "Regressed" : "No Change";
-                        sb.AppendLine($"{group.Key},{row.Name},{col.Name},{row.Mean:0.###},{col.Mean:0.###},{ratio:0.###},{loStr},{hiStr},{qStr},{label},{changeDesc}");
-                    }
+                    var changeDesc = label == "Improved" ? "Improved" : label == "Slower" ? "Regressed" : "No Change";
+                    sb.AppendLine($"{group.Key},{row.Name},{col.Name},{row.Mean:0.###},{col.Mean:0.###},{ratio:0.###},{loStr},{hiStr},{qStr},{label},{changeDesc}");
                 }
             }
 
@@ -446,17 +475,13 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
 
             if (method != null)
             {
-                var comparisonAttribute = method.GetCustomAttribute<SailfishComparisonAttribute>();
-                if (comparisonAttribute != null && !comparisonAttribute.Disabled)
+                var (group, _) = ReadComparisonInfo(method);
+                if (!string.IsNullOrEmpty(group))
                 {
-                    _logger.Log(LogLevel.Debug, "Found comparison group '{0}' for method '{1}'",
-                        comparisonAttribute.ComparisonGroup, method.Name);
-                    return comparisonAttribute.ComparisonGroup;
+                    _logger.Log(LogLevel.Debug, "Found comparison group '{0}' for method '{1}'", group, method.Name);
+                    return group;
                 }
-                else
-                {
-                    _logger.Log(LogLevel.Debug, "No SailfishComparison attribute found for method '{0}'", method.Name);
-                }
+                _logger.Log(LogLevel.Debug, "No comparison attribute found for method '{0}'", method.Name);
             }
 
             return null;
@@ -467,6 +492,64 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
                 "Failed to get comparison group for test '{0}': {1}",
                 testResult.TestCaseId?.DisplayName ?? "Unknown", ex.Message);
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the comparison group + baseline flag for a method, preferring the new
+    /// <see cref="SailfishMethodAttribute"/> shape and falling back to the obsolete
+    /// <see cref="SailfishComparisonAttribute"/> during the deprecation window.
+    /// </summary>
+    private static (string? Group, bool IsBaseline) ReadComparisonInfo(MethodInfo method)
+    {
+        var methodAttr = method.GetCustomAttribute<SailfishMethodAttribute>();
+        if (methodAttr != null && !string.IsNullOrEmpty(methodAttr.ComparisonGroup))
+        {
+            return (methodAttr.ComparisonGroup, methodAttr.IsBaseline);
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        var legacyAttr = method.GetCustomAttribute<SailfishComparisonAttribute>();
+#pragma warning restore CS0618
+        if (legacyAttr != null && !legacyAttr.Disabled)
+        {
+            return (legacyAttr.ComparisonGroup, false);
+        }
+
+        return (null, false);
+    }
+
+    /// <summary>
+    /// Returns the comparison info (group + baseline flag) for a single test result,
+    /// performing the same method lookup as <see cref="GetComparisonGroup"/>.
+    /// </summary>
+    private (string? Group, bool IsBaseline) GetComparisonInfoForResult(
+        CompiledTestCaseResultTrackingFormat testResult, Type testClass)
+    {
+        try
+        {
+            var displayName = testResult.TestCaseId?.DisplayName ?? "Unknown";
+            var methodName = GetMethodName(displayName);
+
+            var method = testClass.GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            if (method == null)
+            {
+                var allMethods = testClass.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+                method = allMethods.FirstOrDefault(m =>
+                    string.Equals(m.Name, methodName, StringComparison.Ordinal) ||
+                    displayName.StartsWith(m.Name, StringComparison.Ordinal));
+            }
+
+            return method != null ? ReadComparisonInfo(method) : (null, false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Warning, ex,
+                "Failed to resolve comparison info for test '{0}': {1}",
+                testResult.TestCaseId?.DisplayName ?? "Unknown", ex.Message);
+            return (null, false);
         }
     }
 }

--- a/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
@@ -187,10 +187,12 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
 
         try
         {
+            // Group by (TestClass, ComparisonGroup) — see ComparisonGroupKey for why class-scoping matters
+            // (same-named groups in different classes must not be merged when counting baselines).
             var comparisonGroups = typed
                 .Where(tr => HasComparisonAttribute(tr.TestResult, tr.TestClass))
-                .GroupBy(tr => GetComparisonGroup(tr.TestResult, tr.TestClass))
-                .Where(g => !string.IsNullOrEmpty(g.Key))
+                .GroupBy(tr => new ComparisonGroupKey(tr.TestClass, GetComparisonGroup(tr.TestResult, tr.TestClass)))
+                .Where(g => !string.IsNullOrEmpty(g.Key.GroupName))
                 .ToList();
 
             if (!comparisonGroups.Any())
@@ -204,6 +206,8 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
 
             foreach (var group in comparisonGroups)
             {
+                var groupName = group.Key.GroupName!;
+                var className = group.Key.TestClass.Name;
                 var members = group.ToList();
                 var methods = members.Select(g => g.TestResult).ToList();
                 if (methods.Count < 2) continue;
@@ -233,9 +237,9 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
                 if (baselineStats.Count > 1)
                 {
                     _logger.Log(LogLevel.Warning,
-                        "Comparison group '{0}' has {1} methods marked IsBaseline=true; expected at most one. " +
+                        "Comparison group '{0}' in class '{1}' has {2} methods marked IsBaseline=true; expected at most one. " +
                         "Falling back to N×N comparison rows. The SF1301 analyzer should catch this at build time.",
-                        group.Key!, baselineStats.Count);
+                        groupName, className, baselineStats.Count);
                 }
 
                 // Build the (i, j) pair list — baseline-vs-contender when one baseline, otherwise full N×N.
@@ -296,7 +300,7 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
                     var qStr = q > 0 ? FormatP(q) : "";
 
                     var changeDesc = label == "Improved" ? "Improved" : label == "Slower" ? "Regressed" : "No Change";
-                    sb.AppendLine($"{group.Key},{row.Name},{col.Name},{row.Mean:0.###},{col.Mean:0.###},{ratio:0.###},{loStr},{hiStr},{qStr},{label},{changeDesc}");
+                    sb.AppendLine($"{groupName},{row.Name},{col.Name},{row.Mean:0.###},{col.Mean:0.###},{ratio:0.###},{loStr},{hiStr},{qStr},{label},{changeDesc}");
                 }
             }
 

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -310,18 +310,23 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             return sb.ToString();
         }
 
-        // Group test results by comparison groups across all classes
+        // Group test results by (TestClass, ComparisonGroup). Grouping by name alone would merge
+        // same-named groups from different test classes — each class's lone baseline would be counted
+        // together, and a valid per-class baseline configuration would collapse to N×N. The grouping
+        // domain matches the analyzer: per-class, per-group.
         var comparisonGroups = allTestResults
             .Where(tr => HasComparisonAttribute(tr.TestResult, tr.TestClass))
-            .GroupBy(tr => GetComparisonGroup(tr.TestResult, tr.TestClass))
-            .Where(g => !string.IsNullOrEmpty(g.Key))
+            .GroupBy(tr => new ComparisonGroupKey(tr.TestClass, GetComparisonGroup(tr.TestResult, tr.TestClass)))
+            .Where(g => !string.IsNullOrEmpty(g.Key.GroupName))
             .ToList();
 
         if (comparisonGroups.Any())
         {
             foreach (var group in comparisonGroups)
             {
-                sb.AppendLine($"## 🔬 Comparison Group: {group.Key}");
+                var groupName = group.Key.GroupName!;
+                var className = group.Key.TestClass.Name;
+                sb.AppendLine($"## 🔬 Comparison Group: {groupName} ({className})");
                 sb.AppendLine();
 
                 var members = group.ToList();
@@ -351,9 +356,9 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                     if (baselines.Count > 1)
                     {
                         _logger.Log(LogLevel.Warning,
-                            "Comparison group '{0}' has {1} methods marked IsBaseline=true; expected at most one. " +
+                            "Comparison group '{0}' in class '{1}' has {2} methods marked IsBaseline=true; expected at most one. " +
                             "Falling back to N×N comparison. The SF1301 analyzer should catch this at build time.",
-                            group.Key!, baselines.Count);
+                            groupName, className, baselines.Count);
                     }
                     sectionHeader = "### Performance Comparison Matrix";
                     comparisonContent = CreateNxNComparisonMatrix(methods);

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -324,7 +324,8 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                 sb.AppendLine($"## 🔬 Comparison Group: {group.Key}");
                 sb.AppendLine();
 
-                var methods = group.Select(g => g.TestResult).ToList();
+                var members = group.ToList();
+                var methods = members.Select(m => m.TestResult).ToList();
                 if (methods.Count < 2)
                 {
                     sb.AppendLine($"⚠️ Insufficient methods for comparison (found {methods.Count}, need at least 2)");
@@ -332,13 +333,37 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                     continue;
                 }
 
-                // Generate NxN comparison matrix
-                var comparisonMatrix = CreateNxNComparisonMatrix(methods);
-                if (!string.IsNullOrEmpty(comparisonMatrix))
+                // Determine baselines (zero, one, or — incorrectly — many).
+                var baselines = members
+                    .Where(m => GetComparisonInfoForResult(m.TestResult, m.TestClass).IsBaseline)
+                    .Select(m => m.TestResult)
+                    .ToList();
+
+                string comparisonContent;
+                string sectionHeader;
+                if (baselines.Count == 1)
                 {
-                    sb.AppendLine("### Performance Comparison Matrix");
+                    sectionHeader = "### Baseline Comparison";
+                    comparisonContent = CreateBaselineComparisonTable(baselines[0], methods);
+                }
+                else
+                {
+                    if (baselines.Count > 1)
+                    {
+                        _logger.Log(LogLevel.Warning,
+                            "Comparison group '{0}' has {1} methods marked IsBaseline=true; expected at most one. " +
+                            "Falling back to N×N comparison. The SF1301 analyzer should catch this at build time.",
+                            group.Key!, baselines.Count);
+                    }
+                    sectionHeader = "### Performance Comparison Matrix";
+                    comparisonContent = CreateNxNComparisonMatrix(methods);
+                }
+
+                if (!string.IsNullOrEmpty(comparisonContent))
+                {
+                    sb.AppendLine(sectionHeader);
                     sb.AppendLine();
-                    sb.AppendLine(comparisonMatrix);
+                    sb.AppendLine(comparisonContent);
                     sb.AppendLine();
                 }
 
@@ -514,6 +539,112 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
     }
 
     /// <summary>
+    /// Creates a baseline-vs-contender comparison table (N−1 comparisons). Each contender's
+    /// ratio is computed relative to the baseline method; q-values are BH-FDR adjusted across
+    /// the N−1 baseline-vs-contender pairs in this group.
+    /// </summary>
+    private string CreateBaselineComparisonTable(
+        CompiledTestCaseResultTrackingFormat baseline,
+        List<CompiledTestCaseResultTrackingFormat> allMethods)
+    {
+        if (allMethods.Count < 2) return string.Empty;
+        try
+        {
+            var stats = allMethods
+                .Where(m => m.PerformanceRunResult != null)
+                .Select(m => new
+                {
+                    Result = m,
+                    Id = m.TestCaseId?.DisplayName ?? m.PerformanceRunResult!.DisplayName,
+                    Name = GetMethodName(m.TestCaseId?.DisplayName ?? m.PerformanceRunResult!.DisplayName),
+                    Mean = m.PerformanceRunResult!.Mean,
+                    StdDev = m.PerformanceRunResult!.StdDev,
+                    N = Math.Max(1, (m.PerformanceRunResult!.DataWithOutliersRemoved?.Length ?? -1) > 0
+                        ? (m.PerformanceRunResult!.DataWithOutliersRemoved?.Length ?? m.PerformanceRunResult!.SampleSize)
+                        : m.PerformanceRunResult!.SampleSize)
+                })
+                .Select(x => new
+                {
+                    x.Result,
+                    x.Id,
+                    x.Name,
+                    x.Mean,
+                    x.N,
+                    SE = (x.N > 1 && x.StdDev > 0) ? x.StdDev / Math.Sqrt(x.N) : 0.0
+                })
+                .Where(s => s.Mean > 0)
+                .ToList();
+
+            var baselineStat = stats.FirstOrDefault(s => ReferenceEquals(s.Result, baseline));
+            if (baselineStat == null || stats.Count < 2) return string.Empty;
+
+            var contenders = stats.Where(s => !ReferenceEquals(s.Result, baseline)).ToList();
+            if (contenders.Count == 0) return string.Empty;
+
+            // BH-FDR over the N−1 baseline-vs-contender p-values
+            var pMap = new Dictionary<(string A, string B), double>();
+            foreach (var c in contenders)
+            {
+                var p = ComputeLogRatioPValue(baselineStat.Mean, baselineStat.SE, baselineStat.N, c.Mean, c.SE, c.N);
+                if (!double.IsNaN(p) && p > 0)
+                {
+                    pMap[MultipleComparisons.NormalizePair(baselineStat.Id, c.Id)] = p;
+                }
+            }
+            var qMap = pMap.Count > 0
+                ? MultipleComparisons.BenjaminiHochbergAdjust(pMap)
+                : new Dictionary<(string, string), double>();
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"### 📐 Baseline-vs-Contender (baseline = `{baselineStat.Name}`, q-values via BH-FDR, α=0.05)");
+            sb.AppendLine("| Method | Mean | Ratio vs Baseline | 95% CI | q-value | Label |");
+            sb.AppendLine("|--------|------|-------------------|--------|---------|-------|");
+            sb.AppendLine($"| `{baselineStat.Name}` _(baseline)_ | {baselineStat.Mean:0.###}ms | — | — | — | — |");
+
+            foreach (var c in contenders.OrderBy(s => s.Mean))
+            {
+                var (ratio, lo, hi) = MultipleComparisons.ComputeRatioCi(baselineStat.Mean, baselineStat.SE, baselineStat.N, c.Mean, c.SE, c.N, 0.95);
+                qMap.TryGetValue(MultipleComparisons.NormalizePair(baselineStat.Id, c.Id), out var q);
+                var sig = q > 0 && q <= 0.05;
+                var label = sig ? (ratio < 1.0 ? "Improved" : "Slower") : "Similar";
+                var ciStr = (lo.HasValue && hi.HasValue) ? $"[{lo.Value:0.###}–{hi.Value:0.###}]" : "—";
+                var qStr = q > 0 ? FormatP(q) : "—";
+                sb.AppendLine($"| `{c.Name}` | {c.Mean:0.###}ms | {ratio:0.###}x | {ciStr} | {qStr} | {label} |");
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("_Ratio is contender/baseline. 'Improved' means significantly faster than baseline; 'Slower' significantly slower; 'Similar' not significant after FDR._");
+            return sb.ToString();
+
+            static string FormatP(double p)
+            {
+                if (p < 1e-3) return p.ToString("0.0e-0");
+                return p.ToString("0.###");
+            }
+
+            static double ComputeLogRatioPValue(double meanA, double seA, int nA, double meanB, double seB, int nB)
+            {
+                if (!(meanA > 0) || !(meanB > 0)) return double.NaN;
+                var seLog = Math.Sqrt(Square(SafeDiv(seA, meanA)) + Square(SafeDiv(seB, meanB)));
+                if (seLog <= 0) return double.NaN;
+                var t = Math.Abs(Math.Log(meanB / meanA)) / seLog;
+                var dof = Math.Max(1, Math.Min(Math.Max(0, nA - 1), Math.Max(0, nB - 1)));
+                var cdf = StudentT.CDF(0, 1, dof, t);
+                var p = 2 * Math.Max(0.0, 1.0 - cdf);
+                return p;
+            }
+
+            static double SafeDiv(double a, double b) => Math.Abs(b) < double.Epsilon ? 0 : a / b;
+            static double Square(double x) => x * x;
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Warning, ex, "Failed to create baseline comparison table: {0}", ex.Message);
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
     /// Calculates the performance comparison between two methods.
     /// </summary>
     /// <param name="method1">The first method (row method).</param>
@@ -630,17 +761,13 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
 
             if (method != null)
             {
-                var comparisonAttribute = method.GetCustomAttribute<SailfishComparisonAttribute>();
-                if (comparisonAttribute != null && !comparisonAttribute.Disabled)
+                var (group, _) = ReadComparisonInfo(method);
+                if (!string.IsNullOrEmpty(group))
                 {
-                    _logger.Log(LogLevel.Debug, "Found comparison group '{0}' for method '{1}'",
-                        comparisonAttribute.ComparisonGroup, method.Name);
-                    return comparisonAttribute.ComparisonGroup;
+                    _logger.Log(LogLevel.Debug, "Found comparison group '{0}' for method '{1}'", group, method.Name);
+                    return group;
                 }
-                else
-                {
-                    _logger.Log(LogLevel.Debug, "No SailfishComparison attribute found for method '{0}'", method.Name);
-                }
+                _logger.Log(LogLevel.Debug, "No comparison attribute found for method '{0}'", method.Name);
             }
 
             return null;
@@ -651,6 +778,65 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                 "Failed to get comparison group for test '{0}': {1}",
                 testResult.TestCaseId?.DisplayName ?? "Unknown", ex.Message);
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the comparison group + baseline flag for a method, preferring the new
+    /// <see cref="SailfishMethodAttribute"/> shape and falling back to the obsolete
+    /// <see cref="SailfishComparisonAttribute"/> during the deprecation window.
+    /// </summary>
+    private static (string? Group, bool IsBaseline) ReadComparisonInfo(MethodInfo method)
+    {
+        var methodAttr = method.GetCustomAttribute<SailfishMethodAttribute>();
+        if (methodAttr != null && !string.IsNullOrEmpty(methodAttr.ComparisonGroup))
+        {
+            return (methodAttr.ComparisonGroup, methodAttr.IsBaseline);
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        var legacyAttr = method.GetCustomAttribute<SailfishComparisonAttribute>();
+#pragma warning restore CS0618
+        if (legacyAttr != null && !legacyAttr.Disabled)
+        {
+            // Legacy attribute had no baseline concept — treat all members as N×N participants.
+            return (legacyAttr.ComparisonGroup, false);
+        }
+
+        return (null, false);
+    }
+
+    /// <summary>
+    /// Returns the comparison info (group + baseline flag) for a single test result,
+    /// performing the same method lookup as <see cref="GetComparisonGroup"/>.
+    /// </summary>
+    private (string? Group, bool IsBaseline) GetComparisonInfoForResult(
+        CompiledTestCaseResultTrackingFormat testResult, Type testClass)
+    {
+        try
+        {
+            var displayName = testResult.TestCaseId?.DisplayName ?? "Unknown";
+            var methodName = GetMethodName(displayName);
+
+            var method = testClass.GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            if (method == null)
+            {
+                var allMethods = testClass.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+                method = allMethods.FirstOrDefault(m =>
+                    string.Equals(m.Name, methodName, StringComparison.Ordinal) ||
+                    displayName.StartsWith(m.Name, StringComparison.Ordinal));
+            }
+
+            return method != null ? ReadComparisonInfo(method) : (null, false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Warning, ex,
+                "Failed to resolve comparison info for test '{0}': {1}",
+                testResult.TestCaseId?.DisplayName ?? "Unknown", ex.Message);
+            return (null, false);
         }
     }
 }

--- a/source/Tests.Analyzers/MethodComparison/BaselineRequiresComparisonGroupTests.cs
+++ b/source/Tests.Analyzers/MethodComparison/BaselineRequiresComparisonGroupTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+using Tests.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Analyzers.MethodComparison;
+
+public class BaselineRequiresComparisonGroupTests
+{
+    [Fact]
+    public async Task ReportsErrorWhenIsBaselineWithoutComparisonGroup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod({|#0:IsBaseline = true|})]
+    public void Orphan() { }
+
+    [SailfishMethod]
+    public void Other() { }
+}";
+        await AnalyzerVerifier<BaselineRequiresComparisonGroupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(BaselineRequiresComparisonGroupAnalyzer.Descriptor)
+                .WithLocation(0)
+                .WithArguments("Orphan"));
+    }
+
+    [Fact]
+    public async Task NoDiagnosticWhenBaselineHasComparisonGroup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod(ComparisonGroup = ""g"", IsBaseline = true)]
+    public void Baseline() { }
+
+    [SailfishMethod(ComparisonGroup = ""g"")]
+    public void Contender() { }
+}";
+        await AnalyzerVerifier<BaselineRequiresComparisonGroupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task NoDiagnosticWhenIsBaselineIsFalse()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod(IsBaseline = false)]
+    public void Plain() { }
+}";
+        await AnalyzerVerifier<BaselineRequiresComparisonGroupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies());
+    }
+}

--- a/source/Tests.Analyzers/MethodComparison/ComparisonGroupNeedsTwoMethodsTests.cs
+++ b/source/Tests.Analyzers/MethodComparison/ComparisonGroupNeedsTwoMethodsTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+using Tests.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Analyzers.MethodComparison;
+
+public class ComparisonGroupNeedsTwoMethodsTests
+{
+    [Fact]
+    public async Task ReportsWarningForSoloMember()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod({|#0:ComparisonGroup = ""solo""|})]
+    public void Lonely() { }
+
+    [SailfishMethod]
+    public void Unrelated() { }
+}";
+        await AnalyzerVerifier<ComparisonGroupNeedsTwoMethodsAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(ComparisonGroupNeedsTwoMethodsAnalyzer.Descriptor)
+                .WithLocation(0)
+                .WithArguments("solo", "Lonely"));
+    }
+
+    [Fact]
+    public async Task NoDiagnosticWhenGroupHasTwoOrMoreMembers()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod(ComparisonGroup = ""g"")]
+    public void One() { }
+
+    [SailfishMethod(ComparisonGroup = ""g"")]
+    public void Two() { }
+}";
+        await AnalyzerVerifier<ComparisonGroupNeedsTwoMethodsAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies());
+    }
+}

--- a/source/Tests.Analyzers/MethodComparison/SingleBaselinePerGroupTests.cs
+++ b/source/Tests.Analyzers/MethodComparison/SingleBaselinePerGroupTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.MethodComparison;
+using Tests.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Analyzers.MethodComparison;
+
+public class SingleBaselinePerGroupTests
+{
+    [Fact]
+    public async Task ReportsErrorWhenTwoMethodsInSameGroupAreBaselines()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod(ComparisonGroup = ""g"", {|#0:IsBaseline = true|})]
+    public void First() { }
+
+    [SailfishMethod(ComparisonGroup = ""g"", {|#1:IsBaseline = true|})]
+    public void Second() { }
+}";
+        await AnalyzerVerifier<SingleBaselinePerGroupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(SingleBaselinePerGroupAnalyzer.Descriptor).WithLocation(0).WithArguments("g", 2),
+            new DiagnosticResult(SingleBaselinePerGroupAnalyzer.Descriptor).WithLocation(1).WithArguments("g", 2));
+    }
+
+    [Fact]
+    public async Task NoDiagnosticWithExactlyOneBaseline()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod(ComparisonGroup = ""g"", IsBaseline = true)]
+    public void Baseline() { }
+
+    [SailfishMethod(ComparisonGroup = ""g"")]
+    public void Contender() { }
+}";
+        await AnalyzerVerifier<SingleBaselinePerGroupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task TwoBaselinesInDifferentGroupsIsAllowed()
+    {
+        // Different groups → no SF1301 because the rule is per (class, group).
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod(ComparisonGroup = ""a"", IsBaseline = true)]
+    public void BaselineA() { }
+
+    [SailfishMethod(ComparisonGroup = ""a"")]
+    public void ContenderA() { }
+
+    [SailfishMethod(ComparisonGroup = ""b"", IsBaseline = true)]
+    public void BaselineB() { }
+
+    [SailfishMethod(ComparisonGroup = ""b"")]
+    public void ContenderB() { }
+}";
+        await AnalyzerVerifier<SingleBaselinePerGroupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies());
+    }
+}

--- a/source/Tests.Analyzers/Utils/TestDependencyExtensionMethods.cs
+++ b/source/Tests.Analyzers/Utils/TestDependencyExtensionMethods.cs
@@ -99,6 +99,8 @@ public sealed class SailfishIterationTeardownAttribute : Attribute, IInnerLifecy
 [AttributeUsage(AttributeTargets.Method, Inherited = false)]
 public sealed class SailfishMethodAttribute : Attribute
 {
+    public string? ComparisonGroup { get; set; }
+    public bool IsBaseline { get; set; }
 }
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]

--- a/source/Tests.E2E.TestSuite/Discoverable/MethodComparisonExample.cs
+++ b/source/Tests.E2E.TestSuite/Discoverable/MethodComparisonExample.cs
@@ -1,20 +1,22 @@
-﻿using Sailfish.Attributes;
+using Sailfish.Attributes;
 
 namespace Tests.E2E.TestSuite.Discoverable;
 
 /// <summary>
-/// Example test class demonstrating the new method comparison feature.
-/// This class shows how to use SailfishComparisonAttribute to mark methods
-/// for "before and after" performance comparisons.
+/// Example test class demonstrating the method comparison feature.
+/// Comparison configuration lives on <see cref="SailfishMethodAttribute"/> itself:
+/// set <c>ComparisonGroup</c> to opt a method into a named comparison, and optionally
+/// set <c>IsBaseline = true</c> on one method per group to switch from the default N×N
+/// matrix to N−1 baseline-vs-contender comparisons.
 /// </summary>
 /// <remarks>
 /// When running individual methods, only that method's results are displayed.
-/// When running the entire class, SailDiff comparisons are performed between
-/// methods in the same comparison group and displayed in the test output.
-/// 
-/// Usage:
-/// - Run individual methods: Only method results shown
-/// - Run entire class: Method results + SailDiff comparison results shown
+/// When running the entire class, comparisons are performed between methods in the
+/// same comparison group and rendered in the markdown/CSV output.
+///
+/// - <c>SumCalculation</c> has no baseline → full N×N matrix is rendered.
+/// - <c>SortingAlgorithm</c> nominates <c>SortWithQuickSort</c> as the baseline → the
+///   table reports each contender's ratio vs. quicksort.
 /// </remarks>
 [Sailfish(Disabled = Constants.Disabled)]
 public class MethodComparisonExample
@@ -33,10 +35,9 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// LINQ-based sum calculation algorithm.
+    /// LINQ-based sum calculation algorithm. Part of the SumCalculation group (no baseline → N×N).
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SumCalculation")]
+    [SailfishMethod(ComparisonGroup = "SumCalculation")]
     public void CalculateSumWithLinq()
     {
         var sum = _data.Sum();
@@ -45,10 +46,9 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Loop-based sum calculation algorithm.
+    /// Loop-based sum calculation algorithm. Part of the SumCalculation group (no baseline → N×N).
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SumCalculation")]
+    [SailfishMethod(ComparisonGroup = "SumCalculation")]
     public void CalculateSumWithLoop()
     {
         var sum = 0;
@@ -61,10 +61,9 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Bubble sort algorithm implementation.
+    /// Bubble sort algorithm — contender in the SortingAlgorithm group.
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
     public void SortWithBubbleSort()
     {
         var array = _data.ToArray();
@@ -83,10 +82,10 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Optimized sorting algorithm using Array.Sort.
+    /// Optimized sorting algorithm — declared as the baseline of SortingAlgorithm.
+    /// All other methods in this group are reported as ratios vs. this one.
     /// </summary>
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm", IsBaseline = true)]
     public void SortWithQuickSort()
     {
         var array = _data.ToArray();
@@ -94,7 +93,7 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Regular method without comparison - will not participate in comparisons.
+    /// Regular method without comparison — will not participate in any comparison group.
     /// </summary>
     [SailfishMethod]
     public void RegularMethod()
@@ -104,7 +103,7 @@ public class MethodComparisonExample
     }
 
     /// <summary>
-    /// Another regular method - demonstrates that non-comparison methods work normally.
+    /// Another regular method — demonstrates that non-comparison methods coexist with comparison ones.
     /// </summary>
     [SailfishMethod]
     public void AnotherRegularMethod()

--- a/source/Tests.Library/DefaultHandlers/Sailfish/CsvTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/CsvTestRunCompletedHandlerTests.cs
@@ -125,6 +125,40 @@ public class CsvTestRunCompletedHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithBaselineComparison_EmitsOnlyBaselineVsContenderRows()
+    {
+        // Arrange — a 2-method group with one baseline → exactly one CSV pair row should appear.
+        var notification = CreateTestNotificationWithBaselineComparison();
+
+        // Act
+        await _handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await _mockMediator.Received(1).Publish(
+            Arg.Is<WriteMethodComparisonCsvNotification>(n =>
+                n.CsvContent.Contains("# Method Comparisons") &&
+                n.CsvContent.Contains("TestGroup,Baseline,Contender")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithLegacyComparisonAttribute_StillEmitsComparison()
+    {
+        // Arrange — exercises the obsolete-attribute fallback path.
+        var notification = CreateTestNotificationWithLegacyComparison();
+
+        // Act
+        await _handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await _mockMediator.Received(1).Publish(
+            Arg.Is<WriteMethodComparisonCsvNotification>(n =>
+                n.CsvContent.Contains("# Method Comparisons") &&
+                n.CsvContent.Contains("TestGroup,")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_WithNonComparisonMethods_GeneratesIndividualResults()
     {
         // Arrange
@@ -339,6 +373,56 @@ public class CsvTestRunCompletedHandlerTests
         return new TestRunCompletedNotification([classExecutionSummary]);
     }
 
+    private TestRunCompletedNotification CreateTestNotificationWithBaselineComparison()
+    {
+        var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(TestClassWithBaselineComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(100.0)
+                    .WithMedian(95.0)
+                    .WithStdDev(5.0)
+                    .WithSampleSize(10)
+                    .Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(200.0)
+                    .WithMedian(195.0)
+                    .WithStdDev(10.0)
+                    .WithSampleSize(10)
+                    .Build()))
+            .Build();
+
+        return new TestRunCompletedNotification([classExecutionSummary]);
+    }
+
+    private TestRunCompletedNotification CreateTestNotificationWithLegacyComparison()
+    {
+        var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(LegacyTestClassWithComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Method1").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(100.0)
+                    .WithMedian(95.0)
+                    .WithStdDev(5.0)
+                    .WithSampleSize(10)
+                    .Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Method2").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(200.0)
+                    .WithMedian(195.0)
+                    .WithStdDev(10.0)
+                    .WithSampleSize(10)
+                    .Build()))
+            .Build();
+
+        return new TestRunCompletedNotification([classExecutionSummary]);
+    }
+
     private TestRunCompletedNotification CreateTestNotificationWithEmptyResults()
     {
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
@@ -393,11 +477,34 @@ public class CsvTestRunCompletedHandlerTests
     [WriteToCsv]
     private class TestClassWithComparison
     {
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Method1() { }
+
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Method2() { }
+    }
+
+    [WriteToCsv]
+    private class TestClassWithBaselineComparison
+    {
+        [SailfishMethod(ComparisonGroup = "TestGroup", IsBaseline = true)]
+        public void Baseline() { }
+
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Contender() { }
+    }
+
+    [WriteToCsv]
+    private class LegacyTestClassWithComparison
+    {
+        // Coverage for the deprecation-window fallback: legacy [SailfishComparison] still resolves.
+#pragma warning disable CS0618 // Type or member is obsolete
         [SailfishComparison("TestGroup")]
         public void Method1() { }
 
         [SailfishComparison("TestGroup")]
         public void Method2() { }
+#pragma warning restore CS0618
     }
 
     [WriteToCsv]

--- a/source/Tests.Library/DefaultHandlers/Sailfish/CsvTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/CsvTestRunCompletedHandlerTests.cs
@@ -142,6 +142,28 @@ public class CsvTestRunCompletedHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithSameGroupNameInTwoClasses_EmitsBaselineRowsForEach()
+    {
+        // Regression: per-class grouping must keep each class's lone baseline intact.
+        // If grouping were by group-name only, the merged group would see 2 baselines and
+        // collapse into N×N pair rows (Baseline,Contender,OtherBaseline,OtherContender pairs).
+        var notification = CreateTestNotificationWithSameGroupNameInTwoClasses();
+
+        await _handler.Handle(notification, CancellationToken.None);
+
+        await _mockMediator.Received(1).Publish(
+            Arg.Is<WriteMethodComparisonCsvNotification>(n =>
+                n.CsvContent.Contains("# Method Comparisons") &&
+                // Each class emits exactly its own baseline-vs-contender row.
+                n.CsvContent.Contains("TestGroup,Baseline,Contender") &&
+                n.CsvContent.Contains("TestGroup,OtherBaseline,OtherContender") &&
+                // The cross-class N×N pair must NOT appear.
+                !n.CsvContent.Contains("TestGroup,Baseline,OtherBaseline") &&
+                !n.CsvContent.Contains("TestGroup,Contender,OtherContender")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_WithLegacyComparisonAttribute_StillEmitsComparison()
     {
         // Arrange — exercises the obsolete-attribute fallback path.
@@ -398,6 +420,35 @@ public class CsvTestRunCompletedHandlerTests
         return new TestRunCompletedNotification([classExecutionSummary]);
     }
 
+    private TestRunCompletedNotification CreateTestNotificationWithSameGroupNameInTwoClasses()
+    {
+        var classA = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(TestClassWithBaselineComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(100.0).WithMedian(95.0).WithStdDev(5.0).WithSampleSize(10).Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(200.0).WithMedian(195.0).WithStdDev(10.0).WithSampleSize(10).Build()))
+            .Build();
+
+        var classB = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(OtherTestClassWithBaselineComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("OtherBaseline").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(150.0).WithMedian(145.0).WithStdDev(7.0).WithSampleSize(10).Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("OtherContender").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(300.0).WithMedian(295.0).WithStdDev(15.0).WithSampleSize(10).Build()))
+            .Build();
+
+        return new TestRunCompletedNotification([classA, classB]);
+    }
+
     private TestRunCompletedNotification CreateTestNotificationWithLegacyComparison()
     {
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
@@ -492,6 +543,18 @@ public class CsvTestRunCompletedHandlerTests
 
         [SailfishMethod(ComparisonGroup = "TestGroup")]
         public void Contender() { }
+    }
+
+    // Deliberately reuses the "TestGroup" name from TestClassWithBaselineComparison to verify
+    // per-class scoping.
+    [WriteToCsv]
+    private class OtherTestClassWithBaselineComparison
+    {
+        [SailfishMethod(ComparisonGroup = "TestGroup", IsBaseline = true)]
+        public void OtherBaseline() { }
+
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void OtherContender() { }
     }
 
     [WriteToCsv]

--- a/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
@@ -148,6 +148,43 @@ public class MethodComparisonTestRunCompletedHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithBaselineComparison_RendersBaselineTable()
+    {
+        // Arrange — a comparison group with exactly one IsBaseline=true method.
+        var notification = CreateTestNotificationWithBaselineComparison();
+
+        // Act
+        await _handler.Handle(notification, CancellationToken.None);
+
+        // Assert — baseline mode emits a "Baseline Comparison" header (not the N×N matrix header)
+        // and a "Ratio vs Baseline" column.
+        await _mockMediator.Received(1).Publish(
+            Arg.Is<WriteMethodComparisonMarkdownNotification>(n =>
+                n.MarkdownContent.Contains("Baseline Comparison") &&
+                n.MarkdownContent.Contains("Ratio vs Baseline") &&
+                n.MarkdownContent.Contains("(baseline)") &&
+                !n.MarkdownContent.Contains("Performance Comparison Matrix")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithLegacyComparisonAttribute_StillRendersComparison()
+    {
+        // Arrange — uses the obsolete [SailfishComparison] attribute via the fallback path.
+        var notification = CreateTestNotificationWithLegacyComparison();
+
+        // Act
+        await _handler.Handle(notification, CancellationToken.None);
+
+        // Assert — legacy attribute has no baseline concept → falls through to N×N matrix.
+        await _mockMediator.Received(1).Publish(
+            Arg.Is<WriteMethodComparisonMarkdownNotification>(n =>
+                n.MarkdownContent.Contains("Comparison Group:") &&
+                n.MarkdownContent.Contains("Performance Comparison Matrix")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_WithNonComparisonMethods_GeneratesIndividualResults()
     {
         // Arrange
@@ -346,6 +383,52 @@ public class MethodComparisonTestRunCompletedHandlerTests
         return new TestRunCompletedNotification([classExecutionSummary]);
     }
 
+    private TestRunCompletedNotification CreateTestNotificationWithBaselineComparison()
+    {
+        var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(TestClassWithBaselineComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(10.0)
+                    .WithMedian(9.5)
+                    .WithSampleSize(100)
+                    .Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(20.0)
+                    .WithMedian(19.5)
+                    .WithSampleSize(100)
+                    .Build()))
+            .Build();
+
+        return new TestRunCompletedNotification([classExecutionSummary]);
+    }
+
+    private TestRunCompletedNotification CreateTestNotificationWithLegacyComparison()
+    {
+        var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(LegacyTestClassWithComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Method1").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(10.0)
+                    .WithMedian(9.5)
+                    .WithSampleSize(100)
+                    .Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Method2").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(20.0)
+                    .WithMedian(19.5)
+                    .WithSampleSize(100)
+                    .Build()))
+            .Build();
+
+        return new TestRunCompletedNotification([classExecutionSummary]);
+    }
+
     private TestRunCompletedNotification CreateTestNotificationWithNonComparisonMethods()
     {
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
@@ -413,11 +496,34 @@ public class MethodComparisonTestRunCompletedHandlerTests
     [WriteToMarkdown]
     private class TestClassWithComparison
     {
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Method1() { }
+
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Method2() { }
+    }
+
+    [WriteToMarkdown]
+    private class TestClassWithBaselineComparison
+    {
+        [SailfishMethod(ComparisonGroup = "TestGroup", IsBaseline = true)]
+        public void Baseline() { }
+
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Contender() { }
+    }
+
+    [WriteToMarkdown]
+    private class LegacyTestClassWithComparison
+    {
+        // Coverage for the deprecation-window fallback: legacy [SailfishComparison] still resolves.
+#pragma warning disable CS0618 // Type or member is obsolete
         [SailfishComparison("TestGroup")]
         public void Method1() { }
 
         [SailfishComparison("TestGroup")]
         public void Method2() { }
+#pragma warning restore CS0618
     }
 
     [WriteToMarkdown]

--- a/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
@@ -168,6 +168,27 @@ public class MethodComparisonTestRunCompletedHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithSameGroupNameInTwoClasses_KeepsEachBaselineMode()
+    {
+        // Regression for the per-class scoping bug: two distinct classes use the same
+        // ComparisonGroup name and each has its own single baseline. Without per-class grouping,
+        // the merged group sees 2 baselines and silently collapses to an N×N matrix.
+        var notification = CreateTestNotificationWithSameGroupNameInTwoClasses();
+
+        await _handler.Handle(notification, CancellationToken.None);
+
+        await _mockMediator.Received(1).Publish(
+            Arg.Is<WriteMethodComparisonMarkdownNotification>(n =>
+                // Both class sections appear under their class-disambiguated headers.
+                n.MarkdownContent.Contains("Comparison Group: TestGroup (TestClassWithBaselineComparison)") &&
+                n.MarkdownContent.Contains("Comparison Group: TestGroup (OtherTestClassWithBaselineComparison)") &&
+                // Both render in baseline mode — never the fallback matrix header.
+                n.MarkdownContent.Contains("Baseline Comparison") &&
+                !n.MarkdownContent.Contains("Performance Comparison Matrix")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_WithLegacyComparisonAttribute_StillRendersComparison()
     {
         // Arrange — uses the obsolete [SailfishComparison] attribute via the fallback path.
@@ -406,6 +427,35 @@ public class MethodComparisonTestRunCompletedHandlerTests
         return new TestRunCompletedNotification([classExecutionSummary]);
     }
 
+    private TestRunCompletedNotification CreateTestNotificationWithSameGroupNameInTwoClasses()
+    {
+        var classA = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(TestClassWithBaselineComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(10.0).WithMedian(9.5).WithSampleSize(100).Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(20.0).WithMedian(19.5).WithSampleSize(100).Build()))
+            .Build();
+
+        var classB = ClassExecutionSummaryTrackingFormatBuilder.Create()
+            .WithTestClass(typeof(OtherTestClassWithBaselineComparison))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(30.0).WithMedian(29.5).WithSampleSize(100).Build()))
+            .WithCompiledTestCaseResult(b => b
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
+                    .WithMean(40.0).WithMedian(39.5).WithSampleSize(100).Build()))
+            .Build();
+
+        return new TestRunCompletedNotification([classA, classB]);
+    }
+
     private TestRunCompletedNotification CreateTestNotificationWithLegacyComparison()
     {
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
@@ -505,6 +555,18 @@ public class MethodComparisonTestRunCompletedHandlerTests
 
     [WriteToMarkdown]
     private class TestClassWithBaselineComparison
+    {
+        [SailfishMethod(ComparisonGroup = "TestGroup", IsBaseline = true)]
+        public void Baseline() { }
+
+        [SailfishMethod(ComparisonGroup = "TestGroup")]
+        public void Contender() { }
+    }
+
+    // Deliberately reuses the "TestGroup" name from TestClassWithBaselineComparison to verify
+    // per-class scoping. Without it, both classes' baselines would merge and fall back to N×N.
+    [WriteToMarkdown]
+    private class OtherTestClassWithBaselineComparison
     {
         [SailfishMethod(ComparisonGroup = "TestGroup", IsBaseline = true)]
         public void Baseline() { }


### PR DESCRIPTION
## Description

Today, opting a method into method comparison requires a second attribute (`[SailfishComparison("group")]`) on top of `[SailfishMethod]`, and there is no way for a user to nominate a baseline — comparisons are always rendered as an N×N matrix. That model has three problems:

1. The library uses two attributes where one would do, and they duplicate properties (`DisplayName`, `Disabled`).
2. Users typically know which method is the "before"/known-good and want to compare alternatives against it. N×N obscures that intent and pays statistical cost (more pairs to FDR-adjust).
3. Adding more knobs (like baselines) onto a second attribute makes the surface worse, not better.

This PR collapses comparison configuration into `[SailfishMethod]` itself and adds a first-class baseline concept, while keeping the old attribute around (obsoleted) so existing users get a deprecation warning rather than a hard break.

## Results

### New attribute shape

```csharp
[SailfishMethod(ComparisonGroup = "Sort", IsBaseline = true)]
public void QuickSort() { /* ... */ }

[SailfishMethod(ComparisonGroup = "Sort")]
public void BubbleSort() { /* ... */ }
```

Comparison stays opt-in: a `[SailfishMethod]` without `ComparisonGroup` simply doesn't participate.

### Per-group behavior

| Baselines in group | Behavior |
| ------------------ | -------- |
| 0                  | N×N matrix (preserves existing behavior — no regression) |
| 1                  | N−1 baseline-vs-contender comparisons, BH-FDR adjusted |
| 2+                 | Analyzer error at build time; runtime warns and falls back to N×N |

### New analyzers

| ID     | Severity | Rule |
| ------ | -------- | ---- |
| SF1300 | Error    | `IsBaseline = true` requires `ComparisonGroup` to be set on the same attribute |
| SF1301 | Error    | At most one method per `(class, ComparisonGroup)` may set `IsBaseline = true` |
| SF1302 | Warning  | A `ComparisonGroup` with only one method produces no output |

### Deprecation

`SailfishComparisonAttribute` is marked `[Obsolete]` pointing at the new shape. Both the runtime (markdown + CSV handlers) and the test-adapter discovery path keep reading it as a fallback during the deprecation window. Existing code that uses `[SailfishComparison("g")]` keeps working but produces a compile-time obsolete warning.

`SailfishComparisonAttribute.DisplayName` was unused — it is not migrated. `SailfishComparisonAttribute.Disabled` is honored only on the legacy attribute; in the new shape, removing `ComparisonGroup` is the equivalent and there is no separate flag.

### Files touched

- **Attributes:** `SailfishMethodAttribute` gains `ComparisonGroup` / `IsBaseline`; `SailfishComparisonAttribute` marked `[Obsolete]`.
- **Runtime:** `MethodComparisonTestRunCompletedHandler` adds a new `CreateBaselineComparisonTable` and routes per-group; `CsvTestRunCompletedHandler` emits N−1 pair rows when in baseline mode. Both fall back to the obsolete attribute if needed.
- **Discovery:** `DiscoveryAnalysisMethods.ExtractComparisonInfo` recognizes `ComparisonGroup = "..."` named-arg syntax on `[SailfishMethod]`; falls back to the positional `[SailfishComparison(...)]` form.
- **Analyzers:** new `Sailfish.Analyzers/DiagnosticAnalyzers/MethodComparison/` directory with shared `MethodComparisonAttributeReader` plus the three analyzers above. `AnalyzerReleases.Unshipped.md` updated.
- **Examples:** both `MethodComparisonExample.cs` files (PerformanceTests and Tests.E2E.TestSuite) migrated to the new shape and updated to demonstrate both modes — `SumCalculation` has no baseline (N×N), `SortingAlgorithm` nominates `SortWithQuickSort` as the baseline (N−1).
- **Tests:** added baseline-mode and legacy-fallback tests in `Tests.Library` for both markdown and CSV handlers (with new `TestClassWithBaselineComparison` and `LegacyTestClassWithComparison` fixtures); 8 new analyzer unit tests in `Tests.Analyzers/MethodComparison/`; extended the stub `SailfishMethodAttribute` in the analyzer test harness.

### Verification

- Full solution builds with no new warnings.
- `Tests.Library`: 1261 / 1261 pass (net9.0 and net10.0).
- `Tests.Analyzers`: 62 / 62 pass (net9.0 and net10.0), including 8 new tests.
- `Tests.TestAdapter`: 554 / 554 pass (net9.0 and net10.0).
- E2E and PerformanceTests projects build clean.

### Out of scope (call out if you want any of these in this PR)

- The `MethodComparisonTestClassCompletedHandler` (its `Handle` early-returns and the heuristic `GetComparisonGroup` is dead code; left untouched to avoid churn).
- Cross-class comparison groups (still per-class).
- An automated migration tool — users get the obsolete-attribute warning and can mechanically fold `[SailfishComparison("X")]` into the sibling `[SailfishMethod]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline comparison mode—comparisons now generate baseline vs. contender pairs instead of full N×N matrices when a baseline method is designated.
  * Comparison group configuration now integrated directly into `SailfishMethod` via new `ComparisonGroup` and `IsBaseline` properties.
  * Comparison groups are now scoped by test class, preventing cross-class group conflicts.

* **Deprecations**
  * `SailfishComparison` attribute is now obsolete; use `SailfishMethod` properties instead (backward compatible during deprecation window).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->