### PR TITLE
perf: speed up unit test suite (~65% wall-time reduction)

### DIFF
--- a/.github/workflows/build-v4.0.yml
+++ b/.github/workflows/build-v4.0.yml
@@ -116,8 +116,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         project: ["Tests.Library", "Tests.TestAdapter", "Tests.Analyzers"]
+        framework: ["net9.0", "net10.0"]
     steps:
       - uses: actions/checkout@v4
 
@@ -135,7 +137,7 @@ jobs:
           path: .
 
       - name: Test Projects
-        run: dotnet test ./source/${{ matrix.project }}/${{ matrix.project }}.csproj --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test ./source/${{ matrix.project }}/${{ matrix.project }}.csproj --framework ${{ matrix.framework }} --verbosity normal --collect:"XPlat Code Coverage"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
@@ -144,8 +146,8 @@ jobs:
           slug: paulegradie/Sailfish
           # Flag each matrix job so codecov merges the parallel uploads
           # by-file instead of letting the last upload win.
-          flags: ${{ matrix.project }}
-          name: ${{ matrix.project }}
+          flags: ${{ matrix.project }}-${{ matrix.framework }}
+          name: ${{ matrix.project }}-${{ matrix.framework }}
           # Don't fail the whole job on a transient codecov outage.
           fail_ci_if_error: false
 

--- a/source/Sailfish/Diagnostics/Environment/EnvironmentHealthChecker.cs
+++ b/source/Sailfish/Diagnostics/Environment/EnvironmentHealthChecker.cs
@@ -13,14 +13,27 @@ namespace Sailfish.Diagnostics.Environment;
 public class EnvironmentHealthChecker : IEnvironmentHealthChecker
 {
     private readonly ITimerCalibrationResultProvider? _timerProvider;
+    private readonly Func<HealthCheckEntry> _timerResolutionProbe;
+    private readonly Func<CancellationToken, Task<HealthCheckEntry>> _backgroundCpuProbe;
 
     public EnvironmentHealthChecker()
+        : this(timerProvider: null, timerResolutionProbe: null, backgroundCpuProbe: null)
     {
     }
 
     public EnvironmentHealthChecker(ITimerCalibrationResultProvider timerProvider)
+        : this(timerProvider, timerResolutionProbe: null, backgroundCpuProbe: null)
+    {
+    }
+
+    internal EnvironmentHealthChecker(
+        ITimerCalibrationResultProvider? timerProvider,
+        Func<HealthCheckEntry>? timerResolutionProbe,
+        Func<CancellationToken, Task<HealthCheckEntry>>? backgroundCpuProbe)
     {
         _timerProvider = timerProvider;
+        _timerResolutionProbe = timerResolutionProbe ?? CheckTimerResolution;
+        _backgroundCpuProbe = backgroundCpuProbe ?? (static ct => CheckBackgroundCpuLoadAsync(ct));
     }
 
     public async Task<EnvironmentHealthReport> CheckAsync(EnvironmentHealthCheckContext? context = null, CancellationToken cancellationToken = default)
@@ -32,7 +45,7 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
             CheckProcessPriority(),
             CheckGcMode(),
             CheckCpuAffinity(),
-            CheckTimerResolution(),
+            _timerResolutionProbe(),
             CheckOsPowerHints()
         };
 
@@ -47,7 +60,7 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
         // Background CPU load sampling (best-effort)
         try
         {
-            var background = await CheckBackgroundCpuLoadAsync().ConfigureAwait(false);
+            var background = await _backgroundCpuProbe(cancellationToken).ConfigureAwait(false);
             entries.Add(background);
         }
         catch
@@ -57,6 +70,12 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
 
         return new EnvironmentHealthReport(entries);
     }
+
+    internal static HealthCheckEntry FastTimerResolutionEntry() =>
+        new("Timer", HealthStatus.Pass, "Stubbed for fast tests");
+
+    internal static HealthCheckEntry FastBackgroundCpuEntry() =>
+        new("Background CPU", HealthStatus.Pass, "Stubbed for fast tests");
 
     private static HealthCheckEntry CheckBuildConfiguration(EnvironmentHealthCheckContext? context)
     {
@@ -323,7 +342,7 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
         }
     }
 
-    private static async Task<HealthCheckEntry> CheckBackgroundCpuLoadAsync()
+    private static async Task<HealthCheckEntry> CheckBackgroundCpuLoadAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -331,7 +350,7 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
             var p = Process.GetCurrentProcess();
             var startCpu = p.TotalProcessorTime;
             var sw = Stopwatch.StartNew();
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
             p.Refresh();
             var endCpu = p.TotalProcessorTime;
             sw.Stop();

--- a/source/Tests.Library/Analysis/SailDiff/DefaultTrackingFileDirectoryReaderTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/DefaultTrackingFileDirectoryReaderTests.cs
@@ -282,12 +282,13 @@ public class DefaultTrackingFileDirectoryReaderTests : IDisposable
         return CreateFile($"{baseName}{DefaultFileSettings.TrackingSuffix}");
     }
 
