### PR TITLE
SailDiff Tier 3: MDE, permutation test, formatter completeness

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,44 @@
 ﻿## What's Changed in v0.0.118 (unreleased)
 
+### SailDiff Tier 3: MDE reporting, permutation test, formatter completeness
+
+Closes out the SailDiff rigor roadmap with power/UX work that turns NoChange verdicts
+into actionable signals and surfaces every Tier 2 field through every output path.
+
+**Minimum Detectable Effect (MDE) on every result.** A new
+`StatisticalTestResult.MinimumDetectableEffectPercent` reports, at the configured α and a
+conventional 80% power, the smallest change the run could reliably catch as a percentage
+of the pooled mean. The new public helper `MinimumDetectableEffect` exposes both the
+absolute MDE (raw units) and the inverse — `SampleSizePerGroup(effect, var, α)` —
+answering the planning question "how many iterations to detect a 5% regression?". All four
+test wrappers populate the MDE field uniformly so it's available regardless of which
+TestType was selected.
+
+**Permutation test option** (`TestType.PermutationTest`). Distribution-free two-sample
+test that shuffles the joint pool of labels K times (default 10,000) and counts how often
+a random label assignment yields a mean difference at least as extreme as the observed
+one. Uses the Phipson-Smyth bias correction `(1 + count) / (1 + K)` so a finite Monte
+Carlo sample never reports an impossible p = 0. Robust against heavy-tailed and
+multi-modal timing data where the t-test's normality assumption is shaky. Configurable
+via new `SailDiffSettings.PermutationCount`. Borrows the rank-sum effect-size suite
+(Cliff's delta + Hodges-Lehmann shift) for output consistency.
+
+**Markdown formatter completeness.** The legacy SailDiff markdown table now includes the
+Tier 2 columns: `QValue (BH)`, `Effect`, `Shift`, `MDE %`. Empty cells when the test type
+doesn't produce a particular field.
+
+**CSV formatter completeness.** `SailDiffWriteAsCsvMap` gains 11 new columns from index 12
+onwards: `QValue`, `EffectName`, `EffectValue`, `EffectCiLower`, `EffectCiUpper`,
+`ShiftName`, `ShiftValue`, `ShiftCiLower`, `ShiftCiUpper`, `ShiftUnits`, `MdePercent`.
+Legacy columns 0..11 preserved verbatim for back-compat with existing consumers.
+
+### Debt cleared in the same change
+
+- **Signed-rank descriptive stats consistency.** The wrapper used to report `before.Mean()` /
+  `after.Mean()` on the *raw* input arrays even when outlier detection had shrunk the
+  samples the test actually saw — visible mean and test verdict could describe different
+  data. Now reports on the post-preprocessing sample, matching every other wrapper.
+
 ### SailDiff Tier 2: effect sizes, difference CIs, BH-FDR across pairs, log-transform
 
 A SailDiff verdict pre-Tier-2 was a binary label (`Improved` / `Regressed` / `NoChange`) plus

--- a/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
+++ b/source/Sailfish/Analysis/SailDiff/SailDiffSettings.cs
@@ -79,9 +79,23 @@ public class SailDiffSettings
     /// </summary>
     public bool LogTransform { get; private set; }
 
+    /// <summary>
+    /// Number of label permutations used when <see cref="TestType.PermutationTest"/> is
+    /// selected. Default 10,000 — the Monte Carlo standard error on a p ≈ 0.05 estimate is
+    /// ~0.002 there. Increase for higher resolution at very small p-values; decrease to
+    /// trade precision for speed.
+    /// </summary>
+    public int PermutationCount { get; private set; } = 10_000;
+
     public void SetLogTransform(bool enabled)
     {
         LogTransform = enabled;
+    }
+
+    public void SetPermutationCount(int count)
+    {
+        if (count < 1) throw new ArgumentOutOfRangeException(nameof(count), "PermutationCount must be ≥ 1.");
+        PermutationCount = count;
     }
 
     public void SetAlpha(double alpha)

--- a/source/Sailfish/Analysis/SailDiff/StatisticalTestExecutor.cs
+++ b/source/Sailfish/Analysis/SailDiff/StatisticalTestExecutor.cs
@@ -2,6 +2,7 @@
 using Sailfish.Analysis.SailDiff.Statistics.Tests;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.KolmogorovSmirnovTestSailfish;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.MWWilcoxonTestSailfish;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.PermutationTest;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.TTest;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.TwoSampleWilcoxonSignedRankTestSailfish;
 using Sailfish.Exceptions;
@@ -19,16 +20,19 @@ public class StatisticalTestExecutor : IStatisticalTestExecutor
     private readonly IMannWhitneyWilcoxonTest _mannWhitneyWilcoxonTestSailfish;
     private readonly ITTest _ttest;
     private readonly ITwoSampleWilcoxonSignedRankTest _twoSampWilcoxonSignedRankTestSailfish;
+    private readonly IPermutationTest _permutationTest;
 
     public StatisticalTestExecutor(IMannWhitneyWilcoxonTest mannWhitneyWilcoxonTestSailfish,
         ITTest ttest,
         ITwoSampleWilcoxonSignedRankTest twoSampWilcoxonSignedRankTestSailfish,
-        IKolmogorovSmirnovTest kolmogorovSmirnovTestSailfish)
+        IKolmogorovSmirnovTest kolmogorovSmirnovTestSailfish,
+        IPermutationTest permutationTest)
     {
         _kolmogorovSmirnovTestSailfish = kolmogorovSmirnovTestSailfish;
         _mannWhitneyWilcoxonTestSailfish = mannWhitneyWilcoxonTestSailfish;
         _ttest = ttest;
         _twoSampWilcoxonSignedRankTestSailfish = twoSampWilcoxonSignedRankTestSailfish;
+        _permutationTest = permutationTest;
     }
 
     public TestResultWithOutlierAnalysis ExecuteStatisticalTest(
@@ -41,7 +45,8 @@ public class StatisticalTestExecutor : IStatisticalTestExecutor
             { TestType.Test, _ttest },
             { TestType.WilcoxonRankSumTest, _mannWhitneyWilcoxonTestSailfish },
             { TestType.TwoSampleWilcoxonSignedRankTest, _twoSampWilcoxonSignedRankTestSailfish },
-            { TestType.KolmogorovSmirnovTest, _kolmogorovSmirnovTestSailfish }
+            { TestType.KolmogorovSmirnovTest, _kolmogorovSmirnovTestSailfish },
+            { TestType.PermutationTest, _permutationTest }
         };
 
         if (!testMap.TryGetValue(settings.TestType, out var value)) throw new SailfishException($"Test type {settings.TestType.ToString()} not supported");

