### PR TITLE
Modernize Sailfish.Analyzers csproj and bundle with TestAdapter

### DIFF
--- a/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
+++ b/source/Sailfish.Analyzers/Sailfish.Analyzers.csproj
@@ -5,28 +5,37 @@
         <Authors>Paul E. Gradie</Authors>
         <Copyright>Copyright</Copyright>
         <PackageTags>analyzers</PackageTags>
-        <NoPackageAnalysis>true</NoPackageAnalysis>
         <Description>
             Welcome to Sailfish!
             There are three tools included in this package:
-            - Sailfish is a simple in-process performace test framework for writing clean, manageable performance tests.
+            - Sailfish is a simple in-process performance test framework for writing clean, manageable performance tests.
             - SailDiff is a statistical testing tool for comparing before change and after change datasets.
             - ScaleFish is a machine learning tool for modeling general logical complexity and making predictions.
             Use these in combination to write a basic performance regression detection system for your application's
             delivery pipeline.
         </Description>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/paulegradie/Sailfish</RepositoryUrl>
+
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
         <IsPackable>true</IsPackable>
+        <IsRoslynComponent>true</IsRoslynComponent>
+        <DevelopmentDependency>true</DevelopmentDependency>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
         <DebugType>Embedded</DebugType>
         <EmbedAllSources>True</EmbedAllSources>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/paulegradie/Sailfish</RepositoryUrl>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+        <NoWarn>$(NoWarn);RS1038</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -34,38 +43,16 @@
         <Optimize>true</Optimize>
     </PropertyGroup>
 
-
-    <Target Name="CopyToSingleFolder" AfterTargets="Build" Condition="'$(TargetFrameworks)' != ''">
-        <!-- This target runs after the build process and works only if multiple target frameworks are defined -->
-        <ItemGroup>
-            <AllFrameworkOutputs Include="$(OutputPath)$(AssemblyName).dll"/>
-        </ItemGroup>
-        <Copy SourceFiles="@(AllFrameworkOutputs)" DestinationFolder="$(BaseOutputPath)$(Configuration)"/>
-    </Target>
-
-    <Target Name="CustomPack" BeforeTargets="Pack" Condition="'$(TargetFrameworks)' != ''">
-        <!-- This target runs before the pack process and works only if multiple target frameworks are defined -->
-        <ItemGroup>
-            <None Include="$(BaseOutputPath)$(Configuration)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs"/>
-        </ItemGroup>
-    </Target>
-
     <ItemGroup>
-        <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="tools"/>
-        <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     </ItemGroup>
 
-    <PropertyGroup>
-        <IncludeBuildOutput>true</IncludeBuildOutput>
-    </PropertyGroup>
     <ItemGroup>
-
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="all" />
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);RS1038</NoWarn>
-    </PropertyGroup>
+
     <ItemGroup>
         <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
         <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />

--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -5,8 +5,8 @@
         <Version>0.0.1-local</Version>
         <Authors>Paul E. Gradie</Authors>
         <Description>
-            Sailfish is a produtiocction friendly performace test suite for owriinting organized performance tests
-            against your component or API - without with all the extra ceremony. Threerehere are a number of fateature
+            Sailfish is a production-friendly performance test suite for writing organized performance tests
+            against your component or API - without all the extra ceremony.
         </Description>
         <RootNamespace>Sailfish.TestAdapter</RootNamespace>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
@@ -38,11 +38,18 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" />
+        <ProjectReference Include="..\Sailfish.Analyzers\Sailfish.Analyzers.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false"
+                          PrivateAssets="all" />
     </ItemGroup>
 
-    <!--    <ItemGroup>-->
-    <!--        <None Include="$(OutputPath)\$(TargetFramework)\Sailfish.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>-->
-    <!--    </ItemGroup>-->
+    <ItemGroup>
+        <None Include="..\Sailfish.Analyzers\bin\$(Configuration)\netstandard2.0\Sailfish.Analyzers.dll"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs"
+              Visible="false" />
+    </ItemGroup>
 
     <ItemGroup>
         <InternalsVisibleTo Include="Tests.TestAdapter" />

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -4,7 +4,7 @@
         <Version>0.0.117</Version>
         <Authors>Paul E. Gradie</Authors>
         <Description>
-            Sailfish is a simple in-process performace test framework for writing clean, manageable performance tests
+            Sailfish is a simple in-process performance test framework for writing clean, manageable performance tests
             against your component or API. The general intention is to provide a simple tool that teams can use to write straight forward
             tests that assess the speed of your code, without weighing you down with all the extra ceremony.
         </Description>