+    // BaseTime + offset gives stable, monotonically-increasing timestamps without sleeping.
+    private static readonly DateTime TimestampBaseUtc = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     private string CreateTrackingFileWithDelay(string baseName, TimeSpan delay)
     {
         var filePath = CreateTrackingFile(baseName);
-        System.Threading.Thread.Sleep(delay);
-        // Touch the file to update its timestamp
-        File.SetLastWriteTimeUtc(filePath, DateTime.UtcNow);
+        File.SetLastWriteTimeUtc(filePath, TimestampBaseUtc + delay);
         return filePath;
     }
 

--- a/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerAdditionalTests.cs
+++ b/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerAdditionalTests.cs
@@ -11,7 +11,7 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public async Task BuildMode_Uses_TestAssemblyPath_When_Provided()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var ctx = new EnvironmentHealthCheckContext
         {
             TestAssemblyPath = typeof(EnvironmentHealthChecker).Assembly.Location
@@ -37,7 +37,7 @@ public class EnvironmentHealthCheckerAdditionalTests
             // Pin to a single core (bit 0)
             proc.ProcessorAffinity = (System.IntPtr)1;
 
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             var affinity = report.Entries.First(e => e.Name == "CPU Affinity");
             affinity.Status.ShouldBe(HealthStatus.Pass);
@@ -62,7 +62,7 @@ public class EnvironmentHealthCheckerAdditionalTests
             System.Environment.SetEnvironmentVariable("COMPlus_TC_QuickJitForLoops", "0");
             System.Environment.SetEnvironmentVariable("COMPlus_TC_OnStackReplacement", "0");
 
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             var jit = report.Entries.First(e => e.Name == "JIT (Tiered/OSR)");
             jit.Details.ShouldContain("Tiered=1");
@@ -95,7 +95,7 @@ public class EnvironmentHealthCheckerAdditionalTests
             // Pin to two cores (bits 0 and 1)
             proc.ProcessorAffinity = (System.IntPtr)3;
 
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             var affinity = report.Entries.First(e => e.Name == "CPU Affinity");
             affinity.Status.ShouldBe(HealthStatus.Warn);
@@ -128,7 +128,7 @@ public class EnvironmentHealthCheckerAdditionalTests
                 return;
             }
 
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             var entry = report.Entries.First(e => e.Name == "Process Priority");
             entry.Status.ShouldBe(HealthStatus.Pass);
@@ -142,7 +142,7 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public async Task BuildMode_Unknown_When_Loading_NonDotNet_File()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var sysDir = System.Environment.SystemDirectory;
         var nonDotNetPath = System.IO.Path.Combine(sysDir, "notepad.exe");
         if (!System.IO.File.Exists(nonDotNetPath))
@@ -181,7 +181,7 @@ public class EnvironmentHealthCheckerAdditionalTests
                 return;
             }
 
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             var entry = report.Entries.First(e => e.Name == "Process Priority");
             entry.Status.ShouldBe(HealthStatus.Warn);
@@ -220,7 +220,7 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public async Task CheckAsync_WithNullContext_Returns_ValidReport()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync(context: null);
 
         report.ShouldNotBeNull();
@@ -231,7 +231,7 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public async Task CheckAsync_WithDefaultCancellationToken_Returns_ValidReport()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync(cancellationToken: default);
 
         report.ShouldNotBeNull();
@@ -242,7 +242,7 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public async Task CheckAsync_WithBothNullContextAndDefaultCancellationToken_Returns_ValidReport()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync(context: null, cancellationToken: default);
 
         report.ShouldNotBeNull();
@@ -253,7 +253,7 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public async Task CheckAsync_WithCancellationToken_Returns_ValidReport()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         using var cts = new System.Threading.CancellationTokenSource();
         var report = await checker.CheckAsync(cancellationToken: cts.Token);
 
@@ -265,14 +265,14 @@ public class EnvironmentHealthCheckerAdditionalTests
     [Fact]
     public void CheckAsync_Implements_IEnvironmentHealthChecker()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         checker.ShouldBeAssignableTo<IEnvironmentHealthChecker>();
     }
 
     [Fact]
     public async Task CheckAsync_Returns_EnvironmentHealthReport()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var result = await checker.CheckAsync();
         result.ShouldBeOfType<EnvironmentHealthReport>();
     }

--- a/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerTestHelpers.cs
+++ b/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerTestHelpers.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Execution;
+
+namespace Tests.Library.Diagnostics.Environment;
+
+internal static class EnvironmentHealthCheckerTestHelpers
+{
+    private static readonly Func<HealthCheckEntry> FastTimerProbe = EnvironmentHealthChecker.FastTimerResolutionEntry;
+    private static readonly Func<CancellationToken, Task<HealthCheckEntry>> FastCpuProbe =
+        static _ => Task.FromResult(EnvironmentHealthChecker.FastBackgroundCpuEntry());
+
+    public static EnvironmentHealthChecker CreateFast(ITimerCalibrationResultProvider? timerProvider = null) =>
+        new(timerProvider, FastTimerProbe, FastCpuProbe);
+}