--- a/source/Sailfish/Analysis/SailDiff/Statistics/MinimumDetectableEffect.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/MinimumDetectableEffect.cs
@@ -1,0 +1,114 @@
+using System;
+using MathNet.Numerics.Distributions;
+
+namespace Sailfish.Analysis.SailDiff.Statistics;
+
+/// <summary>
+/// Minimum Detectable Effect (MDE) — given α, target power (1 − β), observed sample variance,
+/// and sample size, the smallest effect a two-sample test could reliably detect.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For two independent samples with equal variance <c>σ²</c> and equal size <c>N</c> the
+/// two-sided MDE for the mean difference is
+/// <c>MDE = (z_{1−α/2} + z_{1−β}) · σ · sqrt(2 / N)</c>
+/// where <c>z_p</c> is the standard-normal quantile at probability <c>p</c>. This is the
+/// standard sample-size / detectable-effect formula (Cohen 1988; Conover §5.1). When the
+/// two samples have different sizes or variances we use the Welch-style approximation
+/// <c>MDE = (z_{1−α/2} + z_{1−β}) · sqrt(var1/n1 + var2/n2)</c>.
+/// </para>
+/// <para>
+/// Two flavours are exposed: the raw MDE in the sample's units, and the relative MDE as
+/// a percentage of the pooled mean — the form benchmark users actually look at ("this run
+/// could detect changes ≥ 8% at α=0.05, 80% power").
+/// </para>
+/// </remarks>
+public static class MinimumDetectableEffect
+{
+    /// <summary>
+    /// Conventional power target for benchmark workflows: 80% power to detect the MDE.
+    /// Equivalent to a Type II error rate of 0.20.
+    /// </summary>
+    public const double DefaultPower = 0.80;
+
+    /// <summary>
+    /// MDE on the raw scale of the inputs — the smallest absolute mean difference the
+    /// two-sample comparison could detect at the given <paramref name="alpha"/> and
+    /// <paramref name="power"/>. Returns <c>null</c> when sample sizes are too small or
+    /// the variance estimates are degenerate.
+    /// </summary>
+    /// <param name="variance1">Sample variance of group 1.</param>
+    /// <param name="n1">Sample size of group 1.</param>
+    /// <param name="variance2">Sample variance of group 2.</param>
+    /// <param name="n2">Sample size of group 2.</param>
+    /// <param name="alpha">Significance level (Type I error rate).</param>
+    /// <param name="power">Desired power (1 − Type II error rate). Defaults to <see cref="DefaultPower"/>.</param>
+    public static double? Absolute(
+        double variance1, int n1,
+        double variance2, int n2,
+        double alpha,
+        double power = DefaultPower)
+    {
+        if (n1 < 2 || n2 < 2) return null;
+        if (variance1 < 0 || variance2 < 0) return null;
+        if (!(alpha > 0 && alpha < 1)) return null;
+        if (!(power > 0 && power < 1)) return null;
+
+        var standardError = Math.Sqrt(variance1 / n1 + variance2 / n2);
+        if (!(standardError > 0)) return null;
+
+        // z-quantiles for the two-sided test. Using the normal approximation; for typical
+        // benchmark N (≥ 10) this is accurate to ~1% versus the exact t-quantile, and the
+        // MDE is itself a planning-stage estimate so the trade-off is fine.
+        var zAlpha = Normal.InvCDF(0, 1, 1.0 - alpha / 2.0);
+        var zBeta = Normal.InvCDF(0, 1, power);
+
+        return (zAlpha + zBeta) * standardError;
+    }
+
+    /// <summary>
+    /// MDE as a percentage of the pooled mean — the user-facing "I could detect ≥ X%
+    /// changes" metric. Pooled mean is the weighted average of the two sample means.
+    /// Returns <c>null</c> when the pooled mean is not strictly positive (the relative
+    /// expression is undefined for zero/negative locations).
+    /// </summary>
+    public static double? RelativePercent(
+        double mean1, double variance1, int n1,
+        double mean2, double variance2, int n2,
+        double alpha,
+        double power = DefaultPower)
+    {
+        var absolute = Absolute(variance1, n1, variance2, n2, alpha, power);
+        if (absolute is null) return null;
+        var pooledMean = (mean1 * n1 + mean2 * n2) / (double)(n1 + n2);
+        if (!(pooledMean > 0)) return null;
+        return absolute.Value / pooledMean * 100.0;
+    }
+
+    /// <summary>
+    /// Sample size needed (per group) to detect a given absolute effect at the given α and
+    /// power, assuming the supplied per-sample variance is representative. Useful for the
+    /// inverse question: "how many iterations do I need to reliably catch a 5% regression?"
+    /// </summary>
+    /// <remarks>
+    /// Solves the equation <c>effect = (z_{1−α/2} + z_{1−β}) · sqrt(2σ²/N)</c> for <c>N</c>,
+    /// rounded up to the next integer. Returns <c>null</c> for degenerate inputs.
+    /// </remarks>
+    public static int? SampleSizePerGroup(
+        double effectAbsolute,
+        double variance,
+        double alpha,
+        double power = DefaultPower)
+    {
+        if (!(effectAbsolute > 0)) return null;
+        if (variance < 0) return null;
+        if (!(alpha > 0 && alpha < 1)) return null;
+        if (!(power > 0 && power < 1)) return null;
+        if (variance == 0) return 2; // any sample size detects a non-zero effect with zero variance
+
+        var zAlpha = Normal.InvCDF(0, 1, 1.0 - alpha / 2.0);
+        var zBeta = Normal.InvCDF(0, 1, power);
+        var n = 2.0 * variance * Math.Pow((zAlpha + zBeta) / effectAbsolute, 2);
+        return (int)Math.Ceiling(n);
+    }
+}

--- a/source/Sailfish/Analysis/SailDiff/Statistics/MinimumDetectableEffect.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/MinimumDetectableEffect.cs
@@ -109,6 +109,14 @@ public static class MinimumDetectableEffect
         var zAlpha = Normal.InvCDF(0, 1, 1.0 - alpha / 2.0);
         var zBeta = Normal.InvCDF(0, 1, power);
         var n = 2.0 * variance * Math.Pow((zAlpha + zBeta) / effectAbsolute, 2);
-        return (int)Math.Ceiling(n);
+
+        // Tiny effects relative to variance can push `n` past int.MaxValue; an unchecked
+        // cast would wrap to a negative count. Saturate at int.MaxValue instead. Conversely,
+        // very large effects relative to variance can give n < 2 — but a two-sample test
+        // still needs at least N=2 per side, so we clamp upward to match the zero-variance
+        // branch's floor.
+        if (double.IsNaN(n)) return null;
+        if (n >= int.MaxValue) return int.MaxValue;
+        return Math.Max(2, (int)Math.Ceiling(n));
     }
 }

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using MathNet.Numerics.Statistics;
 using Sailfish.Analysis.SailDiff.Statistics.StatsCore.Analysers.AnalysersBase;
 using Sailfish.Analysis.SailDiff.Statistics.StatsCore.Analysers.Factories;
+using Sailfish.Analysis.SailDiff.Statistics.StatsCore.MathOps;
 using Sailfish.Contracts.Public;
 using Sailfish.Contracts.Public.Models;
 
@@ -68,6 +69,15 @@ public class KolmogorovSmirnovTest : IKolmogorovSmirnovTest
                 before,
                 after,
                 additionalResults);
+
+            // MDE on the raw scale — same diagnostic for KS as for the other tests so the
+            // formatters can show it uniformly. KS doesn't naturally produce an effect size
+            // (the D statistic *is* the effect size), so we leave that field unset.
+            testResults.MinimumDetectableEffectPercent = MinimumDetectableEffect.RelativePercent(
+                sample1.Mean(), sample1.Variance(), sample1.Length,
+                sample2.Mean(), sample2.Variance(), sample2.Length,
+                settings.Alpha);
+
             return new TestResultWithOutlierAnalysis(testResults, preprocessed1.OutlierAnalysis, preprocessed2.OutlierAnalysis);
         }
         catch (Exception ex)

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTest.cs
@@ -56,6 +56,10 @@ public class KolmogorovSmirnovTest : IKolmogorovSmirnovTest
                 { AdditionalResults.Tail, test.Tail }
             };
 
+            // SampleSize* / RawData* describe the data the test actually consumed (after
+            // outlier removal), matching the mean/median/p-value already computed from the
+            // processed sample. The original user input is still accessible on the wrapping
+            // TestResultWithOutlierAnalysis via Sample1.OriginalData / Sample2.OriginalData.
             var testResults = new StatisticalTestResult(
                 meanBefore,
                 meanAfter,
@@ -64,10 +68,10 @@ public class KolmogorovSmirnovTest : IKolmogorovSmirnovTest
                 testStatistic,
                 pVal,
                 description,
-                before.Length,
-                after.Length,
-                before,
-                after,
+                sample1.Length,
+                sample2.Length,
+                sample1,
+                sample2,
                 additionalResults);
 
             // MDE on the raw scale — same diagnostic for KS as for the other tests so the

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using MathNet.Numerics.Statistics;
 using Sailfish.Analysis.SailDiff.Statistics.StatsCore.Analysers.Factories;
+using Sailfish.Analysis.SailDiff.Statistics.StatsCore.MathOps;
 using Sailfish.Contracts.Public;
 using Sailfish.Contracts.Public.Models;
 
@@ -90,6 +91,15 @@ public class MannWhitneyWilcoxonTest : IMannWhitneyWilcoxonTest
             // (after − before). Robust, distribution-free, and paired with a CI built from
             // the rank-sum critical value at the user's α.
             testResults.Difference = EffectSizes.HodgesLehmann(sample1, sample2, settings.Alpha);
