### PR TITLE
Fix NRE masking fixture-ctor exceptions in ActivateContainer (#240)

### DIFF
--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -122,10 +122,12 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         }
         catch (Exception ex)
         {
+            var currentInstance = TryGetCurrent(testCaseEnumerator);
+
             await _mediator.Publish(
-                new TestCaseExceptionNotification(testCaseEnumerator.Current.ToExternal(), testCaseGroup, ex),
+                new TestCaseExceptionNotification(currentInstance?.ToExternal(), testCaseGroup, ex),
                 cancellationToken);
-            await DisposeOfTestInstance(testCaseEnumerator.Current);
+            await DisposeOfTestInstance(currentInstance);
             testCaseEnumerator.Dispose();
             var msg = $"Error resolving test from {testProvider.Test.FullName}";
             _logger.Log(LogLevel.Fatal, ex, msg);
@@ -264,13 +266,28 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         }
         catch (Exception ex)
         {
-            await _mediator.Publish(new TestCaseExceptionNotification(instanceContainerEnumerator.Current.ToExternal(), testCaseGroup, ex), ct);
-            await DisposeOfTestInstance(instanceContainerEnumerator.Current);
+            var currentInstance = TryGetCurrent(instanceContainerEnumerator);
+            await _mediator.Publish(new TestCaseExceptionNotification(currentInstance?.ToExternal(), testCaseGroup, ex), ct);
+            await DisposeOfTestInstance(currentInstance);
             continueIterating = true;
             _consoleWriter.WriteString(ex.Message);
         }
 
         return continueIterating;