--- a/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerTests.cs
+++ b/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerTests.cs
@@ -11,7 +11,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task CheckAsync_Returns_Report_WithScoreAndEntries()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync();
 
         report.ShouldNotBeNull();
@@ -23,7 +23,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task Report_Includes_Key_Entries()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync();
 
         var names = report.Entries.Select(e => e.Name).ToList();
@@ -39,7 +39,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task Report_Includes_BuildMode_And_JitEntries()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync();
 
         var names = report.Entries.Select(e => e.Name).ToList();
@@ -53,7 +53,7 @@ public class EnvironmentHealthCheckerTests
         try
         {
             System.Environment.SetEnvironmentVariable("COMPlus_TieredCompilation", "0");
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             var jit = report.Entries.First(e => e.Name == "JIT (Tiered/OSR)");
             jit.Details.ShouldContain("Tiered=");
@@ -87,7 +87,7 @@ public class EnvironmentHealthCheckerTests
                 JitterScore = 100
             }
         };
-        var checker = new EnvironmentHealthChecker(provider);
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
         var report = await checker.CheckAsync();
         report.Entries.Any(e => e.Name == "Timer Jitter" && e.Status == HealthStatus.Pass).ShouldBeTrue();
     }
@@ -106,7 +106,7 @@ public class EnvironmentHealthCheckerTests
                 JitterScore = 60
             }
         };
-        var checker = new EnvironmentHealthChecker(provider);
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
         var report = await checker.CheckAsync();
         report.Entries.Any(e => e.Name == "Timer Jitter" && e.Status == HealthStatus.Warn).ShouldBeTrue();
     }
@@ -125,7 +125,7 @@ public class EnvironmentHealthCheckerTests
                 JitterScore = 20
             }
         };
-        var checker = new EnvironmentHealthChecker(provider);
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
         var report = await checker.CheckAsync();
         report.Entries.Any(e => e.Name == "Timer Jitter" && e.Status == HealthStatus.Fail).ShouldBeTrue();
     }
@@ -145,7 +145,7 @@ public class EnvironmentHealthCheckerTests
                     JitterScore = 80
                 }
             };
-            var checker = new EnvironmentHealthChecker(provider);
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
             var report = await checker.CheckAsync();
             report.Entries.Any(e => e.Name == "Timer Jitter" && e.Status == HealthStatus.Pass).ShouldBeTrue();
         }
@@ -164,7 +164,7 @@ public class EnvironmentHealthCheckerTests
                     JitterScore = 40
                 }
             };
-            var checker = new EnvironmentHealthChecker(provider);
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
             var report = await checker.CheckAsync();
             report.Entries.Any(e => e.Name == "Timer Jitter" && e.Status == HealthStatus.Warn).ShouldBeTrue();
         }
@@ -172,7 +172,7 @@ public class EnvironmentHealthCheckerTests
         [Fact]
         public async Task Report_DoesNotInclude_TimerJitter_WhenProviderNull()
         {
-            var checker = new EnvironmentHealthChecker();
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
             var report = await checker.CheckAsync();
             report.Entries.Any(e => e.Name == "Timer Jitter").ShouldBeFalse();
         }
@@ -181,7 +181,7 @@ public class EnvironmentHealthCheckerTests
         public async Task Report_DoesNotInclude_TimerJitter_WhenProviderCurrentNull()
         {
             var provider = new TestTimerProvider { Current = null };
-            var checker = new EnvironmentHealthChecker(provider);
+            var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
             var report = await checker.CheckAsync();
             report.Entries.Any(e => e.Name == "Timer Jitter").ShouldBeFalse();
         }
@@ -189,7 +189,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task CheckAsync_WithContext_UsesProvidedTestAssemblyPath()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var context = new EnvironmentHealthCheckContext { TestAssemblyPath = typeof(EnvironmentHealthCheckerTests).Assembly.Location };
         var report = await checker.CheckAsync(context);
 
@@ -201,7 +201,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task CheckAsync_WithInvalidTestAssemblyPath_FallsBackToDefaultAssembly()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var context = new EnvironmentHealthCheckContext { TestAssemblyPath = "/nonexistent/path/assembly.dll" };
         var report = await checker.CheckAsync(context);
 
@@ -213,7 +213,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task GcMode_ReturnsValidStatus()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync();
 
         var gcMode = report.Entries.First(e => e.Name == "GC Mode");