+
+            // MDE percentage — what regression size this run could have caught. The MDE
+            // formula uses the t-test sample-variance approximation regardless of which test
+            // actually ran; for rank-based decisions it's a useful order-of-magnitude proxy
+            // because Mann-Whitney's asymptotic relative efficiency vs. the t-test is ~95%.
+            testResults.MinimumDetectableEffectPercent = MinimumDetectableEffect.RelativePercent(
+                sample1.Mean(), sample1.Variance(), sample1.Length,
+                sample2.Mean(), sample2.Variance(), sample2.Length,
+                settings.Alpha);
 
             return new TestResultWithOutlierAnalysis(testResults, preprocessed1.OutlierAnalysis, preprocessed2.OutlierAnalysis);
         }

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTest.cs
@@ -68,6 +68,10 @@ public class MannWhitneyWilcoxonTest : IMannWhitneyWilcoxonTest
                 { AdditionalResults.Statistic2, test.Statistic2 }
             };
 
+            // SampleSize* / RawData* describe the data the test actually consumed (after
+            // outlier removal), matching the mean/median/p-value already computed from the
+            // processed sample. The original user input is still accessible on the wrapping
+            // TestResultWithOutlierAnalysis via Sample1.OriginalData / Sample2.OriginalData.
             var testResults = new StatisticalTestResult(
                 meanBefore,
                 meanAfter,
@@ -76,10 +80,10 @@ public class MannWhitneyWilcoxonTest : IMannWhitneyWilcoxonTest
                 testStatistic,
                 pVal,
                 description,
-                before.Length,
-                after.Length,
-                before,
-                after,
+                sample1.Length,
+                sample2.Length,
+                sample1,
+                sample2,
                 additionalResults);
 
             // Effect size: Cliff's delta (P(after > before) − P(after < before)). Natural

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/PermutationTest/PermutationTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/PermutationTest/PermutationTest.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using MathNet.Numerics.Statistics;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff.Statistics.StatsCore.MathOps;
+using Sailfish.Contracts.Public;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Analysis.SailDiff.Statistics.Tests.PermutationTest;
+
+public interface IPermutationTest : ITest;
+
+/// <summary>
+/// Two-sample permutation test on the difference in means.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distribution-free p-value: shuffles the joint pool of (sample1 ∪ sample2) labels
+/// <c>K</c> times (default 10,000) and counts how often a random label assignment yields
+/// a mean difference at least as extreme as the one actually observed. Reports the
+/// two-tailed permutation p-value:
+/// <c>p = (1 + #{|stat_k| ≥ |stat_obs|}) / (1 + K)</c>
+/// — the +1 in numerator and denominator implements the recommended bias correction
+/// (Phipson &amp; Smyth, 2010) so a sample of resamples never reports an impossible p = 0.
+/// </para>
+/// <para>
+/// Effect-size and shift-estimate reports mirror the Mann-Whitney wrapper (Cliff's delta,
+/// Hodges-Lehmann shift) since both are distribution-free and natural companions to a
+/// permutation test on means.
+/// </para>
+/// <para>
+/// Run order is deterministic when <see cref="IRunSettings.Seed"/> is set on the run
+/// settings registered with the DI container; otherwise the underlying RNG seeds from
+/// the system clock.
+/// </para>
+/// </remarks>
+public class PermutationTest : IPermutationTest
+{
+    /// <summary>
+    /// Default number of label-permutations used to estimate the null distribution. With
+    /// 10,000 permutations the Monte Carlo standard error on a p ≈ 0.05 is ~0.002 — fine
+    /// for typical α thresholds. Increase via <see cref="SailDiffSettings.PermutationCount"/>
+    /// when you need higher resolution at very small p-values.
+    /// </summary>
+    public const int DefaultPermutationCount = 10_000;
+
+    private readonly ITestPreprocessor _preprocessor;
+    private readonly IRunSettings? _runSettings;
+
+    public PermutationTest(ITestPreprocessor preprocessor)
+    {
+        _preprocessor = preprocessor;
+        _runSettings = null;
+    }
+
+    /// <summary>
+    /// Preferred ctor — consumes <see cref="IRunSettings.Seed"/> via DI so the resample
+    /// stream is reproducible across runs.
+    /// </summary>
+    public PermutationTest(ITestPreprocessor preprocessor, IRunSettings runSettings)
+        : this(preprocessor)
+    {
+        _runSettings = runSettings;
+    }
+
+    public TestResultWithOutlierAnalysis ExecuteTest(double[] before, double[] after, SailDiffSettings settings)
+    {
+        var sigDig = settings.Round;
+
+        try
+        {
+            var preprocessed1 = _preprocessor.Preprocess(before, settings.UseOutlierDetection);
+            var preprocessed2 = _preprocessor.Preprocess(after, settings.UseOutlierDetection);
+            var sample1 = preprocessed1.OutlierAnalysis?.DataWithOutliersRemoved ?? preprocessed1.RawData;
+            var sample2 = preprocessed2.OutlierAnalysis?.DataWithOutliersRemoved ?? preprocessed2.RawData;
+
+            if (sample1.Length < 2 || sample2.Length < 2)
+                throw new ArgumentException("Permutation test requires at least 2 observations per side.");
+
+            var observed = sample2.Mean() - sample1.Mean();
+            var observedAbs = Math.Abs(observed);
+
+            var k = settings.PermutationCount > 0 ? settings.PermutationCount : DefaultPermutationCount;
+            var rng = new Random(_runSettings?.Seed ?? Environment.TickCount);
+
+            // Pool the two samples and resample labels K times. We don't permute in place
+            // because we need the originals to stay correct for the descriptive stats below.
+            var pooled = new double[sample1.Length + sample2.Length];
+            Array.Copy(sample1, 0, pooled, 0, sample1.Length);
+            Array.Copy(sample2, 0, pooled, sample1.Length, sample2.Length);
+
+            // Fisher-Yates shuffle is overkill for this — we can compute mean-of-first-N and
+            // mean-of-rest in O(N) per permutation via partial-sum tracking. Simpler approach:
+            // shuffle the pooled array each iteration and split. O(K · N) total. For K=10K
+            // and N≤1000 that's 10M ops — well under a second.
+            var countAtLeastAsExtreme = 0;
+            var shuffled = (double[])pooled.Clone();
+            for (var iter = 0; iter < k; iter++)
+            {
+                ShuffleInPlace(shuffled, rng);
+
+                // Mean of first n1 elements vs mean of the remaining n2.
+                var sum1 = 0.0;
+                for (var i = 0; i < sample1.Length; i++) sum1 += shuffled[i];
+                var mean1 = sum1 / sample1.Length;
+                var sum2 = 0.0;
+                for (var i = sample1.Length; i < shuffled.Length; i++) sum2 += shuffled[i];
+                var mean2 = sum2 / sample2.Length;
+
+                var permDiff = mean2 - mean1;
+                if (Math.Abs(permDiff) >= observedAbs) countAtLeastAsExtreme++;
+            }
+
+            // Phipson & Smyth (2010): (1 + count) / (1 + K) avoids the impossible p = 0
+            // from a finite Monte Carlo sample.
+            var pVal = (1.0 + countAtLeastAsExtreme) / (1.0 + k);
+            var isSignificant = pVal <= settings.Alpha;
+
+            var meanBefore = Math.Round(sample1.Mean(), sigDig);
+            var meanAfter = Math.Round(sample2.Mean(), sigDig);
+            var medianBefore = Math.Round(sample1.Median(), sigDig);
+            var medianAfter = Math.Round(sample2.Median(), sigDig);
+            var testStatistic = Math.Round(observed, sigDig);
+            var changeDirection = meanAfter > meanBefore
+                ? SailfishChangeDirection.Regressed
+                : SailfishChangeDirection.Improved;
+            var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
+
+            var additionalResults = new Dictionary<string, object>
+            {
+                { AdditionalResults.PermutationCount, k },
+                { AdditionalResults.CountAtLeastAsExtreme, countAtLeastAsExtreme }
+            };
+
+            var testResults = new StatisticalTestResult(
+                meanBefore,
+                meanAfter,
+                medianBefore,
+                medianAfter,
+                testStatistic,
+                Math.Round(pVal, TestConstants.PValueSigDig),
+                description,
+                before.Length,
+                after.Length,
+                before,
+                after,
+                additionalResults);
+
+            // Distribution-free effect size + shift — same suite the Mann-Whitney wrapper
+            // reports, for visual consistency in the output.
+            testResults.EffectSize = EffectSizes.CliffsDelta(sample1, sample2, settings.Alpha);
+            testResults.Difference = EffectSizes.HodgesLehmann(sample1, sample2, settings.Alpha);
+            testResults.MinimumDetectableEffectPercent = MinimumDetectableEffect.RelativePercent(
+                sample1.Mean(), sample1.Variance(), sample1.Length,
+                sample2.Mean(), sample2.Variance(), sample2.Length,
+                settings.Alpha);
+
+            return new TestResultWithOutlierAnalysis(testResults, preprocessed1.OutlierAnalysis, preprocessed2.OutlierAnalysis);
+        }
+        catch (Exception ex)
+        {
+            return new TestResultWithOutlierAnalysis(ex);
+        }
+    }
+
+    private static void ShuffleInPlace(double[] arr, Random rng)
+    {
+        for (var i = arr.Length - 1; i > 0; i--)
+        {
+            var j = rng.Next(i + 1);
+            (arr[i], arr[j]) = (arr[j], arr[i]);
+        }
+    }
+
+    public record AdditionalResults
+    {
+        public const string PermutationCount = "PermutationCount";
+        public const string CountAtLeastAsExtreme = "CountAtLeastAsExtreme";
+    }
+}

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/PermutationTest/PermutationTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/PermutationTest/PermutationTest.cs
@@ -132,6 +132,10 @@ public class PermutationTest : IPermutationTest
                 { AdditionalResults.CountAtLeastAsExtreme, countAtLeastAsExtreme }
             };
 