+    }
+
+    private static TestInstanceContainer? TryGetCurrent(IEnumerator<TestInstanceContainer> enumerator)
+    {
+        // Per IEnumerator<T>: Current is undefined when MoveNext has thrown or returned false.
+        // Reading it without a guard masks the real exception with an NRE.
+        try
+        {
+            return enumerator.Current;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private async Task<List<TestCaseExecutionResult>> CatchAndReturn(Exception ex, TestInstanceContainer testCase,

--- a/source/Tests.Library/Execution/TestCaseEnumeratorTests.cs
+++ b/source/Tests.Library/Execution/TestCaseEnumeratorTests.cs
@@ -11,6 +11,8 @@ using Sailfish;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Statistics;
 using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Exceptions;
 using Sailfish.Execution;
 using Sailfish.Extensions.Types;
 using Sailfish.Logging;
@@ -179,5 +181,102 @@ public class TestCaseEnumerationTests
         sut.TestInstanceContainer.ShouldNotBeNull();
         sut.TestInstanceContainer.GroupingId.ShouldBe("MinimalTest.Minimal");
         sut.TestInstanceContainer.TestCaseId.DisplayName.ShouldBe("MinimalTest.Minimal()");
+    }
+
+    [Fact]
+    public async Task OriginalExceptionSurfacesWhenMoveNextThrowsBeforeFirstItem()
+    {
+        // Reproduces issue #240: when MoveNext() throws before producing the first item
+        // (e.g., ISailfishFixture<T> ctor failure during Autofac resolution),
+        // Current is undefined per IEnumerator<T> contract. The bug was that dereferencing
+        // Current in the catch handler masked the real exception with an NRE.
+        var logger = Substitute.For<ILogger>();
+        var consoleWriter = Substitute.For<IConsoleWriter>();
+        var iterator = Substitute.For<ITestCaseIterator>();
+        var printer = Substitute.For<ITestCaseCountPrinter>();
+        var mediator = Substitute.For<IMediator>();
+        var summaryCompiler = Substitute.For<IClassExecutionSummaryCompiler>();
+        var settings = Substitute.For<IRunSettings>();
+        var engine = new SailfishExecutionEngine(logger, consoleWriter, iterator, printer, mediator, summaryCompiler, settings);
+        var executionState = new ExecutionState();
+
+        var originalException = new InvalidOperationException("clear, actionable message from fixture ctor");
+
+        var enumerator = Substitute.For<IEnumerator<TestInstanceContainer>>();
+        enumerator.MoveNext().Throws(originalException);
+        // Simulate IEnumerator<T> contract: Current throws when MoveNext has not produced an item.
+        enumerator.Current.Throws<InvalidOperationException>();
+
+        var testCaseEnumerator = Substitute.For<IEnumerable<TestInstanceContainer>>();
+        testCaseEnumerator.GetEnumerator().Returns(enumerator);
+
+        var provider = Substitute.For<ITestInstanceContainerProvider>();
+        provider.Test.Returns(typeof(TestCaseEnumerationTests));
+        provider.ProvideNextTestCaseEnumeratorForClass().Returns(testCaseEnumerator);
+
+        var result = await engine.ActivateContainer(
+            1,
+            2,
+            provider,
+            executionState,
+            Some.RandomString(),
+            [],
+            CancellationToken.None);
+
+        result.Count.ShouldBe(1);
+        var execResult = result.Single();
+        execResult.IsSuccess.ShouldBeFalse();
+
+        // The wrapping TestCaseEnumerationException must carry the original exception, not an NRE.
+        execResult.Exception.ShouldBeOfType<TestCaseEnumerationException>();
+        execResult.Exception!.InnerException.ShouldBeSameAs(originalException);
+
+        // The mediator must have received the original exception (not an NRE) so the consumer sees it.
+        await mediator.Received(1).Publish(
+            Arg.Is<TestCaseExceptionNotification>(n => n.Exception == originalException),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TestClassInstantiationExceptionSurfacesDirectly()
+    {
+        // When MoveNext() throws a TestClassInstantiationException, the engine returns it
+        // directly (not wrapped). Verify the original exception still reaches the consumer
+        // even when Current is unsafe to read.
+        var logger = Substitute.For<ILogger>();
+        var consoleWriter = Substitute.For<IConsoleWriter>();
+        var iterator = Substitute.For<ITestCaseIterator>();
+        var printer = Substitute.For<ITestCaseCountPrinter>();
+        var mediator = Substitute.For<IMediator>();
+        var summaryCompiler = Substitute.For<IClassExecutionSummaryCompiler>();
+        var settings = Substitute.For<IRunSettings>();
+        var engine = new SailfishExecutionEngine(logger, consoleWriter, iterator, printer, mediator, summaryCompiler, settings);
+        var executionState = new ExecutionState();
+
+        var originalException = new TestClassInstantiationException(
+            typeof(TestCaseEnumerationTests),
+            new InvalidOperationException("fixture ctor blew up"));
+
+        var enumerator = Substitute.For<IEnumerator<TestInstanceContainer>>();
+        enumerator.MoveNext().Throws(originalException);
+        enumerator.Current.Throws<InvalidOperationException>();
+
+        var testCaseEnumerator = Substitute.For<IEnumerable<TestInstanceContainer>>();
+        testCaseEnumerator.GetEnumerator().Returns(enumerator);
+
+        var provider = Substitute.For<ITestInstanceContainerProvider>();
+        provider.Test.Returns(typeof(TestCaseEnumerationTests));
+        provider.ProvideNextTestCaseEnumeratorForClass().Returns(testCaseEnumerator);
+
+        var result = await engine.ActivateContainer(
+            1,
+            2,
+            provider,
+            executionState,
+            Some.RandomString(),
+            [],
+            CancellationToken.None);
+
+        result.Single().Exception.ShouldBeSameAs(originalException);
     }
 }


### PR DESCRIPTION
## Summary
- Guard `testCaseEnumerator.Current` access in `SailfishExecutionEngine.ActivateContainer` so the real fixture/ctor exception surfaces instead of an `NullReferenceException`.
- Apply the same guard to `TryMoveNextOrThrow`, which had the same pattern.
- Add two regression tests in `TestCaseEnumerationTests` covering both the wrapped (`TestCaseEnumerationException`) and direct (`TestClassInstantiationException`) paths. Verified the new tests fail without the fix and pass with it.

Fixes #240

## Root cause
When `MoveNext()` throws before producing the first item (e.g., an `ISailfishFixture<T>` whose ctor throws during Autofac resolution), `IEnumerator<T>.Current` is undefined. The catch handler called `testCaseEnumerator.Current.ToExternal()`, which itself threw — masking the user's original, actionable exception with a generic NRE pointing at `SailfishExecutionEngine.cs:125`.

## Test plan
- [x] `dotnet build` clean
- [x] `Tests.Library` — 1302/1302 pass on net9.0 and net10.0
- [x] `Tests.TestAdapter` — 555/555 pass on net9.0 and net10.0
- [x] Confirmed regression test fails without the fix (stash + run + restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved exception handling during test enumeration to prevent original errors from being masked by secondary failures.
  * Enhanced error reporting reliability when test initialization encounters issues.

* **Tests**
  * Added test coverage for exception handling scenarios during test enumeration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->