@@ -224,7 +224,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task ProcessPriority_ReturnsValidStatus()
     {
-        var checker = new EnvironmentHealthChecker();
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast();
         var report = await checker.CheckAsync();
 
         var priority = report.Entries.First(e => e.Name == "Process Priority");
@@ -235,6 +235,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task Timer_ReturnsValidStatus()
     {
+        // Exercises the real timer-resolution probe (intentionally slow).
         var checker = new EnvironmentHealthChecker();
         var report = await checker.CheckAsync();
 
@@ -247,6 +248,7 @@ public class EnvironmentHealthCheckerTests
     [Fact]
     public async Task BackgroundCpu_ReturnsValidStatus()
     {
+        // Exercises the real CPU sampling probe (intentionally slow).
         var checker = new EnvironmentHealthChecker();
         var report = await checker.CheckAsync();
 
@@ -269,7 +271,7 @@ public class EnvironmentHealthCheckerTests
                 JitterScore = 30
             }
         };
-        var checker = new EnvironmentHealthChecker(provider);
+        var checker = EnvironmentHealthCheckerTestHelpers.CreateFast(provider);
         var report = await checker.CheckAsync();
         report.Entries.Any(e => e.Name == "Timer Jitter" && e.Status == HealthStatus.Fail).ShouldBeTrue();
     }

--- a/source/Tests.Library/Execution/OverheadEstimatorTests.cs
+++ b/source/Tests.Library/Execution/OverheadEstimatorTests.cs
@@ -6,200 +6,47 @@ using Xunit;
 namespace Tests.Library.Execution;
 #pragma warning disable CS0618 // OverheadEstimator is obsolete in production but intentionally tested here
 
-
 /// <summary>
-/// Comprehensive unit tests for OverheadEstimator.
-/// Tests the overhead estimation algorithm, timing logic, and edge cases.
+/// Smoke coverage for the deprecated OverheadEstimator (retained for rollback).
+/// The replacement HarnessBaselineCalibrator has its own dedicated tests; only one
+/// end-to-end probe is kept here so a serious regression is still surfaced.
 /// </summary>
 public class OverheadEstimatorTests
 {
     [Fact]
     public void Constructor_ShouldCreateInstance()
     {
-        // Act
         var estimator = new OverheadEstimator();
-
-        // Assert
         estimator.ShouldNotBeNull();
     }
 
     [Fact]
     public void GetAverageEstimate_WithNoEstimates_ShouldReturnZero()
     {
-        // Arrange
         var estimator = new OverheadEstimator();
-
-        // Act
-        var result = estimator.GetAverageEstimate();
-
-        // Assert
-        result.ShouldBe(0);
-    }
-
-    [Fact]
-    public async Task GetAverageEstimate_AfterSingleEstimate_ShouldReturnEstimate()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-        await estimator.Estimate();
-
-        // Act
-        var result = estimator.GetAverageEstimate();
-
-        // Assert
-        result.ShouldBeGreaterThanOrEqualTo(0);
-    }
-
-    [Fact]
-    public async Task GetAverageEstimate_AfterMultipleEstimates_ShouldReturnAverage()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-        await estimator.Estimate();
-        await estimator.Estimate();
-        await estimator.Estimate();
-
-        // Act
-        var result = estimator.GetAverageEstimate();
-
-        // Assert
-        result.ShouldBeGreaterThanOrEqualTo(0);
+        estimator.GetAverageEstimate().ShouldBe(0);
     }
 
     [Fact]
     public void GetAverageEstimate_ShouldClearEstimatesAfterCall()
     {
-        // Arrange
         var estimator = new OverheadEstimator();
-
-        // Act
         var firstCall = estimator.GetAverageEstimate();
         var secondCall = estimator.GetAverageEstimate();
-
-        // Assert
         firstCall.ShouldBe(0);
         secondCall.ShouldBe(0);
     }
 
+    /// <summary>
+    /// Single end-to-end probe of the deprecated estimator. Estimate() runs 50
+    /// 100ms Task.Delay iterations (~5s wall) so one call is enough.
+    /// </summary>
     [Fact]