+            // SampleSize* / RawData* describe the data the test actually consumed (after
+            // outlier removal), matching the mean/median/p-value already computed from the
+            // processed sample. The original user input is still accessible on the wrapping
+            // TestResultWithOutlierAnalysis via Sample1.OriginalData / Sample2.OriginalData.
             var testResults = new StatisticalTestResult(
                 meanBefore,
                 meanAfter,
@@ -140,10 +144,10 @@ public class PermutationTest : IPermutationTest
                 testStatistic,
                 Math.Round(pVal, TestConstants.PValueSigDig),
                 description,
-                before.Length,
-                after.Length,
-                before,
-                after,
+                sample1.Length,
+                sample2.Length,
+                sample1,
+                sample2,
                 additionalResults);
 
             // Distribution-free effect size + shift — same suite the Mann-Whitney wrapper

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TTest/TTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TTest/TTest.cs
@@ -106,6 +106,14 @@ public class Test : ITTest
                     test.Confidence.Min, test.Confidence.Max);
             }
 
+            // MDE on the raw scale, expressed as a percentage of the pooled mean. Answers
+            // "what's the smallest regression this run could have caught?" — actionable when
+            // the result was NoChange but you suspect a real but small effect was missed.
+            testResults.MinimumDetectableEffectPercent = MinimumDetectableEffect.RelativePercent(
+                rawSample1.Mean(), rawSample1.Variance(), rawSample1.Length,
+                rawSample2.Mean(), rawSample2.Variance(), rawSample2.Length,
+                settings.Alpha);
+
             return new TestResultWithOutlierAnalysis(testResults, preprocessed1.OutlierAnalysis, preprocessed2.OutlierAnalysis);
         }
         catch (Exception ex)

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TTest/TTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TTest/TTest.cs
@@ -57,6 +57,10 @@ public class Test : ITTest
             var changeDirection = meanAfter > meanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
             var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
             var additionalResults = new Dictionary<string, object> { { AdditionalResults.DegreesOfFreedom, dof } };
+            // SampleSize* / RawData* describe the data the test actually consumed (after
+            // outlier removal), matching the mean/median/p-value already computed from the
+            // processed sample. The original user input is still accessible on the wrapping
+            // TestResultWithOutlierAnalysis via Sample1.OriginalData / Sample2.OriginalData.
             var testResults = new StatisticalTestResult(
                 meanBefore,
                 meanAfter,
@@ -65,10 +69,10 @@ public class Test : ITTest
                 testStatistic,
                 pVal,
                 description,
-                before.Length,
-                after.Length,
-                before,
-                after,
+                rawSample1.Length,
+                rawSample2.Length,
+                rawSample1,
+                rawSample2,
                 additionalResults);
 
             // Effect size: Hedges' g on the *raw* scale so the reported magnitude is

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTest.cs
@@ -70,6 +70,10 @@ public class TwoSampleWilcoxonSignedRankTest : ITwoSampleWilcoxonSignedRankTest
             var changeDirection = medianAfter > medianBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
             var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
             var additionalResults = new Dictionary<string, object>();
+            // SampleSize* / RawData* describe the data the test actually consumed (after
+            // outlier removal), matching the mean/median/p-value already computed from the
+            // processed sample. The original user input is still accessible on the wrapping
+            // TestResultWithOutlierAnalysis via Sample1.OriginalData / Sample2.OriginalData.
             var testResults = new StatisticalTestResult(
                 meanBefore,
                 meanAfter,
@@ -78,10 +82,10 @@ public class TwoSampleWilcoxonSignedRankTest : ITwoSampleWilcoxonSignedRankTest
                 testStatistic,
                 pval,
                 description,
-                before.Length,
-                after.Length,
-                before,
-                after,
+                sample1.Length,
+                sample2.Length,
+                sample1,
+                sample2,
                 additionalResults);
 
             // MDE on the raw scale — consistent with the other wrappers. For paired data the

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using MathNet.Numerics.Statistics;
 using Sailfish.Analysis.SailDiff.Statistics.StatsCore.Analysers.Factories;
+using Sailfish.Analysis.SailDiff.Statistics.StatsCore.MathOps;
 using Sailfish.Contracts.Public;
 using Sailfish.Contracts.Public.Models;
 
@@ -54,10 +55,15 @@ public class TwoSampleWilcoxonSignedRankTest : ITwoSampleWilcoxonSignedRankTest
 
             var test = TwoSampleWilcoxonSignedRankFactory.Create(sample1, sample2);
 
-            var meanBefore = Math.Round(before.Mean(), sigDig);
-            var meanAfter = Math.Round(after.Mean(), sigDig);
-            var medianBefore = Math.Round(before.Median(), sigDig);
-            var medianAfter = Math.Round(after.Median(), sigDig);
+            // Descriptive stats reported on the *processed* sample (post-outlier-removal /
+            // alignment), matching every other test wrapper and the p-value just computed.
+            // Pre-Tier-3 this branch reported `before.Mean()` / `after.Mean()` on the raw
+            // input arrays, so the visible mean and the test verdict could describe
+            // different data when outlier detection was on.
+            var meanBefore = Math.Round(sample1.Mean(), sigDig);
+            var meanAfter = Math.Round(sample2.Mean(), sigDig);
+            var medianBefore = Math.Round(sample1.Median(), sigDig);
+            var medianAfter = Math.Round(sample2.Median(), sigDig);
             var testStatistic = Math.Round(test.Statistic, sigDig);
             var pval = test.PValue;
             var isSignificant = pval <= settings.Alpha;
@@ -77,6 +83,15 @@ public class TwoSampleWilcoxonSignedRankTest : ITwoSampleWilcoxonSignedRankTest
                 before,
                 after,
                 additionalResults);
+
+            // MDE on the raw scale — consistent with the other wrappers. For paired data the
+            // formula is a slight over-estimate (it ignores the pairing-induced correlation
+            // reduction) but useful as an order-of-magnitude planning number.
+            testResults.MinimumDetectableEffectPercent = MinimumDetectableEffect.RelativePercent(
+                sample1.Mean(), sample1.Variance(), sample1.Length,
+                sample2.Mean(), sample2.Variance(), sample2.Length,
+                settings.Alpha);
+
             return new TestResultWithOutlierAnalysis(testResults, preprocessed1.OutlierAnalysis, preprocessed2.OutlierAnalysis);
         }
         catch (Exception ex)

--- a/source/Sailfish/Analysis/SailDiff/TestType.cs
+++ b/source/Sailfish/Analysis/SailDiff/TestType.cs
@@ -44,5 +44,16 @@ public enum TestType
     /// than rank-sum for pure location shifts; use when you suspect distributional changes
     /// (e.g., a new code path with bimodal latency) rather than a simple "is run B faster?".
     /// </summary>
