### PR TITLE
Docs: fix example-output tables rendering vertically

### DIFF
--- a/site/src/pages/docs/0/quick-start.md
+++ b/site/src/pages/docs/0/quick-start.md
@@ -125,14 +125,15 @@ The individual descriptive statistics for each method appear in the IDE Test Out
 
 A baseline group renders like:
 
-```markdown
+```
 ## 🔬 Comparison Group: SortingAlgorithms (AlgorithmComparison)
 
 ### 📐 Baseline-vs-Contender (baseline = `QuickSort`, q-values via BH-FDR, α=0.05)
-| Method | Mean | Ratio vs Baseline | 95% CI | q-value | Label |
-|--------|------|-------------------|--------|---------|-------|
-| `QuickSort` _(baseline)_ | 2.100ms | — | — | — | — |
-| `BubbleSort` | 45.200ms | 21.524x | [18.301–24.917] | 1.2e-12 | Slower |
+
+| Method                    | Mean      | Ratio vs Baseline | 95% CI            | q-value | Label  |
+|---------------------------|-----------|-------------------|-------------------|---------|--------|
+| `QuickSort` _(baseline)_  | 2.100ms   | —                 | —                 | —       | —      |
+| `BubbleSort`              | 45.200ms  | 21.524x           | [18.301–24.917]   | 1.2e-12 | Slower |
 ```
 
 ### Output Files

--- a/site/src/pages/docs/1/markdown-output.md
+++ b/site/src/pages/docs/1/markdown-output.md
@@ -60,11 +60,11 @@ The section then contains one of:
 
 Either layout is followed by a `### Detailed Results` table:
 
-```markdown
-| Method | Mean Time | Median Time | Sample Size | Status |
-|--------|-----------|-------------|-------------|--------|
-| QuickSort | 2.100ms | 2.000ms | 100 | ✅ Success |
-| BubbleSort | 45.200ms | 44.100ms | 100 | ✅ Success |
+```
+| Method     | Mean Time  | Median Time | Sample Size | Status     |
+|------------|------------|-------------|-------------|------------|
+| QuickSort  | 2.100ms    | 2.000ms     | 100         | ✅ Success |
+| BubbleSort | 45.200ms   | 44.100ms    | 100         | ✅ Success |
 ```
 
 **Columns:**
@@ -170,11 +170,11 @@ Sailfish uses adaptive precision to ensure readability:
 
 The session markdown includes both comparison methods (under per-group sections) and ungrouped methods (under `## 📊 Individual Test Results`). All tables share the same 5-column shape:
 
-```markdown
-| Method | Mean Time | Median Time | Sample Size | Status |
-|--------|-----------|-------------|-------------|--------|
-| RegularMethod        | 1.000ms  | 1.000ms  | 100 | ✅ Success |
-| AnotherRegularMethod | 1.100ms  | 1.000ms  | 100 | ✅ Success |
+```
+| Method               | Mean Time | Median Time | Sample Size | Status     |
+|----------------------|-----------|-------------|-------------|------------|
+| RegularMethod        | 1.000ms   | 1.000ms     | 100         | ✅ Success |
+| AnotherRegularMethod | 1.100ms   | 1.000ms     | 100         | ✅ Success |
 ```
 
 For per-test CI95/CI99 margins of error or standard deviation, consult the per-class tracking CSV or the [Reproducibility Manifest](/docs/1/reproducibility-manifest).

--- a/site/src/pages/docs/1/method-comparisons.md
+++ b/site/src/pages/docs/1/method-comparisons.md
@@ -192,43 +192,45 @@ Format details and the exact column / section layout:
 
 For the `SortingAlgorithm` group above (quicksort baseline, plus bubble sort and a slow sleeper):
 
-```markdown
+```
 ## 🔬 Comparison Group: SortingAlgorithm (SortingComparison)
 
 ### Baseline Comparison
 
 ### 📐 Baseline-vs-Contender (baseline = `SortWithQuickSort`, q-values via BH-FDR, α=0.05)
-| Method | Mean | Ratio vs Baseline | 95% CI | q-value | Label |
-|--------|------|-------------------|--------|---------|-------|
-| `SortWithQuickSort` _(baseline)_ | 0.005ms | — | — | — | — |
-| `SortWithBubbleSort` | 1.730ms | 346.000x | [298.412–401.213] | 1.2e-12 | Slower |
-| `SortWithOtherSort` | 15.622x | 3124.400x | [2901.011–3365.121] | 8.4e-15 | Slower |
+
+| Method                            | Mean     | Ratio vs Baseline | 95% CI                | q-value | Label  |
+|-----------------------------------|----------|-------------------|-----------------------|---------|--------|
+| `SortWithQuickSort` _(baseline)_  | 0.005ms  | —                 | —                     | —       | —      |
+| `SortWithBubbleSort`              | 1.730ms  | 346.000x          | [298.412–401.213]     | 1.2e-12 | Slower |
+| `SortWithOtherSort`               | 15.622ms | 3124.400x         | [2901.011–3365.121]   | 8.4e-15 | Slower |
 
 _Ratio is contender/baseline. 'Improved' means significantly faster than baseline; 'Slower' significantly slower; 'Similar' not significant after FDR._
 
 ### Detailed Results
 
-| Method | Mean Time | Median Time | Sample Size | Status |
-|--------|-----------|-------------|-------------|--------|
-| SortWithQuickSort | 0.005ms | 0.005ms | 100 | ✅ Success |
-| SortWithBubbleSort | 1.730ms | 1.666ms | 100 | ✅ Success |
-| SortWithOtherSort | 15.622ms | 15.530ms | 100 | ✅ Success |
+| Method              | Mean Time | Median Time | Sample Size | Status     |
+|---------------------|-----------|-------------|-------------|------------|
+| SortWithQuickSort   | 0.005ms   | 0.005ms     | 100         | ✅ Success |
+| SortWithBubbleSort  | 1.730ms   | 1.666ms     | 100         | ✅ Success |
+| SortWithOtherSort   | 15.622ms  | 15.530ms    | 100         | ✅ Success |
 ```
 
 ### N×N mode — example output
 
 For the `SumCalculation` group above (no baseline, two methods):
 