-    public async Task Estimate_ShouldCompleteWithoutException()
+    public async Task Estimate_CompletesAndProducesNonNegativeAverage()
     {
-        // Arrange
         var estimator = new OverheadEstimator();
-
-        // Act & Assert
         await Should.NotThrowAsync(async () => await estimator.Estimate());
-    }
-
-    [Fact]
-    public async Task Estimate_WithMultipleCalls_ShouldProduceConsistentResults()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act
-        await estimator.Estimate();
-        var firstEstimate = estimator.GetAverageEstimate();
-
-        await estimator.Estimate();
-        var secondEstimate = estimator.GetAverageEstimate();
-
-        // Assert
-        // Both estimates should be non-negative
-        firstEstimate.ShouldBeGreaterThanOrEqualTo(0);
-        secondEstimate.ShouldBeGreaterThanOrEqualTo(0);
-    }
-
-    [Fact]
-    public async Task Estimate_ShouldHandleReflectionInvocation()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act & Assert
-        // This tests that the reflection-based method invocation works correctly
-        await Should.NotThrowAsync(async () => await estimator.Estimate());
-    }
-
-
-    [Fact]
-    public async Task Estimate_WithNegativeOverhead_ShouldHandleGracefully()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act
-        await estimator.Estimate();
-        var result = estimator.GetAverageEstimate();
-
-        // Assert
-        // Even if overhead calculation results in negative values,
-        // the estimator should handle it gracefully and return 0 or positive value
-        result.ShouldBeGreaterThanOrEqualTo(0);
-    }
-
-    [Fact]
-    public async Task Estimate_ShouldUseMedianForCalculations()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act
-        await estimator.Estimate();
-        var result = estimator.GetAverageEstimate();
-
-        // Assert
-        // This test verifies that the estimation completes successfully
-        // The actual median calculation is tested implicitly through the algorithm
-        result.ShouldBeGreaterThanOrEqualTo(0);
-    }
-
-    [Fact]
-    public async Task Estimate_ShouldApplyCorrectScalingFactor()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act
-        await estimator.Estimate();
-        var result = estimator.GetAverageEstimate();
-
-        // Assert
-        // The algorithm applies a 0.25 scaling factor to the final estimate
-        // This test ensures the result is reasonable given that scaling
-        result.ShouldBeGreaterThanOrEqualTo(0);
-    }
-
-    [Fact]
-    public async Task Estimate_MultipleSequentialCalls_ShouldWork()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act & Assert
-        for (var i = 0; i < 3; i++)
-        {
-            await Should.NotThrowAsync(async () => await estimator.Estimate());
-            var estimate = estimator.GetAverageEstimate();
-            estimate.ShouldBeGreaterThanOrEqualTo(0);
-        }
-    }
-
-
-    [Fact]
-    public async Task Estimate_ShouldHandleIterationLoops()
-    {
-        // Arrange
-        var estimator = new OverheadEstimator();
-
-        // Act
-        await estimator.Estimate();
-
-        // Assert
-        // This test ensures that the 30-iteration and 20-iteration loops
-        // in the Estimate method complete successfully
-        var result = estimator.GetAverageEstimate();
-        result.ShouldBeGreaterThanOrEqualTo(0);
+        estimator.GetAverageEstimate().ShouldBeGreaterThanOrEqualTo(0);
     }
 }
 

--- a/source/Tests.Library/TestSuiteCoverage/TestSuiteIsCovered.cs
+++ b/source/Tests.Library/TestSuiteCoverage/TestSuiteIsCovered.cs
@@ -1,59 +1,17 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using NSubstitute;
 using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
 using Sailfish.Contracts.Public.Models;
-using Sailfish.Logging;
 using Shouldly;
 using Tests.Common.Builders;
 using Tests.Common.Builders.ScaleFish;
 using Tests.Common.Utils;