-    KolmogorovSmirnovTest
+    KolmogorovSmirnovTest,
+
+    /// <summary>
+    /// Permutation test on the difference in means. Approximate-exact: shuffles the joint
+    /// sample-1 / sample-2 labels <c>K</c> times (default 10,000) and counts how often a
+    /// random permutation produces a mean difference at least as extreme as the observed
+    /// one. Distribution-free, no parametric assumption — robust against heavy-tailed and
+    /// multi-modal timing data where the t-test's normality assumption is shaky. Slower
+    /// than the analytic tests by roughly a factor of <c>K / N</c>; use when the data has
+    /// visible outliers you can't justify removing.
+    /// </summary>
+    PermutationTest
 }

--- a/source/Sailfish/Contracts.Private/CsvMaps/SailDiffWriteAsCsvMap.cs
+++ b/source/Sailfish/Contracts.Private/CsvMaps/SailDiffWriteAsCsvMap.cs
@@ -8,6 +8,10 @@ internal sealed class SailDiffWriteAsCsvMap : ClassMap<SailDiffResult>
 {
     public SailDiffWriteAsCsvMap()
     {
+        // Legacy columns 0..11 preserved verbatim for back-compat with existing CSV
+        // consumers. Tier-2/3 magnitude columns appended from index 12 onwards via Convert
+        // — CsvHelper can't extract nested-record / nullable fields from a member-access
+        // expression alone, so we project to strings explicitly.
         Map(m => m.TestCaseId.DisplayName).Index(0);
         Map(m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.MeanBefore).Index(1);
         Map(m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.MeanAfter).Index(2);
@@ -20,5 +24,29 @@ internal sealed class SailDiffWriteAsCsvMap : ClassMap<SailDiffResult>
         Map(m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.SampleSizeAfter).Index(9);
         Map(m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.RawDataBefore).TypeConverter<DoubleArrayCsvConverter>().Index(10);
         Map(m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.RawDataAfter).TypeConverter<DoubleArrayCsvConverter>().Index(11);
+
+        // BH-FDR–adjusted q-value across the family of comparisons.
+        Map().Name("QValue").Index(12).Convert(args => Stat(args.Value)?.QValue?.ToString() ?? string.Empty);
+
+        // Effect size: name + value + CI bounds. Empty cells when the test type didn't
+        // emit an effect size (e.g. KS).
+        Map().Name("EffectName").Index(13).Convert(args => Stat(args.Value)?.EffectSize?.Name ?? string.Empty);
+        Map().Name("EffectValue").Index(14).Convert(args => Stat(args.Value)?.EffectSize?.Value.ToString() ?? string.Empty);
+        Map().Name("EffectCiLower").Index(15).Convert(args => Stat(args.Value)?.EffectSize?.CiLower?.ToString() ?? string.Empty);
+        Map().Name("EffectCiUpper").Index(16).Convert(args => Stat(args.Value)?.EffectSize?.CiUpper?.ToString() ?? string.Empty);
+
+        // Shift estimate (Mean diff / Hodges-Lehmann / Log-ratio) — name, value, CI, units.
+        Map().Name("ShiftName").Index(17).Convert(args => Stat(args.Value)?.Difference?.Name ?? string.Empty);
+        Map().Name("ShiftValue").Index(18).Convert(args => Stat(args.Value)?.Difference?.Value.ToString() ?? string.Empty);
+        Map().Name("ShiftCiLower").Index(19).Convert(args => Stat(args.Value)?.Difference?.CiLower?.ToString() ?? string.Empty);
+        Map().Name("ShiftCiUpper").Index(20).Convert(args => Stat(args.Value)?.Difference?.CiUpper?.ToString() ?? string.Empty);
+        Map().Name("ShiftUnits").Index(21).Convert(args => Stat(args.Value)?.Difference?.Units ?? string.Empty);
+
+        // Minimum detectable effect as a percentage of the pooled mean.
+        Map().Name("MdePercent").Index(22).Convert(args =>
+            Stat(args.Value)?.MinimumDetectableEffectPercent?.ToString() ?? string.Empty);
     }
+
+    private static StatisticalTestResult? Stat(object value) =>
+        (value as SailDiffResult)?.TestResultsWithOutlierAnalysis?.StatisticalTestResult;
 }

--- a/source/Sailfish/Contracts.Public/Models/StatisticalTestResult.cs
+++ b/source/Sailfish/Contracts.Public/Models/StatisticalTestResult.cs
@@ -81,4 +81,13 @@ public class StatisticalTestResult
     /// <c>null</c> when the test failed or only a single comparison ran.
     /// </summary>
     public double? QValue { get; set; }
+
+    /// <summary>
+    /// Minimum detectable effect — at the configured α and the conventional 80% power, the
+    /// smallest change the run could reliably catch, expressed as a percentage of the
+    /// pooled mean. Large values (say &gt; 10%) mean the run is underpowered for typical
+    /// benchmark regressions. <c>null</c> when the inputs are degenerate (zero variance,
+    /// non-positive mean, or too few samples).
+    /// </summary>
+    public double? MinimumDetectableEffectPercent { get; set; }
 }

--- a/source/Sailfish/Contracts.Public/TestResultTableContentFormatter.cs
+++ b/source/Sailfish/Contracts.Public/TestResultTableContentFormatter.cs
@@ -131,8 +131,10 @@ public class SailDiffResultMarkdownConverter : ISailDiffResultMarkdownConverter
     private static string FormatEffectSize(Sailfish.Contracts.Public.Models.EffectSizeReport? effect)
     {
         if (effect is null) return string.Empty;
+        // CI bounds use the same 0.### precision as the point estimate (and as FormatDifference)
+        // so all bracket-style reports show consistent precision in console/markdown output.
         var ci = effect.CiLower.HasValue && effect.CiUpper.HasValue
-            ? $" [{effect.CiLower.Value:0.##}, {effect.CiUpper.Value:0.##}]"
+            ? $" [{effect.CiLower.Value:0.###}, {effect.CiUpper.Value:0.###}]"
             : string.Empty;
         return $"{effect.Name}={effect.Value:0.###}{ci}";
     }

--- a/source/Sailfish/Contracts.Public/TestResultTableContentFormatter.cs
+++ b/source/Sailfish/Contracts.Public/TestResultTableContentFormatter.cs
@@ -90,16 +90,27 @@ public class SailDiffResultMarkdownConverter : ISailDiffResultMarkdownConverter
             m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.MedianBefore,
             m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.MedianAfter,
             m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.PValue,
+            // Tier-2 fields surface in the legacy markdown so consumers that still depend on
+            // this format (and there are several) see the same magnitude story as the IDE
+            // banner. Nullable values render as empty cells.
+            m => FormatQValue(m.TestResultsWithOutlierAnalysis.StatisticalTestResult.QValue),
+            m => FormatEffectSize(m.TestResultsWithOutlierAnalysis.StatisticalTestResult.EffectSize),
+            m => FormatDifference(m.TestResultsWithOutlierAnalysis.StatisticalTestResult.Difference),
+            m => FormatMde(m.TestResultsWithOutlierAnalysis.StatisticalTestResult.MinimumDetectableEffectPercent),
             m => m.TestResultsWithOutlierAnalysis.StatisticalTestResult.ChangeDescription
         };
 
         var headers = new List<string>
         {
-            "Display Name", $"MeanBefore (N={nBefore})", $"MeanAfter (N={nAfter})", "MedianBefore", "MedianAfter", "PValue", "Change Description"
+            "Display Name",
+            $"MeanBefore (N={nBefore})", $"MeanAfter (N={nAfter})",
+            "MedianBefore", "MedianAfter",
+            "PValue", "QValue (BH)", "Effect", "Shift", "MDE",
+            "Change Description"
         };
         var columnValueSuffixes = new List<string>
         {
-            "", "ms", "ms", "ms", "ms", "", ""
+            "", "ms", "ms", "ms", "ms", "", "", "", "", "%", ""
         };
 
         if (enumeratedResults.Any(x => !string.IsNullOrEmpty(x.TestResultsWithOutlierAnalysis.ExceptionMessage)))
@@ -114,6 +125,28 @@ public class SailDiffResultMarkdownConverter : ISailDiffResultMarkdownConverter
             headers,
             [.. selectors]);
     }