--- a/source/Tests.Analyzers/Tests.Analyzers.csproj
+++ b/source/Tests.Analyzers/Tests.Analyzers.csproj
@@ -5,17 +5,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <NoWarn>$(NoWarn);NU1701;CS0618</NoWarn>
+        <IsPackable>false</IsPackable>
+        <NoWarn>$(NoWarn);CS0618</NoWarn>
         <DefineConstants>$(DefineConstants);HAS_CODEFIX_TESTING</DefineConstants>
-
     </PropertyGroup>
+
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="1.1.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-        <PackageReference Include="xunit.core" Version="2.9.3" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,10 +21,17 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
+
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
+
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="1.1.2" />
     </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\Sailfish.Analyzers\Sailfish.Analyzers.csproj" />
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" IncludeAssets="All" />


### PR DESCRIPTION
## Description

The Sailfish.Analyzers project needed a cleanup pass:

- The csproj had dead code (`CopyToSingleFolder` and `CustomPack` targets gated on `$(TargetFrameworks)` plural, never fired since the project only has a singular `<TargetFramework>`), a phantom `tools/*.ps1` include for a nonexistent directory, and missing modern analyzer-package conventions.
- The Roslyn floor was pinned to `Microsoft.CodeAnalysis.CSharp 5.3.0`, which **requires consumers on .NET SDK 10 to load the analyzer at all**. .NET 9 SDK ships Roslyn 4.x and would silently fail to load it — a problem given the project wants .NET 9 to stay first-class for a while.
- `Sailfish.TestAdapter` did not bundle the analyzer (the bundling block had been commented out for a long time after historically "breaking Visual Studio"). Users had to install `Sailfish.Analyzers` as a separate nuget package — bad DX.
- Three csproj package descriptions had embarrassing typos (`produtiocction`, `performace`, `owriinting`, `Threerehere`, `fateature`) that ship to public NuGet metadata.

## Results

### `Sailfish.Analyzers.csproj`
- Removed dead targets and phantom file includes.
- Added analyzer-package conventions: `IsRoslynComponent=true`, `DevelopmentDependency=true`, `IncludeBuildOutput=false`, `SuppressDependenciesWhenPacking=true`.
- Lowered Roslyn floor `5.3.0 → 4.14.0` (latest 4.x line) so the analyzer loads on .NET 9 SDK 9.0.3xx+ consumers as well as .NET 10.
- Added `Microsoft.CodeAnalysis.Analyzers 3.11.0` meta-analyzer (lints the analyzer code itself).
- Resulting nupkg is clean: only `analyzers/dotnet/cs/Sailfish.Analyzers.dll`, no `lib/`, no transitive deps in nuspec.

### `Tests.Analyzers.csproj`
- Aligned `Microsoft.CodeAnalysis.*` references to `4.14.0` to match the analyzer.
- Switched `xunit.core → xunit` for consistency with other test projects in the repo.
- Held the four `Microsoft.CodeAnalysis.*Testing*` packages at `1.1.2` — the `.XUnit` variants have no `1.1.4` release, and mixing creates a transitive version conflict on `Microsoft.CodeAnalysis.Analyzer.Testing`.
- Preserved `HAS_CODEFIX_TESTING` define and `NoWarn;CS0618` (suppresses obsolete-API warnings from `Verifiers.XUnit`).

### `Sailfish.TestAdapter.csproj`
- Replaced the long-commented bundling attempt with a proper `ProjectReference` (with `OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all"`) and a `<None Include=... Pack="true" PackagePath="analyzers/dotnet/cs"/>` entry.
- The historical "broke VS" failure modes (wrong `lib/{tfm}/` path, Roslyn version higher than the consumer host, per-TFM duplicates) are all now avoided.
- Verified: TestAdapter nupkg now contains `analyzers/dotnet/cs/Sailfish.Analyzers.dll` alongside `lib/net9.0/` and `lib/net10.0/`, with `Sailfish.Analyzers` correctly omitted from the nuspec `<dependencies>`.

### Typo fixes
- `Sailfish.TestAdapter.csproj`: cleaned up the description paragraph (5 typos + grammar)
- `Sailfish.csproj`, `Sailfish.Analyzers.csproj`: `performace → performance`

### Verification
- Full solution builds clean in Debug **and** Release (same 8 pre-existing warnings: 2 obsolete TestPlatform API + 6 `SF1001` firing on E2E tests — analyzer working as expected).
- `Tests.Analyzers`: **54 × 2 = 108 tests passing** on `net9.0` + `net10.0`.

### Follow-ups (not in this PR)
- `Microsoft.CodeAnalysis.Testing.Verifiers.XUnit` is marked obsolete by Microsoft (suppressed via `NoWarn;CS0618`). Migrating to xunit3-based verifiers is a test-code change when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)