### PR TITLE
Docs: teach the new SailfishMethod(ComparisonGroup, IsBaseline) API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Sailfish is a .NET performance testing framework that makes it easy to write, ru
 
 ## Features
 - Statistical rigor: outlier detection, multiple tests, significance analysis
-- Method comparisons with `[SailfishComparison]`
+- Method comparisons via `[SailfishMethod(ComparisonGroup = "…", IsBaseline = true|false)]`
 - Multiple outputs: test logs, Markdown, CSV
 - Easy CI/CD integration
 - Historical analysis with SailDiff
@@ -53,7 +53,7 @@ public class MyPerformanceTest
 ```
 
 ## Algorithm Comparisons
-Compare multiple algorithms automatically and get N×N matrices, significance tests, and clear performance ratios.
+Group two or more methods on a class with `ComparisonGroup` and Sailfish compares them automatically. Mark one method as the baseline with `IsBaseline = true` for an N−1 baseline-vs-contender report, or leave all members baseline-less for an N×N matrix. Both modes report ratios with 95% confidence intervals and BH-FDR–adjusted q-values.
 
 ```csharp
 [WriteToMarkdown]  // Generate consolidated markdown output
@@ -61,15 +61,15 @@ Compare multiple algorithms automatically and get N×N matrices, significance te
 [Sailfish(SampleSize = 100)]
 public class AlgorithmComparison
 {
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
-    public void BubbleSort() { /* implementation */ }
-
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithms", IsBaseline = true)]
     public void QuickSort() { /* implementation */ }
+
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithms")]
+    public void BubbleSort() { /* implementation */ }
 }
 ```
+
+See [Method Comparisons](https://paulgradie.com/Sailfish/docs/1/method-comparisons) for the full feature, including the N×N mode (drop `IsBaseline`) and the SF1300/1301/1302 build-time analyzers.
 
 ## Adaptive Sampling
 Adaptive sampling stops collecting samples once results are statistically stable (defaults shown):
@@ -172,10 +172,10 @@ Sailfish tests then appear in the Unit Tests tool window with gutter play-button
 **Why the mask is needed**: ReSharper has built-in providers for xUnit / NUnit / MSTest only. For other VSTest adapters, it relies on the project being explicitly opted in to VSTest discovery via this mask — without it, ReSharper treats the project as non-test and greys out the run command. See issue [#98](https://github.com/paulegradie/Sailfish/issues/98) for background.
 
 ## Outputs and Reporting
-- N×N method comparison matrices per comparison group
-- Statistical significance testing (p-values, confidence intervals)
+- Per-group method comparisons (N−1 baseline mode or full N×N matrix)
+- BH-FDR–adjusted q-values and 95% ratio confidence intervals
 - Consolidated Markdown and CSV outputs
-- Clear performance ratios (e.g., "X times faster/slower")
+- Improved / Slower / Similar labels at α = 0.05
 
 See the full documentation for output details and examples: https://paulgradie.com/Sailfish/
 

--- a/site/src/pages/docs/0/quick-start.md
+++ b/site/src/pages/docs/0/quick-start.md
@@ -36,6 +36,8 @@ public class Example
 
 ### Method Comparison Test
 
+Mark two or more methods with the same `ComparisonGroup` and Sailfish will compare them. Pick one as the baseline via `IsBaseline = true` for an N−1 baseline-vs-contender report, or leave all members baseline-less for an N×N matrix.
+
 ```csharp
 [WriteToMarkdown]  // Generate consolidated markdown output
 [WriteToCsv]       // Generate consolidated CSV output
@@ -50,12 +52,17 @@ public class AlgorithmComparison
         _data = Enumerable.Range(1, 1000).ToList();
     }
 
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithms", IsBaseline = true)]
+    public void QuickSort()
+    {
+        var array = _data.ToArray();
+        Array.Sort(array);
+    }
+
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithms")]
     public void BubbleSort()
     {
         var array = _data.ToArray();
-        // Bubble sort implementation
         for (int i = 0; i < array.Length - 1; i++)
         {
             for (int j = 0; j < array.Length - i - 1; j++)
@@ -67,16 +74,10 @@ public class AlgorithmComparison
             }
         }
     }
-
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
-    public void QuickSort()
-    {
-        var array = _data.ToArray();
-        Array.Sort(array);
-    }
 }
 ```
+
+See [Method Comparisons](/docs/1/method-comparisons) for the full feature, including the no-baseline N×N mode and the SF1300/1301/1302 build-time analyzers.
 
 ## 3. Register a Dependency
 
@@ -120,29 +121,18 @@ Adjusted Distribution (ms)
 
 ### Method Comparison Results
 
-When using `[SailfishComparison]`, you'll see detailed comparison results in the test output:
+The individual descriptive statistics for each method appear in the IDE Test Output window as usual. The comparison itself — ratios, 95% confidence intervals, BH-FDR q-values, and Improved/Slower/Similar labels — is written to the consolidated Markdown and CSV files when `[WriteToMarkdown]` / `[WriteToCsv]` are present.
 
-```
-📊 PERFORMANCE COMPARISON
-Group: SortingAlgorithms
-==================================================
+A baseline group renders like:
 
-🔴 IMPACT: BubbleSort() vs QuickSort() - 95.3% slower (REGRESSED)
-   P-Value: 0.000001 | Mean: 45.2ms → 2.1ms
+```markdown
+## 🔬 Comparison Group: SortingAlgorithms (AlgorithmComparison)
 
-📋 DETAILED STATISTICS:
-
-| Metric | Primary Method | Compared Method | Change | P-Value  |
-| ------ | -------------- | --------------- | ------ | -------- |
-| Mean   | 45.2ms         | 2.1ms           | +95.3% | 0.000001 |
-| Median | 44.1ms         | 2.0ms           | +95.0% | -        |
-
-Statistical Test: T-Test
-Alpha Level: 0.05
-Sample Size: 100
-Outliers Removed: 3
-
-==================================================
+### 📐 Baseline-vs-Contender (baseline = `QuickSort`, q-values via BH-FDR, α=0.05)
+| Method | Mean | Ratio vs Baseline | 95% CI | q-value | Label |
+|--------|------|-------------------|--------|---------|-------|
+| `QuickSort` _(baseline)_ | 2.100ms | — | — | — | — |
+| `BubbleSort` | 45.200ms | 21.524x | [18.301–24.917] | 1.2e-12 | Slower |
 ```
 
 ### Output Files
@@ -151,7 +141,7 @@ When using `[WriteToMarkdown]` or `[WriteToCsv]`, consolidated files are generat
 
 **Markdown**: `TestSession_abc12345_MethodComparisons_2025-08-03_10-30-00.md`
 - Session header (Generated, Session ID, Total Test Classes, Total Test Cases)
-- Per‑group comparison sections with N×N matrices
+- Per‑group comparison sections — either a baseline table (N−1) or an N×N matrix
 - Per‑class detailed results table (Method, Mean, Median, Sample Size, Status)
 
 **CSV**: `TestSession_abc12345_Results_20250803_103000.csv`