+
+    private static string FormatQValue(double? q) => q.HasValue ? q.Value.ToString("0.####") : string.Empty;
+
+    private static string FormatEffectSize(Sailfish.Contracts.Public.Models.EffectSizeReport? effect)
+    {
+        if (effect is null) return string.Empty;
+        var ci = effect.CiLower.HasValue && effect.CiUpper.HasValue
+            ? $" [{effect.CiLower.Value:0.##}, {effect.CiUpper.Value:0.##}]"
+            : string.Empty;
+        return $"{effect.Name}={effect.Value:0.###}{ci}";
+    }
+
+    private static string FormatDifference(Sailfish.Contracts.Public.Models.DifferenceReport? diff)
+    {
+        if (diff is null) return string.Empty;
+        var ci = diff.CiLower.HasValue && diff.CiUpper.HasValue
+            ? $" [{diff.CiLower.Value:0.###}, {diff.CiUpper.Value:0.###}]"
+            : string.Empty;
+        return $"{diff.Value:0.###} {diff.Units}{ci}";
+    }
+
+    private static string FormatMde(double? mde) => mde.HasValue ? mde.Value.ToString("0.##") : string.Empty;
 
     private string CreateUnifiedFormattedOutput(List<SailDiffResult> enumeratedResults, OutputContext context, double alpha)
     {

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -8,6 +8,7 @@ using Sailfish.Analysis.SailDiff.Statistics;
 using Sailfish.Analysis.SailDiff.Statistics.Tests;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.KolmogorovSmirnovTestSailfish;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.MWWilcoxonTestSailfish;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.PermutationTest;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.TTest;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.TwoSampleWilcoxonSignedRankTestSailfish;
 using Sailfish.Analysis.ScaleFish;
@@ -145,6 +146,7 @@ internal class SailfishModuleRegistrations : IProvideAdditionalRegistrations
         builder.RegisterType<MannWhitneyWilcoxonTest>().As<IMannWhitneyWilcoxonTest>();
         builder.RegisterType<TwoSampleWilcoxonSignedRankTest>().As<ITwoSampleWilcoxonSignedRankTest>();
         builder.RegisterType<KolmogorovSmirnovTest>().As<IKolmogorovSmirnovTest>();
+        builder.RegisterType<PermutationTest>().As<IPermutationTest>();
         builder.RegisterType<ScalefishObservationCompiler>().As<IScalefishObservationCompiler>();
         builder.RegisterType<SailDiffConsoleWindowMessageFormatter>().As<ISailDiffConsoleWindowMessageFormatter>();
     }

--- a/source/Tests.Library/Analysis/SailDiff/MinimumDetectableEffectTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/MinimumDetectableEffectTests.cs
@@ -1,0 +1,146 @@
+using System;
+using Sailfish.Analysis.SailDiff.Statistics;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+/// <summary>
+/// Hand-derivable goldens for the MDE / sample-size utility.
+/// </summary>
+/// <remarks>
+/// Reference values come from the closed-form expression
+/// <c>MDE = (z_{1−α/2} + z_{1−β}) · sqrt(var1/n1 + var2/n2)</c>
+/// with <c>z_{0.975} = 1.95996...</c> and <c>z_{0.80} = 0.84162...</c>.
+/// </remarks>
+public class MinimumDetectableEffectTests
+{
+    [Fact]
+    public void Absolute_DefaultPower_MatchesHandFormula()
+    {
+        // var1 = var2 = 4, n1 = n2 = 100, α = 0.05, power = 0.80.
+        // SE = sqrt(4/100 + 4/100) = sqrt(0.08) = 0.28284...
+        // MDE = (1.95996 + 0.84162) × 0.28284 ≈ 0.79248
+        var result = MinimumDetectableEffect.Absolute(
+            variance1: 4, n1: 100,
+            variance2: 4, n2: 100,
+            alpha: 0.05);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.7925, tolerance: 1e-3);
+    }
+
+    [Fact]
+    public void Absolute_TighterAlpha_RequiresLargerEffect()
+    {
+        // Same data, tighter α should produce a larger MDE because z_{1−α/2} grows.
+        var loose = MinimumDetectableEffect.Absolute(4, 100, 4, 100, alpha: 0.05)!.Value;
+        var tight = MinimumDetectableEffect.Absolute(4, 100, 4, 100, alpha: 0.01)!.Value;
+
+        tight.ShouldBeGreaterThan(loose);
+    }
+
+    [Fact]
+    public void Absolute_HigherPower_RequiresLargerEffect()
+    {
+        // More demanding power target (β smaller) requires a larger detectable effect.
+        var low = MinimumDetectableEffect.Absolute(4, 100, 4, 100, alpha: 0.05, power: 0.80)!.Value;
+        var high = MinimumDetectableEffect.Absolute(4, 100, 4, 100, alpha: 0.05, power: 0.95)!.Value;
+
+        high.ShouldBeGreaterThan(low);
+    }
+
+    [Fact]
+    public void Absolute_LargerN_ReducesDetectableEffect()
+    {
+        // More samples → tighter SE → smaller MDE.
+        var small = MinimumDetectableEffect.Absolute(4, 30, 4, 30, alpha: 0.05)!.Value;
+        var large = MinimumDetectableEffect.Absolute(4, 300, 4, 300, alpha: 0.05)!.Value;
+
+        large.ShouldBeLessThan(small);
+        // sqrt(N) scaling: 10× the samples should shrink MDE by sqrt(10) ≈ 3.16×.
+        (small / large).ShouldBe(Math.Sqrt(10.0), tolerance: 0.05);
+    }
+
+    [Fact]
+    public void Absolute_NullForTooFewSamples()
+    {
+        MinimumDetectableEffect.Absolute(1, 1, 1, 5, 0.05).ShouldBeNull();
+        MinimumDetectableEffect.Absolute(1, 5, 1, 1, 0.05).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Absolute_NullForInvalidAlphaOrPower()
+    {
+        MinimumDetectableEffect.Absolute(1, 10, 1, 10, alpha: -0.1).ShouldBeNull();
+        MinimumDetectableEffect.Absolute(1, 10, 1, 10, alpha: 1.5).ShouldBeNull();
+        MinimumDetectableEffect.Absolute(1, 10, 1, 10, alpha: 0.05, power: 0).ShouldBeNull();
+        MinimumDetectableEffect.Absolute(1, 10, 1, 10, alpha: 0.05, power: 1.0).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Absolute_NullForZeroVariance()
+    {
+        // SE collapses to 0 — the MDE expression returns 0 mathematically, which we surface
+        // as null since "any non-zero difference is detectable" isn't a useful answer.
+        MinimumDetectableEffect.Absolute(0, 10, 0, 10, alpha: 0.05).ShouldBeNull();
+    }
+
+    [Fact]
+    public void RelativePercent_ConvertsToShareOfPooledMean()
+    {
+        // mean1 = mean2 = 100, var1 = var2 = 4, n1 = n2 = 100, α = 0.05, power = 0.80
+        // Pooled mean = 100. Absolute MDE ≈ 0.7925.
+        // Relative% = 0.7925 / 100 × 100 = 0.7925%.
+        var result = MinimumDetectableEffect.RelativePercent(
+            mean1: 100, variance1: 4, n1: 100,
+            mean2: 100, variance2: 4, n2: 100,
+            alpha: 0.05);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.7925, tolerance: 1e-3);
+    }
+
+    [Fact]
+    public void RelativePercent_NullForNonPositiveMean()
+    {
+        // Zero / negative pooled mean ⇒ relative MDE undefined.
+        MinimumDetectableEffect.RelativePercent(0, 4, 100, 0, 4, 100, 0.05).ShouldBeNull();
+        MinimumDetectableEffect.RelativePercent(-10, 4, 100, -10, 4, 100, 0.05).ShouldBeNull();
+    }
+
+    [Fact]
+    public void SampleSizePerGroup_InvertsTheMdeFormula()
+    {
+        // Round-trip: given a target absolute MDE of 0.7925 with var = 4 and α = 0.05,
+        // power = 0.80, the formula should recover N ≈ 100. Round up gives 100.
+        var n = MinimumDetectableEffect.SampleSizePerGroup(0.7925, variance: 4, alpha: 0.05);
+        n.ShouldNotBeNull();
+        n!.Value.ShouldBeInRange(99, 101);
+    }
+
+    [Fact]
+    public void SampleSizePerGroup_SmallerEffect_RequiresLargerN()
+    {
+        var nBig = MinimumDetectableEffect.SampleSizePerGroup(1.0, 4, 0.05)!.Value;
+        var nSmall = MinimumDetectableEffect.SampleSizePerGroup(0.1, 4, 0.05)!.Value;
+
+        // Effect 10× smaller ⇒ N 100× larger.
+        nSmall.ShouldBeGreaterThan(nBig * 90);
+    }
+
+    [Fact]
+    public void SampleSizePerGroup_ZeroEffectIsUndefined()
+    {
+        MinimumDetectableEffect.SampleSizePerGroup(0, 4, 0.05).ShouldBeNull();
+        MinimumDetectableEffect.SampleSizePerGroup(-1, 4, 0.05).ShouldBeNull();
+    }
+
+    [Fact]
+    public void SampleSizePerGroup_ZeroVarianceCollapsesToTwo()
+    {
+        // No noise → any non-zero effect is detectable at N=2 (minimum for the t-test).
+        MinimumDetectableEffect.SampleSizePerGroup(0.5, variance: 0, alpha: 0.05).ShouldBe(2);
+    }
+}
+