-```markdown
+```
 ## 🔬 Comparison Group: SumCalculation (SumComparison)
 
 ### Performance Comparison Matrix
 
 ### 🔢 NxN Comparison Matrix (q-values via BH-FDR, α=0.05)
-| Method | CalculateSumWithLinq | CalculateSumWithLoop |
-|-|-|-|
-| CalculateSumWithLinq | — | 0.987x [0.951–1.024] q=0.512 Similar |
-| CalculateSumWithLoop | 1.013x [0.977–1.052] q=0.512 Similar | — |
+
+| Method                | CalculateSumWithLinq                  | CalculateSumWithLoop                  |
+|-----------------------|---------------------------------------|---------------------------------------|
+| CalculateSumWithLinq  | —                                     | 0.987x [0.951–1.024] q=0.512 Similar  |
+| CalculateSumWithLoop  | 1.013x [0.977–1.052] q=0.512 Similar  | —                                     |
 
 _Cell value is ratio vs. row (col/row). CI is 95% on ratio. 'Improved' means significantly faster; 'Slower' significantly slower; 'Similar' not significant after FDR._
 ```


### PR DESCRIPTION
## Summary
The "Baseline mode — example output" and "N×N mode — example output" code blocks in [docs/1/method-comparisons](https://paulgradie.com/Sailfish/docs/1/method-comparisons) — plus two similar blocks in `quick-start.md` and `markdown-output.md` — were rendering with every `|` and table cell on its own line, turning each table into a long vertical list (see the screenshot the user shared after merging #243).

## Root cause
`site/src/components/CodeBlock.jsx` uses `prism-react-renderer`, which iterates prism's token tree and emits one `<div class="token-line">` per "line" of tokens. Prism's `markdown` grammar (`node_modules/prismjs/components/prism-markdown.js`) recognizes pipe tables and breaks them into nested `table-data` / `punctuation` tokens — the splitter then puts each cell and each `|` on its own visual line.

This only affects blocks tagged ` ```markdown `, and only when prism's `table` pattern matches (i.e. a `| ... |` row followed by a `|---|---|` divider). A solitary table row with no divider escapes the pattern, which is why the smaller sample in `markdown-output.md` line 63 didn't show the bug.

## Fix
Drop the `markdown` language hint on example-output blocks. These show the literal session file Sailfish writes to disk; we're not asking the renderer to syntax-highlight markdown. With no language, prism-react-renderer treats each newline-delimited line as one row of plain text and the table renders correctly as monospaced columns.

Pre-aligned the columns by padding for nicer visual output in the unsyntactically-highlighted block.

While I was in there, fixed `15.622x` → `15.622ms` on the `SortWithOtherSort` baseline row — a unit typo in the original example that landed in #243.

## Files changed
- `site/src/pages/docs/1/method-comparisons.md` — both baseline-mode and N×N-mode example output blocks
- `site/src/pages/docs/0/quick-start.md` — the baseline group example
- `site/src/pages/docs/1/markdown-output.md` — two tables in the Detailed Results / Mixed Test Types examples

## Verification
Started `npm run dev` locally and verified via `curl` that the rendered HTML now produces one `<div class="token-line">` per row of the table, with each row containing the full `| … | … |` string in a single `<span class="token plain">`. Before the fix, each cell was its own `<div>`.

## Test plan
- [ ] Pull the branch, run `npm run dev` in `site/`, open `http://localhost:3000/docs/1/method-comparisons`
- [ ] Confirm the "Baseline mode — example output" and "N×N mode — example output" tables render as proper monospaced tables (columns aligned, rows on single lines)
- [ ] Same check on `http://localhost:3000/docs/0/quick-start` and `http://localhost:3000/docs/1/markdown-output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)