-using Tests.E2E.ExceptionHandling.Tests;
-using Tests.E2E.TestSuite.Discoverable;
-using Tests.E2E.TestSuite.Utils;
 using Xunit;
 
 namespace Tests.Library.TestSuiteCoverage;
 
 public class TestSuiteIsCovered
 {
-    [Fact]
-    public async Task Cover()
-    {
-        await new DemoPerformanceTest().DoThing(new CancellationToken());
-        new ResolveTestCaseIdTestMultipleCtorArgs(
-                new ExampleDependencyForAltRego(),
-                new TestCaseId($"{nameof(ResolveTestCaseIdTestMultipleCtorArgs)}.{nameof(ResolveTestCaseIdTestMultipleCtorArgs.MainMethod)}()"))
-            .MainMethod();
-
-        var se = new ScenariosExample();
-        se.GlobalSetup();
-        se.Scenario = "ScenarioA";
-        se.Scenario = "ScenarioB";
-        await se.TestMethod(new CancellationToken());
-
-        new MinimalTest().Minimal();
-        new E2E.TestSuite.Discoverable.InnerNamespace.MinimalTest().Minimal();
-        var scenarios = new ScenariosExample();
-        scenarios.GlobalSetup();
-        scenarios.Scenario = "ScenarioA";
-        await scenarios.TestMethod(CancellationToken.None);
-        await new IterationSetupExceptionComesFirst().LifeCycleExceptionTests(CancellationToken.None);
-        await new IterationSetupExceptionIsHandled().LifeCycleExceptionTests(CancellationToken.None);
-        await new MethodSetupExceptionIsHandled().LifeCycleExceptionTests(CancellationToken.None);
-        await new MultipleInjectionsOnAsyncMethod().MainMethod(Substitute.For<ILogger>(), CancellationToken.None);
-        await new OnlyTheSailfishMethodThrows().MethodTeardown(CancellationToken.None);
-        await new GlobalSetupExceptionIsHandled().LifeCycleExceptionTests(CancellationToken.None);
-
-        new VoidMethodRequestsCancellationToken().MainMethod(CancellationToken.None);
-
-        await Should.ThrowAsync<Exception>(async () => await new IterationSetupExceptionComesFirst().MethodTeardown(CancellationToken.None));
-        await Should.ThrowAsync<Exception>(async () => await new MethodTeardownExceptionComesFirst().GlobalTeardown(CancellationToken.None));
-        await Should.ThrowAsync<Exception>(async () => await new IterationSetupExceptionComesFirst().SailfishMethodException(CancellationToken.None));
-    }
-
     [Fact]
     public void TestBuildersDontBlowUp()
     {

--- a/source/Tests.TestAdapter/AssemblyDiscoveryCollection.cs
+++ b/source/Tests.TestAdapter/AssemblyDiscoveryCollection.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace Tests.TestAdapter;
+
+/// <summary>
+/// Groups tests that load and walk this project's compiled DLL through
+/// <c>TestDiscovery</c> / <c>DllFinder</c>. Running them in parallel across
+/// classes occasionally produces empty discovery results — the failure mode
+/// looks like a discovery-time race against the build directory rather than a
+/// real bug, so we serialize the fixtures instead of paying the cost of
+/// reproducing it.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class AssemblyDiscoveryCollection
+{
+    public const string Name = "AssemblyDiscovery";
+}

--- a/source/Tests.TestAdapter/Queue/QueueHealthCheckComprehensiveTests.cs
+++ b/source/Tests.TestAdapter/Queue/QueueHealthCheckComprehensiveTests.cs
@@ -289,9 +289,9 @@ public class QueueHealthCheckComprehensiveTests : IDisposable
 
         // Act
         await _healthCheck.StartAsync(CancellationToken.None);
-        
-        // Wait a bit for the initial health check
-        await Task.Delay(100);
+
+        // Wait for the initial health check to fire its event
+        await WaitFor.ConditionAsync(() => eventArgs is not null, description: "initial HealthStatusChanged event");
 
         // Assert
         // The initial health check should trigger an event

--- a/source/Tests.TestAdapter/Queue/TestCompletionQueueConsumerTests.cs
+++ b/source/Tests.TestAdapter/Queue/TestCompletionQueueConsumerTests.cs
@@ -230,17 +230,22 @@ public class TestCompletionQueueConsumerTests : IDisposable
     {
         // Arrange
         _consumer = new TestCompletionQueueConsumer(_queue, _logger);
+        var dequeueCount = 0;
         _queue.DequeueAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<TestCompletionQueueMessage?>(null)); // Queue completed
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref dequeueCount);
+                return Task.FromResult<TestCompletionQueueMessage?>(null);
+            }); // Queue completed
         await _consumer.StartAsync(CancellationToken.None);
-        await Task.Delay(100); // Give processing loop time to start
+        await WaitFor.ConditionAsync(() => dequeueCount > 0, description: "processing loop started");
 
         // Act
         await _consumer.StopAsync(CancellationToken.None);
 
         // Assert
         _consumer.IsRunning.ShouldBeFalse();
-        _logger.Received().Log(LogLevel.Information, 
+        _logger.Received().Log(LogLevel.Information,
             Arg.Is<string>(s => s.Contains("Test completion queue consumer service stopped successfully")));
     }
 
@@ -298,12 +303,17 @@ public class TestCompletionQueueConsumerTests : IDisposable
         _consumer.RegisterProcessor(processor);
 
         // Setup queue to return null (queue completed)
+        var dequeueCount = 0;
         _queue.DequeueAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<TestCompletionQueueMessage?>(null));
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref dequeueCount);
+                return Task.FromResult<TestCompletionQueueMessage?>(null);
+            });
 
         // Act
         await _consumer.StartAsync(CancellationToken.None);
-        await Task.Delay(100); // Give processing loop time to process
+        await WaitFor.ConditionAsync(() => dequeueCount > 0, description: "processing loop dequeued at least once");
         await _consumer.StopAsync(CancellationToken.None);
 
         // Assert - Should not throw, processor should not be called
@@ -318,8 +328,13 @@ public class TestCompletionQueueConsumerTests : IDisposable
         var processor = Substitute.For<ITestCompletionQueueProcessor>();
         var message = TestCompletionQueueConsumerTests.CreateTestMessage();
 
+        var processorCalls = 0;
         processor.ProcessTestCompletion(Arg.Any<TestCompletionQueueMessage>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new Exception("Processor error")));
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref processorCalls);
+                return Task.FromException(new Exception("Processor error"));
+            });
 
         _consumer.RegisterProcessor(processor);
 
@@ -330,9 +345,8 @@ public class TestCompletionQueueConsumerTests : IDisposable
 
         // Act
         var processingTask = _consumer.StartAsync(CancellationToken.None);
-        // Wait long enough for all 3 retry attempts: initial + 100ms delay + attempt2 + 200ms delay + attempt3
-        // Total: ~800ms to be safe, then stop
-        await Task.Delay(1000);
+        // Wait for all 3 retry attempts to complete (initial + 100ms + 200ms delays inside the consumer).
+        await WaitFor.CountReachedAsync(() => processorCalls, 3);
         await _consumer.StopAsync(CancellationToken.None);
         await processingTask;
 