--- a/source/Tests.Library/Analysis/SailDiff/PermutationTestTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/PermutationTestTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using NSubstitute;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.PermutationTest;
+using Sailfish.Contracts.Public;
+using Sailfish.Contracts.Public.Models;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+/// <summary>
+/// Hand-verifiable behavioural goldens for the two-sample permutation test.
+/// </summary>
+public class PermutationTestTests
+{
+    [Fact]
+    public void IdenticalSamples_GiveLargeNonSignificantPValue()
+    {
+        // sample1 == sample2 ⇒ every label permutation produces the same |mean difference|
+        // as the observed one (zero), so the count "at least as extreme" equals K. The
+        // Phipson & Smyth bias correction gives p = (1+K)/(1+K) = 1.
+        var sample = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var test = MakeTest(seed: 42);
+
+        var result = test.ExecuteTest(sample, sample,
+            new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest));
+
+        result.ExceptionMessage.ShouldBeEmpty();
+        result.StatisticalTestResult.PValue.ShouldBe(1.0, tolerance: 1e-9);
+        result.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.NoChange);
+    }
+
+    [Fact]
+    public void StronglySeparatedSamples_ProduceTinyPValue()
+    {
+        // All values in sample2 > all values in sample1 → the observed mean difference is
+        // the largest possible under any label permutation. The only permutations matching
+        // it are those that recover the original split, giving p ≈ 1 / C(20, 10) ≈ 5e-6.
+        // Phipson-Smyth lower bound at K=10000 is 1/10001 ≈ 1e-4, so the test reports the
+        // floor here.
+        var sample1 = Enumerable.Range(0, 10).Select(i => (double)i).ToArray();
+        var sample2 = Enumerable.Range(100, 10).Select(i => (double)i).ToArray();
+        var test = MakeTest(seed: 42);
+
+        var result = test.ExecuteTest(sample1, sample2,
+            new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest));
+
+        result.ExceptionMessage.ShouldBeEmpty();
+        result.StatisticalTestResult.PValue.ShouldBeLessThan(0.001);
+        result.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Regressed);
+    }
+
+    [Fact]
+    public void Deterministic_GivenSeed_SameP()
+    {
+        // Two runs with the same RunSettings.Seed must produce bit-identical p-values.
+        var rng = new Random(1);
+        var sample1 = Enumerable.Range(0, 30).Select(_ => 100 + rng.NextDouble() * 5).ToArray();
+        var sample2 = Enumerable.Range(0, 30).Select(_ => 102 + rng.NextDouble() * 5).ToArray();
+
+        var settings = new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest);
+
+        var a = MakeTest(seed: 1234).ExecuteTest(sample1, sample2, settings);
+        var b = MakeTest(seed: 1234).ExecuteTest(sample1, sample2, settings);
+
+        a.StatisticalTestResult.PValue.ShouldBe(b.StatisticalTestResult.PValue);
+    }
+
+    [Fact]
+    public void Deterministic_DifferentSeeds_AreClose()
+    {
+        // Different RNG streams can produce slightly different Monte Carlo p-values, but
+        // both should fall well within the Monte Carlo SE (~0.002 at K=10000, p≈0.5).
+        var rng = new Random(1);
+        var sample1 = Enumerable.Range(0, 30).Select(_ => 100 + rng.NextDouble() * 5).ToArray();
+        var sample2 = Enumerable.Range(0, 30).Select(_ => 102 + rng.NextDouble() * 5).ToArray();
+
+        var settings = new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest);
+
+        var a = MakeTest(seed: 1234).ExecuteTest(sample1, sample2, settings);
+        var b = MakeTest(seed: 9999).ExecuteTest(sample1, sample2, settings);
+
+        Math.Abs(a.StatisticalTestResult.PValue - b.StatisticalTestResult.PValue).ShouldBeLessThan(0.01);
+    }
+
+    [Fact]
+    public void PermutationCount_LowerSetting_RunsFaster_AndStillProducesValidP()
+    {
+        // Smaller K → coarser p-value resolution but still a valid probability. Phipson &
+        // Smyth lower bound at K=100 is 1/101 ≈ 0.01; matching that for the all-separated
+        // case below.
+        var sample1 = Enumerable.Range(0, 10).Select(i => (double)i).ToArray();
+        var sample2 = Enumerable.Range(100, 10).Select(i => (double)i).ToArray();
+
+        var settings = new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest);
+        settings.SetPermutationCount(100);
+
+        var result = MakeTest(seed: 42).ExecuteTest(sample1, sample2, settings);
+        result.ExceptionMessage.ShouldBeEmpty();
+        result.StatisticalTestResult.PValue.ShouldBeInRange(0.0, 1.0);
+    }
+
+    [Fact]
+    public void PopulatesEffectSizeAndDifferenceLikeRankSum()
+    {
+        // Permutation test borrows the rank-sum effect-size suite for consistency.
+        var rng = new Random(7);
+        var sample1 = Enumerable.Range(0, 20).Select(_ => 100 + rng.NextDouble() * 5).ToArray();
+        var sample2 = Enumerable.Range(0, 20).Select(_ => 110 + rng.NextDouble() * 5).ToArray();
+
+        var settings = new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest);
+        var result = MakeTest(seed: 42).ExecuteTest(sample1, sample2, settings);
+
+        result.StatisticalTestResult.EffectSize.ShouldNotBeNull();
+        result.StatisticalTestResult.EffectSize!.Name.ShouldBe("Cliff's delta");
+
+        result.StatisticalTestResult.Difference.ShouldNotBeNull();
+        result.StatisticalTestResult.Difference!.Name.ShouldBe("Hodges-Lehmann shift");
+    }
+
+    [Fact]
+    public void TooSmallSamples_ReturnError()
+    {
+        // Minimum useful permutation test is 2v2 → C(4,2) = 6 distinct permutations.
+        // Below that the test should error rather than emit garbage.
+        var settings = new SailDiffSettings(alpha: 0.05, useOutlierDetection: false, testType: TestType.PermutationTest);
+        var result = MakeTest(seed: 42).ExecuteTest(new[] { 1.0 }, new[] { 2.0 }, settings);
+
+        result.ExceptionMessage.ShouldNotBeNullOrEmpty();
+    }
+
+    private static PermutationTest MakeTest(int? seed)
+    {
+        var preprocessor = new TestPreprocessor(new SailfishOutlierDetector());
+        if (seed is null) return new PermutationTest(preprocessor);
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.Seed.Returns(seed.Value);
+        return new PermutationTest(preprocessor, runSettings);
+    }
+}

--- a/source/Tests.Library/E2EScenarios/Handlers/SailDiffAnalysisCompletedNotificationHandlerTests.cs
+++ b/source/Tests.Library/E2EScenarios/Handlers/SailDiffAnalysisCompletedNotificationHandlerTests.cs
@@ -63,8 +63,11 @@ public class SailDiffAnalysisCompleteNotificationHandlerTests : IDisposable
         var files = Directory.GetFiles(outputDirectory);
         var mdContent = await File.ReadAllTextAsync(files.Single(x => x.EndsWith(DefaultFileSettings.MarkdownSuffix)));
         var csvContent = await File.ReadAllTextAsync(files.Single(x => x.EndsWith(DefaultFileSettings.CsvSuffix)));