--- a/site/src/pages/docs/1/csv-output.md
+++ b/site/src/pages/docs/1/csv-output.md
@@ -15,13 +15,11 @@ Apply the `[WriteToCsv]` attribute to any test class:
 [Sailfish(SampleSize = 100)]
 public class PerformanceTest
 {
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
-    public void BubbleSort() { /* implementation */ }
-
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
+    [SailfishMethod(ComparisonGroup = "Algorithms", IsBaseline = true)]
     public void QuickSort() { /* implementation */ }
+
+    [SailfishMethod(ComparisonGroup = "Algorithms")]
+    public void BubbleSort() { /* implementation */ }
 
     [SailfishMethod]
     public void RegularMethod() { /* implementation */ }
@@ -49,7 +47,7 @@ PerformanceTest,RegularMethod,1.000,1.000,0.100,100,,Success
 - **MedianTime**: Median execution time in milliseconds
 - **StdDev**: Standard deviation of execution times
 - **SampleSize**: Number of iterations executed
-- **ComparisonGroup**: Comparison group name (if using `[SailfishComparison]`); empty for ungrouped methods
+- **ComparisonGroup**: Comparison group name (set via `SailfishMethod(ComparisonGroup = "...")`); empty for ungrouped methods. The group is scoped per test class — the same name in two different classes is reported as two independent groups, distinguished by the `TestClass` column.
 - **Status**: Test execution status (`Success` / `Failed`)
 
 {% callout title="Where are CI95_MOE / CI99_MOE?" type="note" %}
@@ -58,21 +56,26 @@ The session CSV intentionally keeps the per-test row narrow. The CI95 / CI99 mar
 
 ### Section 2: Method Comparisons
 
+The shape of this section depends on whether the group has a baseline:
+
+- **Baseline mode** (`IsBaseline = true` on one member): N−1 rows. Each row compares the baseline (Method1) to one contender (Method2).
+- **N×N mode** (no baseline): N×(N−1)/2 rows. Every unique pair appears once.
+
 ```csv
 # Method Comparisons
 ComparisonGroup,Method1,Method2,Mean1,Mean2,Ratio,CI95_Lower,CI95_Upper,q_value,Label,ChangeDescription
-Algorithms,BubbleSort,QuickSort,45.200,2.100,21.5,18.3,24.9,0.000,Slower,Regressed
+Algorithms,QuickSort,BubbleSort,2.100,45.200,21.524,18.301,24.917,1.2e-12,Slower,Regressed
 ```
 
 **Fields:**
 - **ComparisonGroup**: Name of the comparison group
-- **Method1 / Method2**: Methods being compared
-- **Mean1 / Mean2**: Mean execution times for each method
-- **Ratio**: `Mean1 / Mean2` (unitless). Values > 1 indicate Method 1 is slower; values < 1 indicate faster.
+- **Method1 / Method2**: The two methods being compared. In baseline mode, Method1 is always the baseline.
+- **Mean1 / Mean2**: Mean execution times (ms) for each method
+- **Ratio**: `Mean2 / Mean1` (unitless). Values > 1 indicate Method 2 is slower than Method 1; values < 1 indicate Method 2 is faster.
 - **CI95_Lower / CI95_Upper**: 95% confidence interval endpoints for the ratio (computed on the log scale)
-- **q_value**: Benjamini–Hochberg adjusted p-value (multiple comparisons correction)
-- **Label**: One of Improved, Similar, or Slower
-- **ChangeDescription**: Legacy summary for backward compatibility (Improved/Regressed/No Change)
+- **q_value**: Benjamini–Hochberg adjusted p-value across the group (multiple comparisons correction)
+- **Label**: One of Improved, Similar, or Slower at α = 0.05
+- **ChangeDescription**: Legacy summary for backward compatibility (Improved / Regressed / No Change)
 
 ## Session-Based Consolidation
 
@@ -127,20 +130,24 @@ When you have multiple comparison groups, each generates its own set of comparis
 ```csv
 # Method Comparisons
 ComparisonGroup,Method1,Method2,Mean1,Mean2,Ratio,CI95_Lower,CI95_Upper,q_value,Label,ChangeDescription
-StringOperations,StringConcat,StringBuilder,15.200,8.100,1.9,1.7,2.2,0.000,Slower,Regressed
-StringOperations,StringConcat,StringInterpolation,15.200,12.300,1.2,1.1,1.4,0.023,Slower,Regressed
-StringOperations,StringBuilder,StringInterpolation,8.100,12.300,0.66,0.60,0.72,0.001,Improved,Improved
-Collections,ListIteration,ArrayIteration,5.400,3.200,1.7,1.5,1.9,0.000,Slower,Regressed
+StringOperations,StringBuilder,StringConcat,8.100,15.200,1.877,1.689,2.085,1.0e-12,Slower,Regressed
+StringOperations,StringBuilder,StringInterpolation,8.100,12.300,1.519,1.371,1.682,2.3e-08,Slower,Regressed
+StringOperations,StringConcat,StringInterpolation,15.200,12.300,0.809,0.731,0.895,3.4e-04,Improved,Improved
+Collections,ArrayIteration,ListIteration,3.200,5.400,1.688,1.523,1.870,4.1e-10,Slower,Regressed
 ```
 
-### N×N Comparison Matrices
+The rows above are an N×N example — none of the methods is marked `IsBaseline`. Add `IsBaseline = true` to one method per group and the section shrinks to N−1 rows, with Method1 always being that baseline.
 
-For groups with multiple methods, all pairwise comparisons are included:
+### Pair counts per group
 
-- **2 methods**: 1 comparison
-- **3 methods**: 3 comparisons (A vs B, A vs C, B vs C)
-- **4 methods**: 6 comparisons
-- **N methods**: N×(N-1)/2 comparisons
+| Methods in group | No-baseline (N×N) rows | Baseline (N−1) rows |
+| --- | --- | --- |
+| 2 | 1 | 1 |
+| 3 | 3 | 2 |
+| 4 | 6 | 3 |
+| N | N × (N−1) / 2 | N − 1 |
+
+Baseline mode is set by adding `IsBaseline = true` to exactly one `[SailfishMethod]` in the group. The CSV row count for that group shrinks accordingly and the FDR adjustment runs over the smaller set, sharpening individual q-values.
 
 ### Mixed Test Types
 
@@ -165,12 +172,10 @@ Use meaningful test class and method names since they appear in the CSV:
 [WriteToCsv]
 public class DatabaseQueryPerformance  // Clear class name
 {
-    [SailfishMethod]
-    [SailfishComparison("QueryTypes")]
+    [SailfishMethod(ComparisonGroup = "QueryTypes", IsBaseline = true)]
     public void SimpleSelect() { }      // Descriptive method name
 
-    [SailfishMethod]
-    [SailfishComparison("QueryTypes")]
+    [SailfishMethod(ComparisonGroup = "QueryTypes")]
     public void ComplexJoin() { }       // Descriptive method name
 }
 ```
@@ -180,9 +185,9 @@ public class DatabaseQueryPerformance  // Clear class name
 Choose comparison group names that clearly indicate what's being compared:
 
 ```csharp
-[SailfishComparison("DatabaseQueries")]     // Good
-[SailfishComparison("SerializationMethods")] // Good
-[SailfishComparison("Group1")]               // Poor
+[SailfishMethod(ComparisonGroup = "DatabaseQueries")]      // Good
+[SailfishMethod(ComparisonGroup = "SerializationMethods")] // Good
+[SailfishMethod(ComparisonGroup = "Group1")]               // Poor
 ```
 
 ### 3. Configure Output Directory
@@ -221,9 +226,9 @@ If CSV files are empty or missing:
 
 If method comparisons are missing from the CSV:
 
-1. **Verify group names**: Ensure methods use identical group names (case-sensitive)
-2. **Check method count**: Need at least 2 methods in a group for comparisons
-3. **Confirm attributes**: Both `[SailfishMethod]` and `[SailfishComparison]` required
+1. **Verify group names**: Ensure methods use identical `ComparisonGroup` values (case-sensitive)
+2. **Check method count**: Need at least 2 methods in a group for comparisons (SF1302 warns at build time)
+3. **Single baseline per group**: At most one method in the group can set `IsBaseline = true` (SF1301 enforces this)
 
 ### Excel Import Issues
 

--- a/site/src/pages/docs/1/markdown-output.md
+++ b/site/src/pages/docs/1/markdown-output.md
@@ -15,13 +15,11 @@ Apply the `[WriteToMarkdown]` attribute to any test class:
 [Sailfish(SampleSize = 100)]
 public class PerformanceTest
 {
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
-    public void BubbleSort() { /* implementation */ }
-
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
+    [SailfishMethod(ComparisonGroup = "Algorithms", IsBaseline = true)]
     public void QuickSort() { /* implementation */ }
+
+    [SailfishMethod(ComparisonGroup = "Algorithms")]
+    public void BubbleSort() { /* implementation */ }
 
     [SailfishMethod]
     public void RegularMethod() { /* implementation */ }
@@ -53,16 +51,20 @@ The header is followed by optional `## 🏥 Environment Health Check` and `## �
 
 ### Section 2: Per-Group Comparison Sections
 
-For each `[SailfishComparison]` group with at least two methods, the file emits an `## 🔬 Comparison Group: {GroupName}` section containing:
+For each `(class, ComparisonGroup)` with at least two methods, the file emits an `## 🔬 Comparison Group: {GroupName} ({ClassName})` section. The class name is included so same-named groups in different classes are reported separately.
 
-- A `### Performance Comparison Matrix` — the N×N matrix with ratios (col / row), 95% ratio CIs, and BH-FDR q-values.
-- A `### Detailed Results` table:
+The section then contains one of:
+
+- **Baseline mode** (exactly one method in the group sets `IsBaseline = true`): a `### Baseline Comparison` section with one row per contender. Ratio is contender/baseline, with a 95% CI and BH-FDR q-value.
+- **N×N mode** (no baseline): a `### Performance Comparison Matrix` — every pair of methods appears as a cell with ratio (col / row), 95% CI, and q-value.
+
+Either layout is followed by a `### Detailed Results` table:
 
 ```markdown
 | Method | Mean Time | Median Time | Sample Size | Status |
 |--------|-----------|-------------|-------------|--------|
-| BubbleSort | 45.200ms | 44.100ms | 100 | ✅ Success |
 | QuickSort | 2.100ms | 2.000ms | 100 | ✅ Success |
+| BubbleSort | 45.200ms | 44.100ms | 100 | ✅ Success |
 ```
 
 **Columns:**
@@ -139,16 +141,18 @@ See [latest performance results](./TestSession_abc12345_Results_20250803_103000.
 
 ### Multiple Comparison Groups
 
-When you have multiple comparison groups, each gets its own `## 🔬 Comparison Group: {GroupName}` section with its own NxN matrix and detailed results table. The detailed table is always 5 columns (Method, Mean Time, Median Time, Sample Size, Status); ratios and q‑values live in the matrix above it.
+Each group gets its own `## 🔬 Comparison Group: {GroupName} ({ClassName})` section with its own baseline table or N×N matrix, followed by the detailed results table. The detailed table is always 5 columns (Method, Mean Time, Median Time, Sample Size, Status); ratios, CIs, and q-values live in the comparison section above it.
 
-### N×N Comparison Matrices
+### Pair counts per group
 
-For groups with multiple methods, all pairwise comparisons are included:
+| Methods in group | No-baseline (N×N) cells off-diagonal | Baseline (N−1) rows |
+| --- | --- | --- |
+| 2 | 2 (one each way) | 1 |
+| 3 | 6 | 2 |
+| 4 | 12 | 3 |
+| N | N × (N−1) | N − 1 |
 
-- **2 methods**: 1 comparison
-- **3 methods**: 3 comparisons (A vs B, A vs C, B vs C)
-- **4 methods**: 6 comparisons
-- **N methods**: N×(N-1)/2 comparisons
+Baseline mode is set by adding `IsBaseline = true` to exactly one `[SailfishMethod]` in the group. The N−1 layout is generally easier to read and gives sharper q-values because the FDR adjustment is over fewer hypotheses.
 
 ### Adaptive Precision Formatting
 
@@ -185,12 +189,10 @@ Use meaningful test class and method names since they appear in the markdown:
 [WriteToMarkdown]
 public class DatabaseQueryPerformance  // Clear class name
 {
-    [SailfishMethod]
-    [SailfishComparison("QueryTypes")]
+    [SailfishMethod(ComparisonGroup = "QueryTypes", IsBaseline = true)]
     public void SimpleSelect() { }      // Descriptive method name
 
-    [SailfishMethod]
-    [SailfishComparison("QueryTypes")]
+    [SailfishMethod(ComparisonGroup = "QueryTypes")]
     public void ComplexJoin() { }       // Descriptive method name
 }
 ```
@@ -200,9 +202,9 @@ public class DatabaseQueryPerformance  // Clear class name
 Choose comparison group names that clearly indicate what's being compared:
 
 ```csharp
-[SailfishComparison("DatabaseQueries")]     // Good
-[SailfishComparison("SerializationMethods")] // Good
-[SailfishComparison("Group1")]               // Poor
+[SailfishMethod(ComparisonGroup = "DatabaseQueries")]      // Good
+[SailfishMethod(ComparisonGroup = "SerializationMethods")] // Good
+[SailfishMethod(ComparisonGroup = "Group1")]               // Poor
 ```
 
 ### 3. Configure Output Directory
@@ -250,9 +252,9 @@ If markdown files are empty or missing:
 
 If method comparisons are missing from the markdown:
 
-1. **Verify group names**: Ensure methods use identical group names (case-sensitive)
-2. **Check method count**: Need at least 2 methods in a group for comparisons
-3. **Confirm attributes**: Both `[SailfishMethod]` and `[SailfishComparison]` required
+1. **Verify group names**: Ensure methods use identical `ComparisonGroup` values (case-sensitive)
+2. **Check method count**: Need at least 2 methods in a group for comparisons (SF1302 warns at build time)
+3. **At most one baseline**: SF1301 errors at build time if more than one method in a group sets `IsBaseline = true`
 
 ### GitHub Rendering Issues
 

--- a/site/src/pages/docs/1/method-comparisons.md
+++ b/site/src/pages/docs/1/method-comparisons.md
@@ -316,21 +316,24 @@ public void Method1()
 }
 ```
 
-## Configuring SailDiff (alpha, test type)
+## Configuring the significance threshold
 
-Method comparisons share the same statistical machinery as historical SailDiff comparisons. You can configure the significance threshold and test type via `.sailfish.json`:
+You can configure the alpha used by the method-comparison output via `.sailfish.json`:
 
 ```json
 {
   "SailDiffSettings": {
-    "TestType": "WilcoxonRankSumTest",
     "Alpha": 0.05,
     "Disabled": false
   }
 }
 ```
 
-The Improved / Slower / Similar labels are decided against the configured `Alpha` after the BH-FDR adjustment. The N×N matrix and the baseline-vs-contender table both use that same `Alpha` for per-pair significance, and the reported ratio confidence intervals follow the matching `1 − Alpha` level — no hardcoded `0.05` anywhere in the formatters.
+The Improved / Slower / Similar labels are decided against the configured `Alpha` after the BH-FDR adjustment. The N×N matrix and the baseline-vs-contender table both use that same `Alpha` for per-pair significance, and the reported ratio confidence intervals follow the matching `1 − Alpha` level — no hardcoded `0.05` in the formatters.
+
+{% callout title="TestType is not honoured here" type="note" %}
+`SailDiffSettings.TestType` controls the test used by [historical SailDiff comparisons](/docs/2/saildiff), not method comparisons. The method-comparison handlers always compute p-values from a Welch-style log-ratio approximation (Student-t CDF on the log-scale standard error), regardless of what `TestType` is set to in `.sailfish.json`. Only `Alpha` is read by these output paths.
+{% /callout %}
 
 ## Troubleshooting
 

--- a/site/src/pages/docs/1/method-comparisons.md
+++ b/site/src/pages/docs/1/method-comparisons.md
@@ -4,503 +4,358 @@ title: Method Comparisons
 
 ## Introduction
 
-**Method Comparisons** enable you to automatically compare the performance of multiple methods within a single test run. This powerful feature uses the `[SailfishComparison]` attribute to group related methods and automatically generates statistical comparisons between them using SailDiff.
+**Method Comparisons** let you put two or more methods in a named *comparison group* on a single test class, then automatically have Sailfish report how they perform relative to each other. Comparison is configured directly on `[SailfishMethod]` via two properties:
 
-When you mark methods with the same comparison group name, Sailfish will:
-- Execute all methods in the group
-- Perform N×N statistical comparisons between all methods
-- Display perspective-based results for each method in the test output
-- Show statistical significance with intuitive color coding
-- Generate consolidated comparison data in markdown and CSV outputs (when using `[WriteToMarkdown]` or `[WriteToCsv]` attributes)
+- `ComparisonGroup = "..."` opts a method into a named group. Two or more methods in the same group on the same class are compared.
+- `IsBaseline = true` (at most one method per group) switches the group from the default N×N matrix to N−1 baseline-vs-contender rows.
+
+When a group has at least two methods, Sailfish:
+- Computes a ratio (and a 95% confidence interval on that ratio) between methods.
+- Adjusts p-values across the group with the Benjamini–Hochberg FDR procedure and reports a q-value.
+- Labels each comparison **Improved**, **Slower**, or **Similar** at α = 0.05.
+- Emits the comparison to the consolidated session Markdown and CSV when `[WriteToMarkdown]` / `[WriteToCsv]` are present on the class.
 
 ## Basic Usage
 
-### Simple Comparison
+### Default — N×N matrix (no baseline)
 
-Mark methods with the `[SailfishComparison]` attribute using the same group name:
+When you don't nominate a baseline, every pair of methods in the group is compared and the markdown shows a full N×N matrix.
 
 ```csharp
-[WriteToMarkdown]  // Optional: Generate consolidated markdown output
-[WriteToCsv]       // Optional: Generate consolidated CSV output
+[WriteToMarkdown]
+[WriteToCsv]
 [Sailfish(SampleSize = 100)]
-public class AlgorithmComparison
+public class SumComparison
 {
     private List<int> _data = new();
 
     [SailfishGlobalSetup]
-    public void Setup()
-    {
-        _data = Enumerable.Range(1, 1000).ToList();
-    }
+    public void Setup() => _data = Enumerable.Range(0, 1000).ToList();
 
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
-    public void BubbleSort()
-    {
-        var array = _data.ToArray();
-        // Bubble sort implementation
-        for (int i = 0; i < array.Length - 1; i++)
-        {
-            for (int j = 0; j < array.Length - i - 1; j++)
-            {
-                if (array[j] > array[j + 1])
-                {
-                    (array[j], array[j + 1]) = (array[j + 1], array[j]);
-                }
-            }
-        }
-    }
-
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
-    public void QuickSort()
-    {
-        var array = _data.ToArray();
-        Array.Sort(array); // Built-in optimized sort
-    }
-
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithms")]
-    public void LinqSort()
-    {
-        var sorted = _data.OrderBy(x => x).ToArray();
-    }
-}
-```
-
-### Multiple Comparison Groups
-
-You can have multiple comparison groups in the same test class:
-
-```csharp
-[WriteToMarkdown]  // Generate consolidated markdown with comparison matrices
-[WriteToCsv]       // Generate consolidated CSV with comparison data
-[Sailfish(SampleSize = 50)]
-public class MultipleComparisons
-{
-    // Group 1: String operations
-    [SailfishMethod]
-    [SailfishComparison("StringOperations")]
-    public void StringConcat() { /* implementation */ }
-
-    [SailfishMethod]
-    [SailfishComparison("StringOperations")]
-    public void StringBuilder() { /* implementation */ }
-
-    // Group 2: Collection operations
-    [SailfishMethod]
-    [SailfishComparison("Collections")]
-    public void ListIteration() { /* implementation */ }
-
-    [SailfishMethod]
-    [SailfishComparison("Collections")]
-    public void ArrayIteration() { /* implementation */ }
-
-    // Regular method (not part of any comparison)
-    [SailfishMethod]
-    public void RegularMethod() { /* implementation */ }
-}
-```
-
-## Output Formats
-
-Method comparison results are available in multiple formats:
-
-### 1. Test Output Window (IDE/Console)
-
-Real-time perspective-based results shown during test execution. Each method displays its comparison results from its own perspective.
-
-### 2. Consolidated Markdown Files
-
-When using `[WriteToMarkdown]`, generates session-based markdown files containing:
-- Session metadata and summary statistics
-- Individual test results for all methods
-- N×N comparison matrices for each comparison group
-- Statistical analysis with ratio confidence intervals and BH‑FDR–adjusted q‑values; labeled as Improved/Similar/Slower
-
-**Example filename**: `TestSession_abc12345_Results_20250803_103000.md`
-
-{% callout title="See also" type="note" %}
-Format details and troubleshooting:
-- [Markdown Output](/docs/1/markdown-output)
-- [CSV Output](/docs/1/csv-output)
-{% /callout %}
-{% callout title="Label terminology" type="note" %}
-Consolidated outputs (Markdown/CSV) use Improved/Similar/Slower labels and include q-values (BH‑FDR) and 95% ratio CIs. Legacy per‑method IDE output may still show IMPROVED/REGRESSED/NO CHANGE; both refer to the same underlying statistics.
-{% /callout %}
-
-
-### 3. Consolidated CSV Files
-
-When using `[WriteToCsv]`, generates session-based CSV files containing:
-- Session metadata (session ID, timestamp, test counts)
-- Individual test results (all performance metrics)
-- Method comparison data (performance ratios, change descriptions)
-- Excel-friendly format with clear section separation
-
-**Example filename**: `TestSession_abc12345_Results_20250803_103000.csv`
-
-{% callout title="CSV format details" type="note" %}
-See full format and complete examples here: [CSV Output](/docs/1/csv-output)
-{% /callout %}
-
-## Understanding the Results
-
-### Individual Test Results
-
-Each method first displays its individual performance statistics:
-
-```
-MethodComparisonExample.SortWithQuickSort
-
-Descriptive Statistics
-----------------------
-| Stat   |  Time (ms) |
-| ---    | ---        |
-| Mean   |     0.0053 |
-| Median |      0.005 |
-| StdDev |     0.0005 |
-| Min    |     0.0047 |
-| Max    |     0.0099 |
-
-Outliers Removed (2)
---------------------
-2 Upper Outliers: 0.0091, 0.0099
-
-Distribution (ms)
------------------
-0.0057, 0.0048, 0.0058, 0.0058, 0.0057, 0.0047, 0.0048, 0.0047...
-```
-
-### Performance Comparison Output
-
-After individual statistics, methods show their comparison results in a comprehensive format:
-
-```
-📊 PERFORMANCE COMPARISON
-Group: SortingAlgorithm
-==================================================
-
-🟢 IMPACT: SortWithQuickSort() vs SortWithBubbleSort() - 99.7% faster (IMPROVED)
-   P-Value: 0.000000 | Mean: 1.730ms → 0.005ms
-
-📋 DETAILED STATISTICS:
-
-| Metric | Primary Method | Compared Method | Change | P-Value  |
-| ------ | -------------- | --------------- | ------ | -------- |
-| Mean   | 1.730ms        | 0.005ms         | -99.7% | 0.000000 |
-| Median | 1.666ms        | 0.005ms         | -99.7% | -        |
-
-Statistical Test: T-Test
-Alpha Level: 0.05
-Sample Size: 100
-Outliers Removed: 7
-
-==================================================
-```
-
-### Multiple Comparisons
-
-When a method belongs to a comparison group with multiple methods, it shows comparisons against each other method:
-
-```
-📊 PERFORMANCE COMPARISON
-Group: SortingAlgorithm
-==================================================
-
-🟢 IMPACT: SortWithQuickSort() vs SortWithBubbleSort() - 99.7% faster (IMPROVED)
-   P-Value: 0.000000 | Mean: 1.730ms → 0.005ms
-
-==================================================
-
-📊 PERFORMANCE COMPARISON
-Group: SortingAlgorithm
-==================================================
-
-🟢 IMPACT: SortWithQuickSort() vs SortWithOtherSort() - 100.0% faster (IMPROVED)
-   P-Value: 0.000000 | Mean: 15.622ms → 0.005ms
-
-==================================================
-```
-
-### Understanding the Output Format
-
-**Header Section:**
-- **Group**: Shows the comparison group name
-- **IMPACT**: Primary comparison result with color coding and percentage change
-- **P-Value**: Statistical significance value
-- **Mean Transition**: Shows the performance change (before → after)
-
-**Detailed Statistics Table:**
-- **Metric**: Statistical measure (Mean, Median)
-- **Primary Method**: The current method being analyzed
-- **Compared Method**: The method being compared against
-- **Change**: Percentage change (negative = improvement, positive = regression)
-- **P-Value**: Statistical significance for each metric
-
-**Test Information:**
-- **Statistical Test**: Type of test used (T-Test, Wilcoxon, etc.)
-- **Alpha Level**: Significance threshold (typically 0.05)
-- **Sample Size**: Number of iterations per method
-- **Outliers Removed**: Number of outliers detected and excluded
-
-### Color Coding
-
-Results use intuitive color coding based on statistical significance:
-
-- 🟢 **Green**: Statistically significantly faster (IMPROVED)
-- 🔴 **Red**: Statistically significantly slower (REGRESSED)
-- ⚪ **Gray/White**: No statistically significant difference (NO CHANGE)
-
-### Statistical Significance
-
-The framework uses SailDiff's statistical analysis to determine significance:
-
-- **IMPROVED**: Method is statistically significantly faster than the compared method
-- **REGRESSED**: Method is statistically significantly slower than the compared method
-- **NO CHANGE**: No statistically significant difference detected (p-value ≥ alpha level)
-
-## Advanced Features
-
-### N×N Comparisons
-
-When you have multiple methods in a comparison group, the framework automatically performs N×N comparisons:
-
-- **2 methods**: Each method gets 1 comparison
-- **3 methods**: Each method gets 2 comparisons
-- **4 methods**: Each method gets 3 comparisons
-- **N methods**: Each method gets (N-1) comparisons
-
-This gives you a complete comparison matrix showing how each method performs relative to all others.
-
-### Integration with SailDiff
-
-Method comparisons are powered by SailDiff, which provides:
-
-- Statistical hypothesis testing
-- Outlier detection and removal
-- Multiple statistical test options (T-Test, Wilcoxon, etc.)
-- Configurable significance levels
-
-You can configure SailDiff behavior using `.sailfish.json`:
-
-```json
-{
-  "SailDiffSettings": {
-    "TestType": "Test",
-    "Alpha": 0.001,
-    "Disabled": false
-  }
-}
-```
-
-### Attribute properties
-
-`[SailfishComparison]` has two optional named arguments beyond the required group name:
-
-- **`DisplayName`** — overrides the method name in comparison output. Useful when you want a friendly label without renaming the C# method.
-- **`Disabled`** — when `true`, the method is excluded from comparisons even though other methods in the group are present. Lets you toggle a comparator off without removing the attribute.
-
-```csharp
-[SailfishMethod]
-[SailfishComparison("SortingAlgorithms", DisplayName = "Built-in Array.Sort")]
-public void QuickSort() { /* ... */ }
-
-[SailfishMethod]
-[SailfishComparison("SortingAlgorithms", Disabled = true)]
-public void OldExperiment() { /* ... */ }
-```
-
-### Failure handling
-
-If a `[SailfishComparison]` method throws, Sailfish publishes a normal failed `TestOutcome` for that case immediately and **excludes it from the batch**:
-
-- The exception surfaces in the IDE Test Explorer as a failure, with the stack trace attached.
-- Sibling comparators are not blocked — the comparison batch readiness check only counts surviving members.
-- The N×N matrix is computed across the surviving members. If fewer than two members survive, no matrix is produced (and a short note is emitted to the consolidated outputs).
-
-This is why a partially-failing group still reports useful comparisons rather than silently hanging.
-
-## Best Practices
-
-### 1. Use Meaningful Group Names
-
-Choose descriptive names that clearly indicate what's being compared:
-
-```csharp
-[SailfishComparison("DatabaseQueries")]     // Good
-[SailfishComparison("SerializationMethods")] // Good
-[SailfishComparison("Group1")]               // Poor
-```
-
-### 2. Ensure Fair Comparisons
-
-Make sure compared methods are testing equivalent functionality:
-
-```csharp
-// Good: All methods sort the same data
-[SailfishComparison("SortingAlgorithms")]
-public void BubbleSort() { /* sorts _data */ }
-
-[SailfishComparison("SortingAlgorithms")]
-public void QuickSort() { /* sorts _data */ }
-
-// Poor: Methods do different things
-[SailfishComparison("Mixed")]
-public void SortData() { /* sorts data */ }
-
-[SailfishComparison("Mixed")]
-public void SearchData() { /* searches data - not comparable! */ }
-```
-
-### 3. Use Adequate Sample Sizes
-
-Ensure your sample size is large enough for meaningful statistical analysis:
-
-
-{% callout title="Tip: Adaptive Sampling" type="note" %}
-Instead of guessing a fixed `SampleSize`, enable [Adaptive Sampling](/docs/1/adaptive-sampling). Sailfish stops when results are statistically stable (using coefficient of variation and confidence interval width thresholds), often reducing runtime while preserving rigor. Opt in per class via `[Sailfish]` or set a global policy with `RunSettingsBuilder`.
-{% /callout %}
-
-```csharp
-[Sailfish(SampleSize = 100)] // Good for most comparisons
-public class PerformanceComparison
-{
-    // Methods with small performance differences need larger samples
-    // Methods with large performance differences can use smaller samples
-}
-```
-
-### 4. Consider Test Isolation
-
-Each method should be independent and not affect others:
-
-```csharp
-[SailfishGlobalSetup]
-public void Setup()
-{
-    // Initialize shared data once
-    _data = GenerateTestData();
-}
-
-[SailfishMethod]
-[SailfishComparison("Algorithms")]
-public void Method1()
-{
-    var localCopy = _data.ToArray(); // Work with copies
-    // Process localCopy...
-}
-```
-
-## Troubleshooting
-
-### No Comparison Results Shown
-
-If you don't see comparison results:
-
-1. **Check group names**: Ensure methods use identical group names (case-sensitive)
-2. **Verify attributes**: Both `[SailfishMethod]` and `[SailfishComparison]` are required
-3. **Minimum methods**: You need at least 2 methods in a group for comparisons
-4. **Run all tests**: Comparisons only work when running multiple tests together
-
-### Unexpected Results
-
-If results seem incorrect:
-
-1. **Check test isolation**: Ensure methods don't interfere with each other
-2. **Verify data consistency**: All methods should work with equivalent data
-3. **Review sample size**: Increase sample size for more reliable statistics
-4. **Check for outliers**: SailDiff automatically handles outliers, but extreme variations may affect results
-
-## Complete Example
-
-Here's a comprehensive example demonstrating all method comparison features:
-
-```csharp
-[WriteToMarkdown]  // Generate consolidated markdown output
-[WriteToCsv]       // Generate consolidated CSV output
-[Sailfish(DisableOverheadEstimation = true, SampleSize = 100)]
-public class MethodComparisonExample
-{
-    private readonly List<int> _data = new();
-
-    [SailfishGlobalSetup]
-    public void Setup()
-    {
-        // Initialize test data
-        _data.Clear();
-        for (int i = 0; i < 1000; i++)
-        {
-            _data.Add(i);
-        }
-    }
-
-    // Group 1: Sum calculation algorithms
-    [SailfishMethod]
-    [SailfishComparison("SumCalculation")]
+    [SailfishMethod(ComparisonGroup = "SumCalculation")]
     public void CalculateSumWithLinq()
     {
         var sum = _data.Sum();
-        Thread.Sleep(1); // Simulate work
     }
 
-    [SailfishMethod]
-    [SailfishComparison("SumCalculation")]
+    [SailfishMethod(ComparisonGroup = "SumCalculation")]
     public void CalculateSumWithLoop()
     {
         var sum = 0;
-        foreach (var item in _data)
-        {
-            sum += item;
-        }
-        Thread.Sleep(1); // Simulate work
+        for (var i = 0; i < _data.Count; i++) sum += _data[i];
     }
+}
+```
 
-    // Group 2: Sorting algorithms
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
-    public void SortWithBubbleSort()
-    {
-        var array = _data.ToArray();
-        // Bubble sort implementation
-        for (int i = 0; i < array.Length - 1; i++)
-        {
-            for (int j = 0; j < array.Length - i - 1; j++)
-            {
-                if (array[j] > array[j + 1])
-                {
-                    (array[j], array[j + 1]) = (array[j + 1], array[j]);
-                }
-            }
-        }
-    }
+With a third method in the group, you'd get three pairwise comparisons; with N methods, N×(N−1)/2.
 
-    [SailfishMethod]
-    [SailfishComparison("SortingAlgorithm")]
+### Baseline mode — N−1 comparisons
+
+When exactly one method in the group sets `IsBaseline = true`, the output collapses to N−1 rows: each contender is reported as a ratio against the baseline.
+
+```csharp
+[WriteToMarkdown]
+[WriteToCsv]
+[Sailfish(SampleSize = 100)]
+public class SortingComparison
+{
+    private List<int> _data = new();
+
+    [SailfishGlobalSetup]
+    public void Setup() => _data = Enumerable.Range(0, 1000).ToList();
+
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm", IsBaseline = true)]
     public void SortWithQuickSort()
     {
         var array = _data.ToArray();
         Array.Sort(array);
     }
 
-    // Regular method (not part of any comparison)
-    [SailfishMethod]
-    public void RegularMethod()
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
+    public void SortWithBubbleSort()
     {
-        Thread.Sleep(1);
+        var array = _data.ToArray();
+        for (var i = 0; i < array.Length - 1; i++)
+            for (var j = 0; j < array.Length - i - 1; j++)
+                if (array[j] > array[j + 1])
+                    (array[j], array[j + 1]) = (array[j + 1], array[j]);
+    }
+
+    [SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
+    public void SortWithOtherSort()
+    {
+        Thread.Sleep(10);
     }
 }
 ```
 
-## Repository Examples
+Prefer baseline mode when there's an obvious reference implementation (a current production algorithm, a "known-good" library call, etc.) — the output is shorter, easier to read at a glance, and FDR-adjusts fewer tests so individual q-values are sharper.
 
-See the complete working examples in the Sailfish repository:
-- `source/PerformanceTests/ExamplePerformanceTests/MethodComparisonExample.cs`
+### Mixing comparison and non-comparison methods
 
-This example demonstrates:
-- Multiple comparison groups in a single class
-- N×N comparisons with 2+ methods per group
-- Integration with output attributes (`[WriteToMarkdown]`, `[WriteToCsv]`)
-- Session-based consolidation across test runs
-- Best practices for test setup and isolation
-- Mixed usage (comparison methods + regular methods)
+A test class can mix methods with and without `ComparisonGroup`. Methods without it run as ordinary Sailfish methods and never appear in any comparison section.
+
+```csharp
+[SailfishMethod(ComparisonGroup = "SortingAlgorithm", IsBaseline = true)]
+public void SortWithQuickSort() { /* ... */ }
+
+[SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
+public void SortWithBubbleSort() { /* ... */ }
+
+[SailfishMethod]
+public void RegularMethod() { /* never compared */ }
+```
+
+### Multiple groups in one class
+
+A class can declare any number of independent groups:
+
+```csharp
+[SailfishMethod(ComparisonGroup = "Serialization", IsBaseline = true)]
+public void SerializeWithSystemTextJson() { /* ... */ }
+
+[SailfishMethod(ComparisonGroup = "Serialization")]
+public void SerializeWithNewtonsoft() { /* ... */ }
+
+[SailfishMethod(ComparisonGroup = "Collections")]
+public void ListIteration() { /* ... */ }
+
+[SailfishMethod(ComparisonGroup = "Collections")]
+public void ArrayIteration() { /* ... */ }
+```
+
+Each group produces its own section in the consolidated outputs.
+
+## Rules per group
+
+For each `(class, ComparisonGroup)` pair, the number of methods marked `IsBaseline = true` determines the output:
+
+| Baselines in the group | Behavior |
+| --- | --- |
+| **0** | N×N matrix — every pair compared. |
+| **1** | N−1 baseline-vs-contender rows. |
+| **2+** | Build error (SF1301). Runtime falls back to N×N and emits a warning. |
+
+A group with only one method produces no comparison (the SF1302 analyzer warns at build time).
+
+{% callout title="Per-class scoping" type="note" %}
+Comparison groups are scoped **per test class**, not across the whole session. Two different test classes can each define `ComparisonGroup = "Sort"` and they will be reported as independent groups. The consolidated Markdown header includes the class name to disambiguate: `## 🔬 Comparison Group: Sort (ClassNameA)` and `## 🔬 Comparison Group: Sort (ClassNameB)`. The CSV row's `ComparisonGroup` column emits just the group name — the class is identifiable from the surrounding row context.
+{% /callout %}
+
+## Build-time checks (analyzers)
+
+The Sailfish analyzers catch the most common mistakes at compile time:
+
+| ID | Severity | Rule |
+| --- | --- | --- |
+| **SF1300** | Error | `IsBaseline = true` requires `ComparisonGroup` to be set on the same `[SailfishMethod]` attribute. A baseline outside a group is meaningless. |
+| **SF1301** | Error | At most one method per `(class, ComparisonGroup)` may set `IsBaseline = true`. Two or more is ambiguous; the runtime falls back to N×N and logs a warning if you suppress this. |
+| **SF1302** | Warning | A `ComparisonGroup` with fewer than two methods produces no output. Either add another method or remove `ComparisonGroup`. |
+
+## Output Formats
+
+Method comparison results are emitted in three places:
+
+### 1. Test output window (IDE / Console)
+
+Each method's individual descriptive statistics (mean, median, stddev, outliers) appear in the IDE Test Output window or console as it normally would for any Sailfish method. The pairwise / baseline comparison tables live in the consolidated session files.
+
+### 2. Consolidated Markdown (`[WriteToMarkdown]`)
+
+A single Markdown file per session containing:
+- Session header (session ID, timestamp, test counts).
+- Optional Environment Health and Reproducibility Summary sections.
+- One `## 🔬 Comparison Group: GroupName (ClassName)` section per group, containing either a baseline table (when one method is the baseline) or an N×N matrix.
+- A `### Detailed Results` table with mean / median / sample size / status for each member.
+- A `## 📊 Individual Test Results` section for any method that wasn't in a comparison group.
+
+**Example filename**: `TestSession_abc12345_Results_20250803_103000.md`
+
+### 3. Consolidated CSV (`[WriteToCsv]`)
+
+A single CSV file per session containing:
+- Session metadata.
+- Individual test results (all methods, with their `ComparisonGroup` column populated when applicable).
+- A `# Method Comparisons` section with one row per comparison — N−1 rows in baseline mode, N×(N−1)/2 rows in N×N mode.
+
+**Example filename**: `TestSession_abc12345_Results_20250803_103000.csv`
+
+{% callout title="See also" type="note" %}
+Format details and the exact column / section layout:
+- [Markdown Output](/docs/1/markdown-output)
+- [CSV Output](/docs/1/csv-output)
+{% /callout %}
+
+## Understanding the Results
+
+### Baseline mode — example output
+
+For the `SortingAlgorithm` group above (quicksort baseline, plus bubble sort and a slow sleeper):
+
+```markdown
+## 🔬 Comparison Group: SortingAlgorithm (SortingComparison)
+
+### Baseline Comparison
+
+### 📐 Baseline-vs-Contender (baseline = `SortWithQuickSort`, q-values via BH-FDR, α=0.05)
+| Method | Mean | Ratio vs Baseline | 95% CI | q-value | Label |
+|--------|------|-------------------|--------|---------|-------|
+| `SortWithQuickSort` _(baseline)_ | 0.005ms | — | — | — | — |
+| `SortWithBubbleSort` | 1.730ms | 346.000x | [298.412–401.213] | 1.2e-12 | Slower |
+| `SortWithOtherSort` | 15.622x | 3124.400x | [2901.011–3365.121] | 8.4e-15 | Slower |
+
+_Ratio is contender/baseline. 'Improved' means significantly faster than baseline; 'Slower' significantly slower; 'Similar' not significant after FDR._
+
+### Detailed Results
+
+| Method | Mean Time | Median Time | Sample Size | Status |
+|--------|-----------|-------------|-------------|--------|
+| SortWithQuickSort | 0.005ms | 0.005ms | 100 | ✅ Success |
+| SortWithBubbleSort | 1.730ms | 1.666ms | 100 | ✅ Success |
+| SortWithOtherSort | 15.622ms | 15.530ms | 100 | ✅ Success |
+```
+
+### N×N mode — example output
+
+For the `SumCalculation` group above (no baseline, two methods):
+
+```markdown
+## 🔬 Comparison Group: SumCalculation (SumComparison)
+
+### Performance Comparison Matrix
+
+### 🔢 NxN Comparison Matrix (q-values via BH-FDR, α=0.05)
+| Method | CalculateSumWithLinq | CalculateSumWithLoop |
+|-|-|-|
+| CalculateSumWithLinq | — | 0.987x [0.951–1.024] q=0.512 Similar |
+| CalculateSumWithLoop | 1.013x [0.977–1.052] q=0.512 Similar | — |
+
+_Cell value is ratio vs. row (col/row). CI is 95% on ratio. 'Improved' means significantly faster; 'Slower' significantly slower; 'Similar' not significant after FDR._
+```
+
+### Reading the labels
+
+- **Improved**: significantly faster than its reference (the baseline in N−1 mode, the row method in N×N mode) after the FDR adjustment.
+- **Slower**: significantly slower than its reference after the FDR adjustment.
+- **Similar**: not significant at α = 0.05 after FDR — either truly indistinguishable, or the sample size is too small to resolve a real difference.
+
+The 95% confidence interval on the ratio is the most direct measure of magnitude. If the interval doesn't cross 1.0 cleanly, the difference is meaningful at the chosen α.
+
+## Failure handling
+
+If a method in a comparison group throws, Sailfish publishes a normal failed `TestOutcome` for that case immediately and **excludes it from the comparison batch**:
+
+- The exception surfaces in the IDE Test Explorer as a failure, with the stack trace attached.
+- Sibling members are not blocked — the comparison batch readiness check only counts surviving members.
+- The comparison is computed across the survivors. If fewer than two members survive, no comparison is produced (a short note is emitted to the consolidated outputs).
+
+This is why a partially-failing group still reports useful comparisons rather than silently hanging.
+
+## Best Practices
+
+### 1. Use a baseline when one exists
+
+If there's an obvious reference (current production code, a library call, an algorithm you're trying to beat), nominate it with `IsBaseline = true`. Output is shorter and the FDR adjustment is tighter — N−1 hypotheses vs. N×(N−1)/2.
+
+### 2. Use meaningful group names
+
+```csharp
+[SailfishMethod(ComparisonGroup = "DatabaseQueries")]      // Good
+[SailfishMethod(ComparisonGroup = "SerializationMethods")] // Good
+[SailfishMethod(ComparisonGroup = "Group1")]               // Poor
+```
+
+### 3. Ensure fair comparisons
+
+Compared methods should be testing equivalent functionality:
+
+```csharp
+// Good: all members of the group do the same thing
+[SailfishMethod(ComparisonGroup = "SortingAlgorithms", IsBaseline = true)]
+public void QuickSort() { /* sorts _data */ }
+
+[SailfishMethod(ComparisonGroup = "SortingAlgorithms")]
+public void BubbleSort() { /* sorts _data */ }
+
+// Poor: the two members aren't comparable
+[SailfishMethod(ComparisonGroup = "Mixed")]
+public void SortData() { /* sorts data */ }
+
+[SailfishMethod(ComparisonGroup = "Mixed")]
+public void SearchData() { /* searches data */ }
+```
+
+### 4. Sample sizes large enough to resolve the effect you care about
+
+{% callout title="Tip: Adaptive Sampling" type="note" %}
+Instead of guessing a fixed `SampleSize`, enable [Adaptive Sampling](/docs/1/adaptive-sampling). Sailfish stops once results are statistically stable (using coefficient of variation and confidence interval width thresholds), which often shortens runtime while preserving rigor. Opt in per class via `[Sailfish]` or set a global policy with `RunSettingsBuilder`.
+{% /callout %}
+
+```csharp
+[Sailfish(SampleSize = 100)] // good default for most comparisons
+public class PerformanceComparison
+{
+    // Methods with small performance differences need larger samples;
+    // methods with large differences can use smaller samples.
+}
+```
+
+### 5. Isolate methods from each other
+
+Each method should be independent. Mutating shared state from one method into the next will silently bias comparisons.
+
+```csharp
+[SailfishGlobalSetup]
+public void Setup() => _data = GenerateTestData();
+
+[SailfishMethod(ComparisonGroup = "Algorithms", IsBaseline = true)]
+public void Method1()
+{
+    var local = _data.ToArray(); // work on a copy
+    // ...
+}
+```
+
+## Configuring SailDiff (alpha, test type)
+
+Method comparisons share the same statistical machinery as historical SailDiff comparisons. You can configure the significance threshold and test type via `.sailfish.json`:
+
+```json
+{
+  "SailDiffSettings": {
+    "TestType": "Test",
+    "Alpha": 0.05,
+    "Disabled": false
+  }
+}
+```
+
+The Improved / Slower / Similar labels are decided at α = 0.05 against the BH-adjusted q-value.
+
+## Troubleshooting
+
+### No comparison section in the output
+
+1. **At least two methods in the group**: a lone method in a group produces no comparison (SF1302).
+2. **Identical group names**: `ComparisonGroup` is case-sensitive — `"sort"` and `"Sort"` are different groups.
+3. **`[WriteToMarkdown]` / `[WriteToCsv]` on the class**: the consolidated session files are only generated when one of those attributes is present.
+4. **Run more than one method**: comparison output only appears when at least two members of the group execute in the same session.
+
+### SF1301 error: "Only one IsBaseline per ComparisonGroup is allowed"
+
+Two or more methods in the same group set `IsBaseline = true`. Pick one. If you really want N×N output, remove `IsBaseline` from all of them.
+
+### SF1300 error: "IsBaseline=true requires a ComparisonGroup"
+
+You set `IsBaseline = true` but forgot `ComparisonGroup`. Either add the group name or remove `IsBaseline`.
+
+### Unexpected results
+
+1. **Check test isolation**: ensure methods don't interfere with each other (shared mutable state, leftover side-effects).
+2. **Verify data consistency**: all methods should work with equivalent input.
+3. **Increase sample size**: small differences need more samples to resolve.
+4. **Check outliers**: extreme noise can dominate small effects even after outlier filtering.
+
+## Complete example
+
+See the runnable example in the repository: [`source/PerformanceTests/ExamplePerformanceTests/MethodComparisonExample.cs`](https://github.com/paulegradie/Sailfish/blob/main/source/PerformanceTests/ExamplePerformanceTests/MethodComparisonExample.cs). It exercises both modes — a no-baseline `SumCalculation` group (N×N) and a `SortingAlgorithm` group with `SortWithQuickSort` as the baseline (N−1) — alongside ordinary non-comparison methods on the same class.

--- a/site/src/pages/docs/1/output-attributes.md
+++ b/site/src/pages/docs/1/output-attributes.md
@@ -13,16 +13,14 @@ The `[WriteToMarkdown]` attribute generates consolidated markdown files containi
 [Sailfish]
 public class PerformanceTest
 {
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
-    public void BubbleSort()
+    [SailfishMethod(ComparisonGroup = "Algorithms", IsBaseline = true)]
+    public void QuickSort()
     {
         // Implementation
     }
 
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
-    public void QuickSort()
+    [SailfishMethod(ComparisonGroup = "Algorithms")]
+    public void BubbleSort()
     {
         // Implementation
     }
@@ -38,8 +36,9 @@ public class PerformanceTest
 ### Markdown Output Features
 
 - **Session-based consolidation**: Single markdown file per test session
-- **Per-group sections**: NxN comparison matrix and a five-column detailed results table per comparison group
-- **Statistical analysis**: BH-FDR q-values and 95% ratio confidence intervals in the matrix
+- **Per-group sections**: Either a baseline-vs-contender table (when one method is the baseline) or an N×N comparison matrix (when none is), followed by a five-column detailed results table per comparison group
+- **Per-class scoping**: Section header is `## 🔬 Comparison Group: GroupName (ClassName)` so same-named groups in different classes are reported separately
+- **Statistical analysis**: BH-FDR q-values and 95% ratio confidence intervals
 - **Environment & reproducibility headers**: Optional `🏥 Environment Health Check` and `🔁 Reproducibility Summary` sections near the top when enabled
 
 CI95/CI99 margins of error are not embedded in the consolidated session markdown — they're available in the per-class tracking CSV and in the Reproducibility Manifest.
@@ -62,16 +61,14 @@ The `[WriteToCsv]` attribute generates consolidated CSV files containing both in
 [Sailfish]
 public class PerformanceTest
 {
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
-    public void BubbleSort()
+    [SailfishMethod(ComparisonGroup = "Algorithms", IsBaseline = true)]
+    public void QuickSort()
     {
         // Implementation
     }
 
-    [SailfishMethod]
-    [SailfishComparison("Algorithms")]
-    public void QuickSort()
+    [SailfishMethod(ComparisonGroup = "Algorithms")]
+    public void BubbleSort()
     {
         // Implementation
     }
@@ -86,7 +83,8 @@ public class PerformanceTest
 
 ### CSV Output Features
 
-- **Two-section format**: Individual test results and pairwise method comparisons
+- **Two-section format**: Individual test results and method comparison rows
+- **Baseline-aware row count**: N−1 rows in baseline mode, N×(N−1)/2 rows in N×N mode
 - **Excel-compatible**: Easy to import and analyze in spreadsheet applications
 - **Session-based consolidation**: Single CSV file per test session
 - **Numeric ratios with confidence intervals and q-values**: Comparison rows include the BH-FDR q-value and 95% ratio CI bounds
@@ -104,8 +102,10 @@ PerformanceTest,RegularMethod,1.000,1.000,0.100,100,,Success
 
 # Method Comparisons
 ComparisonGroup,Method1,Method2,Mean1,Mean2,Ratio,CI95_Lower,CI95_Upper,q_value,Label,ChangeDescription
-Algorithms,BubbleSort,QuickSort,45.200,2.100,0.046,0.040,0.054,1.2e-12,Improved,Improved
+Algorithms,QuickSort,BubbleSort,2.100,45.200,21.524,18.301,24.917,1.2e-12,Slower,Regressed
 ```
+
+In this example QuickSort is the baseline, so Method1 is always QuickSort and one row appears per contender. Ratio = Mean2 / Mean1, so values > 1 indicate Method2 is slower than the baseline.
 
 ## Combined Usage
 
@@ -147,9 +147,9 @@ public class SerializationBenchmarks { }
 Use meaningful comparison group names that clearly indicate what's being compared:
 
 ```csharp
-[SailfishComparison("DatabaseQueries")]     // Good
-[SailfishComparison("SerializationMethods")] // Good
-[SailfishComparison("Group1")]               // Poor
+[SailfishMethod(ComparisonGroup = "DatabaseQueries")]      // Good
+[SailfishMethod(ComparisonGroup = "SerializationMethods")] // Good
+[SailfishMethod(ComparisonGroup = "Group1")]               // Poor
 ```
 
 ### 3. Consider Output Directory

--- a/site/src/pages/docs/2/saildiff.md
+++ b/site/src/pages/docs/2/saildiff.md
@@ -9,7 +9,7 @@ title: SailDiff
 SailDiff operates in two main modes:
 
 1. **Historical Comparisons**: Compare current test runs against previously saved tracking data
-2. **Method Comparisons**: Compare multiple methods within a single test run using the `[SailfishComparison]` attribute
+2. **Method Comparisons**: Compare multiple methods within a single test run via `SailfishMethod(ComparisonGroup = "...")`
 
 When enabled, SailDiff will produce various measurements describing the differences between test runs or methods. Results are presented via multiple output formats:
 
@@ -19,13 +19,13 @@ When enabled, SailDiff will produce various measurements describing the differen
 
 ### Method Comparisons
 
-For real-time method comparisons within a single test run, see the [Method Comparisons](/docs/1/method-comparisons) documentation. This feature allows you to compare multiple algorithms or implementations automatically using the `[SailfishComparison("GroupName")]` attribute.
+For real-time method comparisons within a single test run, see the [Method Comparisons](/docs/1/method-comparisons) documentation. This feature allows you to compare multiple algorithms or implementations automatically by setting `ComparisonGroup = "..."` on `[SailfishMethod]` (and optionally `IsBaseline = true` on one method per group).
 
 Method comparisons generate:
-- **N×N comparison matrices**: Every method compared against every other method in the same group
-- **Statistical significance testing**: P-values and confidence intervals
-- **Performance ratios**: Clear "X times faster/slower" descriptions
-- **Consolidated outputs**: Both markdown and CSV formats available with `[WriteToMarkdown]` and `[WriteToCsv]` attributes
+- **N×N or N−1 layouts**: every pair compared (no baseline) or each contender against the chosen baseline
+- **Statistical significance testing**: BH-FDR–adjusted q-values and 95% confidence intervals on the ratio
+- **Improved / Slower / Similar labels** at α = 0.05
+- **Consolidated outputs**: both markdown and CSV formats with `[WriteToMarkdown]` and `[WriteToCsv]`
 
 ## Enabling / Configuring SailDiff
 

--- a/site/src/pages/docs/4/releasenotes.md
+++ b/site/src/pages/docs/4/releasenotes.md
@@ -16,8 +16,8 @@ Sailfish, `Sailfish.TestAdapter`, and `Sailfish.Analyzers` now target `net9.0` a
 `[SailfishMethodSetup(nameof(Foo), nameof(Bar), RunOnce = true)]` invokes a setup/teardown at most once per executor run, even when multiple `MethodNames` are listed. [Learn more →](/docs/1/sailfish-test-lifecycle)
 {% /callout %}
 
-{% callout title="Fix: SailfishComparison failure handling" type="note" %}
-Failed `[SailfishComparison]` members now publish `TestOutcome.Failed` (no more silent `TestOutcome.None`) and don't block sibling members from completing the comparison batch. [Learn more →](/docs/1/method-comparisons)
+{% callout title="Fix: Method-comparison failure handling" type="note" %}
+Failed members of a comparison group now publish `TestOutcome.Failed` (no more silent `TestOutcome.None`) and don't block sibling members from completing the comparison batch. [Learn more →](/docs/1/method-comparisons)
 {% /callout %}
 
 {% callout title="Feature highlight: Timer Calibration + Jitter Score" type="note" %}

--- a/source/PerformanceTests/README.md
+++ b/source/PerformanceTests/README.md
@@ -19,7 +19,7 @@ Welcome to the **Sailfish Performance Testing Examples** project! This comprehen
 This project showcases **Sailfish**, a powerful .NET performance testing framework that enables:
 
 - **Precise Performance Measurement** with statistical analysis
-- **Method Comparisons** with automatic N×N algorithm comparison
+- **Method Comparisons** with automatic N×N matrix or N−1 baseline-vs-contender comparisons
 - **Parameterized Testing** with multiple variable combinations
 - **Scenario-Based Testing** for complex real-world scenarios
 - **IDE Integration** with test adapter support
@@ -111,27 +111,32 @@ public string Scenario { get; set; } = null!;
 ### ⚖️ **Method Comparisons**
 
 #### [`MethodComparisonExample.cs`](ExamplePerformanceTests/MethodComparisonExample.cs)
-**Algorithm comparison** - demonstrates the new method comparison feature that automatically compares multiple algorithms within a single test run.
+**Algorithm comparison** - demonstrates the method comparison feature, which automatically compares multiple algorithms within a single test run. Set `ComparisonGroup` on `[SailfishMethod]` to opt a method into a named group; mark one method with `IsBaseline = true` to switch from the default N×N matrix to N−1 baseline-vs-contender rows.
 
 ```csharp
-[SailfishMethod]
-[SailfishComparison("SortingAlgorithms")]
-public void BubbleSort() { /* Implementation */ }
+// Default N×N matrix — no baseline:
+[SailfishMethod(ComparisonGroup = "SumCalculation")]
+public void CalculateSumWithLinq() { /* Implementation */ }
 
-[SailfishMethod]
-[SailfishComparison("SortingAlgorithms")]
-public void QuickSort() { /* Implementation */ }
+[SailfishMethod(ComparisonGroup = "SumCalculation")]
+public void CalculateSumWithLoop() { /* Implementation */ }
 
-[SailfishMethod]
-[SailfishComparison("SortingAlgorithms")]
-public void LinqSort() { /* Implementation */ }
+// N−1 baseline-vs-contender — QuickSort is the reference:
+[SailfishMethod(ComparisonGroup = "SortingAlgorithm", IsBaseline = true)]
+public void SortWithQuickSort() { /* Implementation */ }
+
+[SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
+public void SortWithBubbleSort() { /* Implementation */ }
+
+[SailfishMethod(ComparisonGroup = "SortingAlgorithm")]
+public void SortWithOtherSort() { /* Implementation */ }
 ```
 
 **Features:**
-- **N×N Comparisons**: Each method shows how it compares to all others
-- **Statistical Analysis**: Powered by SailDiff with significance testing
-- **Perspective-Based Results**: Each method shows comparisons from its viewpoint
-- **Color-Coded Output**: 🟢 Improved, 🔴 Regressed, ⚪ No Change
+- **Two modes**: N×N matrix (no baseline) or N−1 rows against a chosen baseline
+- **Statistical analysis**: BH-FDR–adjusted q-values and 95% ratio confidence intervals
+- **Build-time checks**: SF1300/1301/1302 analyzers catch common misconfigurations
+- **Consolidated outputs**: markdown and CSV via `[WriteToMarkdown]` / `[WriteToCsv]`
 
 ### 🌐 **Real-World Integration**
 


### PR DESCRIPTION
## Summary
Updates the documentation site and READMEs to match the redesigned method-comparison API. The docs previously taught only the obsolete `[SailfishComparison]` attribute and made no mention of baselines, per-class scoping, or the new build-time analyzers.

## Origin of the API change
The new shape — `SailfishMethod(ComparisonGroup = "…", IsBaseline = true|false)` — landed in [#238](https://github.com/paulegradie/Sailfish/pull/238), which is already on `main` (commit `71dd087`). This PR therefore targets `main` directly and does not need to stack on top of #238.

## What changed in the docs
- **`site/src/pages/docs/1/method-comparisons.md`** — full rewrite. Teaches the new shape, the two output modes (N×N when no baseline, N−1 when exactly one is set), per-class scoping, and the SF1300/1301/1302 analyzers.
- **`site/src/pages/docs/0/quick-start.md`** — replaced the comparison-test code sample and updated the example output to the consolidated baseline table format.
- **`site/src/pages/docs/1/csv-output.md`** — updated code samples, corrected ratio formula (`Mean2 / Mean1`), added a pair-count table contrasting N×N vs baseline modes.
- **`site/src/pages/docs/1/markdown-output.md`** — updated samples, mentioned baseline vs N×N layouts, and noted the per-class scope of the `## 🔬 Comparison Group: GroupName (ClassName)` header.
- **`site/src/pages/docs/1/output-attributes.md`** — updated code samples and feature descriptions.
- **`site/src/pages/docs/2/saildiff.md`** — replaced the bare `[SailfishComparison]` reference with the new attribute shape.
- **`site/src/pages/docs/4/releasenotes.md`** — genericized the comparison-failure-handling callout (which referenced the obsolete attribute by name).
- **`README.md`** — updated the Features list, the Algorithm Comparisons section, and the Outputs and Reporting bullets.
- **`source/PerformanceTests/README.md`** — updated the `MethodComparisonExample` snippet and feature bullets.

## What is deliberately not documented
The obsolete `[SailfishComparison]` attribute. Its compile-time `[Obsolete]` warning is the migration guide for existing users; new documentation reflects only the supported shape.

## Test plan
- [ ] Skim the rewritten `method-comparisons.md` for accuracy against `MethodComparisonExample.cs`
- [ ] Optionally run the site locally (`cd site && npm install && npm run dev`) and load `/docs/1/method-comparisons` to verify Markdoc renders the callouts and tables
- [ ] Grep the repo for lingering `SailfishComparison` references in user-facing docs (excluded: `AnalyzerReleases.Unshipped.md`, the source attribute definition itself, and the historical specs under `AiAssistedDevSpecs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)