@@ -358,8 +372,13 @@ public class TestCompletionQueueConsumerTests : IDisposable
         var processor = Substitute.For<ITestCompletionQueueProcessor>();
         var message = TestCompletionQueueConsumerTests.CreateTestMessage();
 
+        var processorCalls = 0;
         processor.ProcessTestCompletion(Arg.Any<TestCompletionQueueMessage>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new OperationCanceledException()));
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref processorCalls);
+                return Task.FromException(new OperationCanceledException());
+            });
 
         _consumer.RegisterProcessor(processor);
 
@@ -370,7 +389,7 @@ public class TestCompletionQueueConsumerTests : IDisposable
 
         // Act
         await _consumer.StartAsync(CancellationToken.None);
-        await Task.Delay(200); // Give processing loop time to process
+        await WaitFor.CountReachedAsync(() => processorCalls, 1);
         await _consumer.StopAsync(CancellationToken.None);
 
         // Assert - Should log warning for cancellation
@@ -386,6 +405,13 @@ public class TestCompletionQueueConsumerTests : IDisposable
         var processor2 = Substitute.For<ITestCompletionQueueProcessor>();
         var message = TestCompletionQueueConsumerTests.CreateTestMessage();
 
+        var p1Calls = 0;
+        var p2Calls = 0;
+        processor1.ProcessTestCompletion(Arg.Any<TestCompletionQueueMessage>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { Interlocked.Increment(ref p1Calls); return Task.CompletedTask; });
+        processor2.ProcessTestCompletion(Arg.Any<TestCompletionQueueMessage>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { Interlocked.Increment(ref p2Calls); return Task.CompletedTask; });
+
         _consumer.RegisterProcessor(processor1);
         _consumer.RegisterProcessor(processor2);
 
@@ -396,7 +422,7 @@ public class TestCompletionQueueConsumerTests : IDisposable
 
         // Act
         await _consumer.StartAsync(CancellationToken.None);
-        await Task.Delay(200); // Give processing loop time to process
+        await WaitFor.ConditionAsync(() => p1Calls >= 1 && p2Calls >= 1, description: "both processors invoked");
         await _consumer.StopAsync(CancellationToken.None);
 
         // Assert - Both processors should be called
@@ -413,9 +439,18 @@ public class TestCompletionQueueConsumerTests : IDisposable
         var processor2 = Substitute.For<ITestCompletionQueueProcessor>();
         var message = TestCompletionQueueConsumerTests.CreateTestMessage();
 
+        var p1Calls = 0;
+        var p2Calls = 0;
+
         // First processor throws exception
         processor1.ProcessTestCompletion(Arg.Any<TestCompletionQueueMessage>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new Exception("Processor 1 error")));
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref p1Calls);
+                return Task.FromException(new Exception("Processor 1 error"));
+            });
+        processor2.ProcessTestCompletion(Arg.Any<TestCompletionQueueMessage>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { Interlocked.Increment(ref p2Calls); return Task.CompletedTask; });
 
         _consumer.RegisterProcessor(processor1);
         _consumer.RegisterProcessor(processor2);
@@ -427,9 +462,8 @@ public class TestCompletionQueueConsumerTests : IDisposable
 
         // Act
         var processingTask = _consumer.StartAsync(CancellationToken.None);
-        // Wait long enough for all 3 retry attempts: initial + 100ms delay + attempt2 + 200ms delay + attempt3
-        // Total: ~1000ms to be safe, then stop
-        await Task.Delay(1000);
+        // Wait until the retry-and-continue behavior has actually completed.
+        await WaitFor.ConditionAsync(() => p1Calls >= 3 && p2Calls >= 1, description: "p1 retried 3x and p2 invoked");
         await _consumer.StopAsync(CancellationToken.None);
         await processingTask;
 

--- a/source/Tests.TestAdapter/Queue/WaitFor.cs
+++ b/source/Tests.TestAdapter/Queue/WaitFor.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.TestAdapter.Queue;
+
+internal static class WaitFor
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(5);
+
+    public static async Task ConditionAsync(Func<bool> condition, TimeSpan? timeout = null, string? description = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? DefaultTimeout);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(PollInterval);
+        }
+
+        if (condition()) return;
+        throw new TimeoutException($"Condition not met within {(timeout ?? DefaultTimeout).TotalMilliseconds:F0} ms: {description ?? "unspecified"}");
+    }
+
+    public static Task CountReachedAsync(Func<int> counter, int target, TimeSpan? timeout = null) =>
+        ConditionAsync(() => counter() >= target, timeout, $"counter >= {target}");
+}

--- a/source/Tests.TestAdapter/TestAdapterTests.cs
+++ b/source/Tests.TestAdapter/TestAdapterTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Tests.TestAdapter;
 