+        // Tier-3 appended QValue, Effect{Name,Value,CiLower,CiUpper}, Shift{Name,Value,
+        // CiLower,CiUpper,Units}, and MdePercent columns. The fixture's StatisticalTestResult
+        // doesn't populate those, so they render as empty cells (the trailing commas).
         const string expectedCsv = """
-                                   5,6,5,5,345,0.001,No Change,3,3,"1,2,3","9,10,11"
+                                   5,6,5,5,345,0.001,No Change,3,3,"1,2,3","9,10,11",,,,,,,,,,,
                                    """;
         files.Length.ShouldBe(2);
         mdContent.ShouldBe("This is some markdown");

--- a/source/Tests.Library/ExtensionMethods/TableParserExtensionMethodsFixture.cs
+++ b/source/Tests.Library/ExtensionMethods/TableParserExtensionMethodsFixture.cs
@@ -51,7 +51,8 @@ public class TableParserExtensionMethodsFixture
             new MannWhitneyWilcoxonTest(preprocessor),
             new Test(preprocessor),
             new TwoSampleWilcoxonSignedRankTest(preprocessor),
-            new KolmogorovSmirnovTest(preprocessor)
+            new KolmogorovSmirnovTest(preprocessor),
+            new Sailfish.Analysis.SailDiff.Statistics.Tests.PermutationTest.PermutationTest(preprocessor)
         ).ExecuteStatisticalTest(
             [2, 2, 4, 4, 5, 5, 6, 7, 6],
             [9, 8, 7, 6, 4, 4, 1, 2, 3, 2],

--- a/source/Tests.TestAdapter/DirectoryRecursionTests.cs
+++ b/source/Tests.TestAdapter/DirectoryRecursionTests.cs
@@ -29,27 +29,35 @@ public class DirectoryRecursionTests
     [Fact]
     public void RecurseUpwardsUntilFileIsFound_WithValidFile_ShouldReturnFileInfo()
     {
-        // Arrange
-        var currentDirectory = Directory.GetCurrentDirectory();
-        var testFile = Path.Combine(currentDirectory, "test.csproj");
-        
-        // Create a temporary test file
-        File.WriteAllText(testFile, "<Project></Project>");
-        
+        // Build an isolated three-level dir tree under Path.GetTempPath() with the .csproj
+        // file at the top. Pre-fix this test used Directory.GetCurrentDirectory() as the
+        // start point and dropped a test.csproj into it — but RecurseUpwardsUntilFileIsFound
+        // searches the *parent* of its source path, so it only succeeded when something else
+        // in the test runner's working-directory chain happened to contain a .csproj. CI
+        // layouts that lack that ancestry (build agents, dotnet test in detached mode) made
+        // the test flake. The temp-dir tree is hermetic.
+        var rootDir = Path.Combine(Path.GetTempPath(), "Sailfish_DirRecursionTest_" + Guid.NewGuid().ToString("N"));
+        var middleDir = Path.Combine(rootDir, "middle");
+        var leafDir = Path.Combine(middleDir, "leaf");
+        Directory.CreateDirectory(leafDir);
+
+        var csprojPath = Path.Combine(rootDir, "TestProject.csproj");
+        File.WriteAllText(csprojPath, "<Project></Project>");
+        // The function inspects files in Path.GetDirectoryName(sourceFile); pass a file in
+        // the leaf directory so the recursion has to walk up two levels to find the csproj.
+        var sourceFile = Path.Combine(leafDir, "source.cs");
+        File.WriteAllText(sourceFile, string.Empty);
+
         try
         {
-            // Act
-            var result = DirectoryRecursion.RecurseUpwardsUntilFileIsFound(".csproj", currentDirectory, 5);
+            var result = DirectoryRecursion.RecurseUpwardsUntilFileIsFound(".csproj", sourceFile, 5);
 
-            // Assert
             result.ShouldNotBeNull();
-            result.Name.ShouldEndWith(".csproj");
+            result.Name.ShouldBe("TestProject.csproj");
         }
         finally
         {
-            // Cleanup
-            if (File.Exists(testFile))
-                File.Delete(testFile);
+            if (Directory.Exists(rootDir)) Directory.Delete(rootDir, recursive: true);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the SailDiff rigor roadmap with power/UX work that converts NoChange verdicts into actionable signals and surfaces every Tier 2 field through every output path.

## What's in the box

### Minimum Detectable Effect (MDE) on every result
- New \`StatisticalTestResult.MinimumDetectableEffectPercent\` — at the configured α and a conventional 80% power, the smallest change this run could reliably catch as a percentage of the pooled mean. Answers \"why didn't we catch anything?\" — when MDE is large, the run is underpowered for typical benchmark regressions.
- New public \`MinimumDetectableEffect\` helper exposes both \`Absolute()\` (raw units) and the inverse \`SampleSizePerGroup(effect, var, α)\` — answers \"how many iterations to detect a 5% regression?\".
- All four test wrappers (t-test, rank-sum, KS, signed-rank, and the new permutation test) populate the MDE field uniformly so it's available regardless of which TestType is selected.

### Permutation test option (\`TestType.PermutationTest\`)
- Distribution-free two-sample test: shuffles the joint pool of (sample1 ∪ sample2) labels K times (default 10,000) and counts how often a random label assignment yields a mean difference at least as extreme as the observed one.
- **Phipson-Smyth bias correction** (\`p = (1 + count) / (1 + K)\`) — a finite Monte Carlo sample never reports an impossible \`p = 0\`.
- New \`SailDiffSettings.PermutationCount\` + setter.
- Deterministic when \`IRunSettings.Seed\` is set (DI-injected).
- Borrows the rank-sum effect-size suite (Cliff's delta + Hodges-Lehmann shift) for output consistency.
- Robust against heavy-tailed and multi-modal timing data where the t-test's normality assumption is shaky.

### Markdown formatter completeness
\`TestResultTableContentFormatter\` legacy markdown table now includes the Tier 2 columns: \`QValue (BH)\`, \`Effect\`, \`Shift\`, \`MDE %\`. Empty cells when the test type doesn't produce a particular field.

### CSV formatter completeness
\`SailDiffWriteAsCsvMap\` gains 11 new columns (indexes 12..22): \`QValue\`, \`EffectName\`, \`EffectValue\`, \`EffectCiLower\`, \`EffectCiUpper\`, \`ShiftName\`, \`ShiftValue\`, \`ShiftCiLower\`, \`ShiftCiUpper\`, \`ShiftUnits\`, \`MdePercent\`. Legacy columns 0..11 preserved verbatim for back-compat with existing consumers.

## Debt cleared in the same change

**Signed-rank descriptive stats consistency.** The wrapper used to report \`before.Mean()\` / \`after.Mean()\` on the *raw* input arrays even when outlier detection had shrunk the samples the test actually saw — visible mean and test verdict could describe different data. Now reports on the post-preprocessing sample, matching every other wrapper (and matching the consistency fix Tier 1 made for Mann-Whitney).

## Tests

- **\`MinimumDetectableEffectTests\` (13)** — hand-derivable goldens for \`Absolute\`, \`RelativePercent\`, \`SampleSizePerGroup\` including the sqrt(N) scaling identity and degenerate-input null returns.
- **\`PermutationTestTests\` (7)** — identical samples → p ≈ 1, fully separated → p hits the Phipson-Smyth floor, determinism under same seed, different seeds give close p-values (within Monte Carlo SE), \`PermutationCount\` knob effect, effect-size population, too-small-sample error.
- Existing tests updated where the new public surface needed it (executor ctor takes the new dependency; CSV golden absorbs the new empty-trailing columns).

Full suite: **1963 / 1963 green**.

## Test plan

- [ ] CI green
- [ ] Run SailDiff with \`new SailDiffSettings(testType: TestType.PermutationTest)\` on a benchmark with heavy-tailed timings and confirm the p-value is in a sensible range.
- [ ] Inspect a CSV from a real run and confirm the new columns (QValue, EffectName, EffectValue, etc.) populate as expected.
- [ ] Inspect the markdown output and confirm MDE, Effect, Shift columns render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new permutation test statistical test type for two-sample comparisons.
  * All statistical tests now report minimum detectable effect as a percentage.
  * Enhanced CSV export with Q-values, effect sizes, shifts, confidence intervals, and MDE percentages.
  * Expanded markdown table output with comprehensive statistical result details.

* **Bug Fixes**
  * Fixed Wilcoxon test to compute mean/median from processed samples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->