+[Collection(AssemblyDiscoveryCollection.Name)]
 public class TestDiscovererTests : IAsyncLifetime
 {
     private IDiscoveryContext _context = null!;

--- a/source/Tests.TestAdapter/TestCaseAssemblyFixture.cs
+++ b/source/Tests.TestAdapter/TestCaseAssemblyFixture.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Tests.TestAdapter;
 
+[Collection(AssemblyDiscoveryCollection.Name)]
 public class TestCaseAssemblyFixture
 {
     private static string FindSpecificUniqueFile(string fileName)

--- a/source/Tests.TestAdapter/TestDiscoveryFixture.cs
+++ b/source/Tests.TestAdapter/TestDiscoveryFixture.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Tests.TestAdapter;
 
+[Collection(AssemblyDiscoveryCollection.Name)]
 public class TestDiscoveryFixture
 {
     [Fact]

--- a/source/Tests.TestAdapter/TestDiscoveryTests.cs
+++ b/source/Tests.TestAdapter/TestDiscoveryTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Tests.TestAdapter;
 
+[Collection(AssemblyDiscoveryCollection.Name)]
 public class TestDiscoveryTests
 {
     [Fact]

--- a/source/Tests.TestAdapter/TestExecutionFixture.cs
+++ b/source/Tests.TestAdapter/TestExecutionFixture.cs
@@ -22,6 +22,7 @@ using IRunSettings = Sailfish.Contracts.Public.Models.IRunSettings;
 
 namespace Tests.TestAdapter;
 
+[Collection(AssemblyDiscoveryCollection.Name)]
 public class TestExecutionFixture
 {
     private readonly ContainerBuilder _builder;


### PR DESCRIPTION
## Summary

Cuts Tests.Library wall time on net10.0 from **79 s → 28 s** by removing avoidable sleeps and synthetic-coverage E2E work, plus fixes a long-standing order-dependent flake in `TestDiscoveryFixture`.

## Changes

- **`EnvironmentHealthChecker` testability seam.** The CPU sampler (`Task.Delay(500)`) and timer-resolution probe (16× `Thread.Sleep(1)`) are now injectable. Tests use a fast-fake helper; two tests intentionally exercise the real probes to keep coverage. ~17 s of compute removed.
- **`DefaultTrackingFileDirectoryReaderTests`** — `SetLastWriteTimeUtc(...)` replaces `Thread.Sleep(...)` for setting file mtimes. ~2 s removed.
- **`TestSuiteIsCovered.Cover`** — removed; it called real E2E `Task.Delay` methods purely for coverage. The same paths are already exercised by `AFullTestRunOfTheDemoShouldFindAllTests`. ~0.9 s removed.
- **Queue tests** — hardcoded `Task.Delay(100/200/1000)` replaced with a small `WaitFor.ConditionAsync(...)` / `WaitFor.CountReachedAsync(...)` helper that polls with a 5 ms tick. ~3 s removed across the project.
- **`OverheadEstimatorTests`** — 13 redundant smoke tests for the `[Obsolete]` `OverheadEstimator` consolidated down to 4. (Its replacement `HarnessBaselineCalibrator` already has dedicated tests.) ~70 s of accumulated test time removed (~12 s of wall time).
- **`AssemblyDiscoveryCollection`** — the five test classes that load the project's compiled DLL through `TestDiscovery` / `DllFinder` are now in a single `[Collection]` with `DisableParallelization = true`. This removes an intermittent failure in `TestDiscoveryFixture.AllTestsAreDiscovered` without serializing the other ~545 tests in the project.
- **CI matrix split.** `build-v4.0.yml` now fans out `{project} × {framework}` so net9.0 and net10.0 each get their own runner instead of sharing one with code-coverage collection.

## Measured

| Project | Before (net10.0) | After (net10.0) |
| --- | --- | --- |
| Tests.Library | 79 s | **28 s** |
| Tests.TestAdapter | 4 s | 3 s |
| Tests.Analyzers | 7 s | 7 s |

Stress-tested 15 consecutive runs of Tests.TestAdapter and 5 consecutive runs of all three unit-test projects — all green.

## Test plan
- [x] `dotnet test` Tests.Library on net9.0 + net10.0 — all pass
- [x] `dotnet test` Tests.TestAdapter on net9.0 + net10.0 — all pass
- [x] `dotnet test` Tests.Analyzers on net9.0 + net10.0 — all pass
- [x] 15× stress run of Tests.TestAdapter — flake gone
- [ ] CI matrix runs both TFMs as separate jobs and uploads coverage with per-TFM flags

## Out of scope (noted in original review, not actioned)

- The `ConvergenceChecks*` Mann-Whitney tests (~9 s each) loop 20× over a deterministic statistical test on data generated once — likely overkill, but reducing the iteration count changes test semantics so I left it.
- xUnit v2 → v3 migration would unlock per-test parallelism within a class. Worth doing eventually but a much bigger lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)