### PR TITLE
SailDiff: fix Mann-Whitney n1>n2 false-negative and BH-FDR NaN contamination

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,35 @@ Sailfish's internal DI container moved from Autofac to `Microsoft.Extensions.Dep
 
 See [Registering Tests Dependencies](docs/1/test-dependencies) for the current docs.
 
+### SailDiff critical bug fixes (post-Tier-3 follow-up)
+
+Two latent correctness bugs surfaced by a deep code review of the SailDiff Tier 1/2/3
+work. Both could cause SailDiff to either **miss a real regression** or
+**fabricate a phantom one**, so they're worth calling out independently of the tier work.
+
+**Mann-Whitney with unequal samples now rejects correctly.** When the post-preprocessing
+sample sizes were unequal (`n1 > n2`) — which routinely happens once Tukey-fence outlier
+detection trims one side — `MannWhitneyDistribution.InnerComplementaryDistributionFunction`
+returned the *CDF* instead of the CCDF. Combined with the wrapper's two-sided p-value
+formula `2·min(F(U), F_c(U))`, the calculation collapsed to `2·F(U)` with `U` chosen as
+the maximum, yielding `p = 1` even on maximally-separated data. The asymmetric branch was
+a leftover from the pre-DP era and is now gone — the discrete CCDF lookup is used
+unconditionally. Regression tests at the distribution level (`Ccdf_*`,
+`TwoSidedPValue_MaxSeparation_*`) and at the wrapper level
+(`MannWhitney_NLargerThanM_MaximallySeparatedSamples_RejectsAtAlpha005`,
+`MannWhitney_NLargerThanM_AndNSmallerThanM_GivesConsistentPValue`) pin both directions of
+the fix.
+
+**Benjamini-Hochberg FDR no longer contaminated by NaN p-values.** The internal `ClampP`
+helper mapped `NaN` to `0.0`, placing any failed pair at the head of the sorted-ascending
+vector and dragging every other pair's q-value down via BH's right-to-left running min.
+A single Welch test that hit zero variance could therefore *fabricate* significance for
+unrelated pairs in the same family. `ClampP` now maps `NaN` to `1.0` (the most
+conservative placement), so failed pairs land at the tail of the family with `q = 1.0`
+and cannot lower any other pair's q-value. New tests in `Tier2CompleteTests`
+(`BenjaminiHochberg_NaNPValuesDoNotContaminateOtherPairsQValues`,
+`BenjaminiHochberg_OnlyNaNPValues_AllQuotedAsOne`) pin the new behavior.
+
 ### SailDiff Tier 3: MDE reporting, permutation test, formatter completeness
 
 Closes out the SailDiff rigor roadmap with power/UX work that turns NoChange verdicts

--- a/source/Sailfish/Analysis/SailDiff/Statistics/MultipleComparisons.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/MultipleComparisons.cs
@@ -122,7 +122,17 @@ namespace Sailfish.Analysis.SailDiff.Statistics
 
         private static double ClampP(double p)
         {
-            if (double.IsNaN(p) || p < 0) return 0.0;
+            // NaN p-values arise from degenerate inputs (e.g. Welch's t with zero variance
+            // on both sides, or KS on constant samples). Map them to 1.0 — the *most
+            // conservative* placement in the BH family — so a single failed test cannot
+            // contaminate the right-to-left running-min that drives the q-values for every
+            // other pair. The pre-fix mapping `NaN → 0` placed the failed pair at the head
+            // of the sorted-ascending vector, dragging unrelated q-values below alpha and
+            // fabricating significance. Treating NaN as p=1 keeps the pair in the family
+            // (so the key/value correspondence with the input dict is preserved) while
+            // ensuring it can never lower another pair's q-value.
+            if (double.IsNaN(p)) return 1.0;
+            if (p < 0) return 0.0;
             if (p > 1) return 1.0;
             return p;
         }

--- a/source/Sailfish/Analysis/SailDiff/Statistics/StatsCore/Distributions/MannWhitneyDistribution.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/StatsCore/Distributions/MannWhitneyDistribution.cs
@@ -128,7 +128,21 @@ internal sealed class MannWhitneyDistribution : UnivariateContinuousDistribution
 
     protected override double InnerComplementaryDistributionFunction(double x)
     {
-        return NumberOfSamples1 <= NumberOfSamples2 ? ComplementaryDistributionFunction(x) : DistributionFunction(x);
+        // The U statistic's null distribution is symmetric around n1·n2/2 (because
+        // U1 + U2 = n1·n2 under any rank assignment), so the *same* PMF table serves
+        // both U1 and U2. Pre-fix, this override branched on n1 vs n2 and returned the
+        // CDF (DistributionFunction(x)) when n1 > n2 — that was a leftover hack from
+        // the pre-DP era when the caller swapped samples and the distribution did not
+        // carry its own CCDF table. The bug meant the wrapper's two-tailed formula
+        //
+        //     p = min(2·min(F(U), F_c(U)), 1)
+        //
+        // collapsed to min(2·F(U2), 1) whenever the wrapper picked U2 (n1 ≥ n2). For
+        // a maximally-separated dataset that yields U2 = n1·n2 → F(U2) = 1 → p = 1,
+        // i.e. the test silently fails to reject even when the alternative is true.
+        // The fix unconditionally delegates to the discrete CCDF lookup, which returns
+        // the correct P(U ≥ ⌈x⌉) regardless of which side's U was passed.
+        return ComplementaryDistributionFunction(x);
     }
 
     public override double DistributionFunction(double x)

--- a/source/Tests.Library/Analysis/SailDiff/Statistics/StatsCore/Distributions/MannWhitneyDistributionTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Statistics/StatsCore/Distributions/MannWhitneyDistributionTests.cs
@@ -323,5 +323,80 @@ public class MannWhitneyDistributionTests
         distribution.ShouldNotBeNull();
         distribution.Mean.ShouldBe(4.5);
     }
+
+    // ─── Regression: asymmetric n1 vs n2 returns correct CCDF ─────────────────────────────
+    //
+    // Pre-fix, MannWhitneyDistribution.InnerComplementaryDistributionFunction branched on
+    // n1 vs n2 and returned the CDF when n1 > n2 — a leftover from the pre-DP era. The
+    // wrapper's two-sided p-value formula 2·min(F(U), F_c(U)) then collapsed for n1 > n2
+    // to 2·F(U) with U = U2 = max, returning p = 1 even for maximally-separated data.
+    //
+    // These tests pin both sides of the fix: the CCDF is correct in both n1 < n2 and
+    // n1 > n2 orientations, the CDF + CCDF satisfy the documented discrete identity
+    // F(u) + F_c(u) = 1 + P(U = u), and the orientation symmetry P(U1 ≤ u) = P(U2 ≥ n1·n2 − u)
+    // holds across both sample-size relations.
+
+    [Fact]
+    public void Ccdf_NLargerThanM_ReturnsCcdfNotCdf()
+    {
+        // 5 vs 4 — the "n1 > n2" path that the asymmetric branch corrupted. Untied ranks so
+        // the exact DP path activates.
+        var ranks = Enumerable.Range(1, 9).Select(x => (double)x).ToArray();
+        var distribution = new MannWhitneyDistribution(ranks, 5, 4);
+
+        // U support is {0, ..., 20}; mid-support u = 10 should have F + Fc = 1 + PMF(10).
+        var f = distribution.DistributionFunction(10);
+        var fc = distribution.ComplementaryDistributionFunction(10);
+        var pmfAt10 = distribution.ProbabilityDensityFunction(10);
+
+        (f + fc).ShouldBe(1.0 + pmfAt10, tolerance: 1e-9);
+
+        // At the upper boundary U = 20, P(U ≥ 20) = PMF(20) > 0, so Fc(20) is strictly
+        // positive — not F(20) = 1.0, which the pre-fix code would have returned.
+        var fcMax = distribution.ComplementaryDistributionFunction(20);
+        fcMax.ShouldBeGreaterThan(0);
+        fcMax.ShouldBeLessThan(0.1, customMessage: "tail PMF at U=max should be small but non-zero");
+    }
+
+    [Fact]
+    public void Ccdf_IsConsistentAcrossSampleSizeOrientations()
+    {
+        // The U-statistic null distribution is symmetric: passing (n1, n2) or (n2, n1)
+        // must yield the same PMF at every support point and the same CCDF at every query.
+        var ranks = Enumerable.Range(1, 9).Select(x => (double)x).ToArray();
+        var d54 = new MannWhitneyDistribution(ranks, 5, 4);  // n1 > n2 — the pre-fix bug path
+        var d45 = new MannWhitneyDistribution(ranks, 4, 5);  // n1 < n2 — pre-fix correct path
+
+        for (var u = 0; u <= 20; u++)
+        {
+            d54.ComplementaryDistributionFunction(u).ShouldBe(
+                d45.ComplementaryDistributionFunction(u),
+                tolerance: 1e-12,
+                customMessage: $"CCDF at u={u} should not depend on n1 vs n2 orientation");
+        }
+    }
+
+    [Fact]
+    public void TwoSidedPValue_MaxSeparation_NLargerThanM_RejectsCorrectly()
+    {
+        // The agent's regression example: before=[1..5], after=[6..9]. Ranks are 1..9.
+        // Rank1 = [1,2,3,4,5], Rank2 = [6,7,8,9]. U1 = 0, U2 = 20 = n1·n2 (max separation).
+        // Pre-fix wrapper computed p ≈ min(2·F(U2), 1) = min(2·1, 1) = 1.
+        // Post-fix: p ≈ 2·min(F(20), F_c(20)) where F_c(20) = PMF(20) ≈ 1/126 ≈ 0.0079.
+        // So p ≈ 2·0.0079 ≈ 0.016 — small enough to reject at α = 0.05.
+        var ranks = Enumerable.Range(1, 9).Select(x => (double)x).ToArray();
+        var distribution = new MannWhitneyDistribution(ranks, 5, 4);
+
+        // Mirror the wrapper's two-sided formula directly so this test is robust to wrapper
+        // refactors and isolates the distribution-level fix.
+        const double u = 20.0;
+        var twoSidedP = Math.Min(2.0 * Math.Min(distribution.DistributionFunction(u),
+                                                distribution.ComplementaryDistributionFunction(u)), 1.0);
+
+        twoSidedP.ShouldBeLessThan(0.05,
+            customMessage: "Maximally-separated 5-vs-4 sample must yield p < 0.05; the pre-fix branch returned p = 1.");
+        twoSidedP.ShouldBeGreaterThan(0.0,
+            customMessage: "p-value must be strictly positive (smallest possible for n1=5, n2=4 is 2/C(9,4) = 2/126 ≈ 0.016).");
+    }
 }
 

--- a/source/Tests.Library/Analysis/SailDiff/Tier2CompleteTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Tier2CompleteTests.cs
@@ -269,8 +269,11 @@ public class Tier2CompleteTests
         ba.ExceptionMessage.ShouldBeEmpty();
         ab.StatisticalTestResult.PValue.ShouldBe(ba.StatisticalTestResult.PValue, tolerance: 1e-12,
             customMessage: "p-value must be invariant under sample-order swap.");
+        // SailfishChangeDirection is a static class of `const string`, so these constants
+        // are already strings — `.ToString()` would be a no-op. Matches the convention in
+        // Tier1RigorTests where ChangeDescription is compared to the bare constant.
         ab.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Regressed);
-        ba.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Improved.ToString());
+        ba.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Improved);
     }
 
     // ─── Critical regression: NaN p-value cannot contaminate BH-FDR family ──────────────

--- a/source/Tests.Library/Analysis/SailDiff/Tier2CompleteTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Tier2CompleteTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NSubstitute;
 using Sailfish.Analysis;
 using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics;
 using Sailfish.Analysis.SailDiff.Statistics.Tests;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.MWWilcoxonTestSailfish;
 using Sailfish.Analysis.SailDiff.Statistics.Tests.TTest;
@@ -219,6 +220,114 @@ public class Tier2CompleteTests
         // Falls back to raw scale → Difference report uses Mean difference / ms units.
         result.StatisticalTestResult.Difference!.Name.ShouldBe("Mean difference");
         result.StatisticalTestResult.Difference.Units.ShouldBe("ms");
+    }
+
+    // ─── Critical regression: MannWhitney must reject when n1 > n2 ───────────────────────
+    //
+    // The exact-null CCDF lookup branched on (n1 ≤ n2) and returned the *CDF* when n1 > n2.
+    // Combined with the wrapper's two-sided p-value formula, p collapsed to ≈ 2·F(U2) and the
+    // test silently failed to reject even maximally-separated data. The fix removes the branch
+    // and uses the discrete CCDF directly; see MannWhitneyDistribution.cs for the rationale.
+
+    [Fact]
+    public void MannWhitney_NLargerThanM_MaximallySeparatedSamples_RejectsAtAlpha005()
+    {
+        // 5-vs-4 maximally-separated samples. Pre-fix: p = 1, post-fix: p ≈ 2/126 ≈ 0.016.
+        // Using outlier-detection off because Tukey on tiny tight clusters can remove
+        // everything and we want to pin the raw-input behavior.
+        var before = new double[] { 1, 2, 3, 4, 5 };
+        var after = new double[] { 6, 7, 8, 9 };
+
+        var test = new MannWhitneyWilcoxonTest(new TestPreprocessor(new SailfishOutlierDetector()));
+        var result = test.ExecuteTest(before, after,
+            new SailDiffSettings(alpha: 0.05, useOutlierDetection: false));
+
+        result.ExceptionMessage.ShouldBeEmpty();
+        var stat = result.StatisticalTestResult;
+        stat.PValue.ShouldBeLessThan(0.05,
+            customMessage: $"5-vs-4 maximally-separated samples must reject at α=0.05; got p={stat.PValue}");
+        stat.ChangeDescription.ShouldBe(SailfishChangeDirection.Regressed,
+            customMessage: "After is uniformly larger than Before, so the wrapper should report Regressed.");
+    }
+
+    [Fact]
+    public void MannWhitney_NLargerThanM_AndNSmallerThanM_GivesConsistentPValue()
+    {
+        // Symmetry check: swapping the two samples must flip the direction label but yield
+        // an identical p-value. Pre-fix this would diverge by orders of magnitude because
+        // only one orientation went through the buggy branch.
+        var a = new double[] { 1, 2, 3, 4, 5 };
+        var b = new double[] { 6, 7, 8, 9 };
+
+        var test = new MannWhitneyWilcoxonTest(new TestPreprocessor(new SailfishOutlierDetector()));
+        var settings = new SailDiffSettings(alpha: 0.05, useOutlierDetection: false);
+
+        var ab = test.ExecuteTest(a, b, settings);
+        var ba = test.ExecuteTest(b, a, settings);
+
+        ab.ExceptionMessage.ShouldBeEmpty();
+        ba.ExceptionMessage.ShouldBeEmpty();
+        ab.StatisticalTestResult.PValue.ShouldBe(ba.StatisticalTestResult.PValue, tolerance: 1e-12,
+            customMessage: "p-value must be invariant under sample-order swap.");
+        ab.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Regressed);
+        ba.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Improved.ToString());
+    }
+
+    // ─── Critical regression: NaN p-value cannot contaminate BH-FDR family ──────────────
+    //
+    // ClampP(NaN) used to map to 0.0, placing the NaN pair at the head of the sorted-ascending
+    // vector and dragging every other pair's q-value down via the right-to-left running min.
+    // The fix maps NaN to 1.0 (most conservative), so a single failed test cannot fabricate
+    // significance elsewhere in the family.
+
+    [Fact]
+    public void BenjaminiHochberg_NaNPValuesDoNotContaminateOtherPairsQValues()
+    {
+        // 4 well-behaved pairs at p = {0.20, 0.30, 0.40, 0.50} — none significant at α = 0.05.
+        // Pre-fix, adding a single NaN pair would compute m = 5, sort [NaN→0, 0.20, 0.30, 0.40, 0.50]
+        // and (with monotonisation) push q-values down enough that ε-shifted alphas could flag
+        // the 0.20 pair as significant. Post-fix, NaN sorts to the end as p = 1 and is harmless.
+        var withoutNaN = new Dictionary<string, double>
+        {
+            ["A"] = 0.20,
+            ["B"] = 0.30,
+            ["C"] = 0.40,
+            ["D"] = 0.50,
+        };
+        var withNaN = new Dictionary<string, double>(withoutNaN)
+        {
+            ["E"] = double.NaN,
+        };
+
+        var qWithout = MultipleComparisons.BenjaminiHochbergAdjust(withoutNaN);
+        var qWith = MultipleComparisons.BenjaminiHochbergAdjust(withNaN);
+
+        // q-values for the well-behaved pairs must be *no smaller* with the NaN present.
+        // (They will typically be slightly larger because m grew from 4 to 5.)
+        foreach (var key in withoutNaN.Keys)
+        {
+            qWith[key].ShouldBeGreaterThanOrEqualTo(qWithout[key] - 1e-12,
+                customMessage: $"Adding a NaN pair lowered the q-value for {key} from {qWithout[key]} to {qWith[key]} — the family was contaminated.");
+        }
+
+        // The NaN entry itself should land at q = 1.0 (the conservative cap).
+        qWith["E"].ShouldBe(1.0, tolerance: 1e-12,
+            customMessage: "NaN p-value should be treated as the most conservative; q must be 1.0.");
+    }
+
+    [Fact]
+    public void BenjaminiHochberg_OnlyNaNPValues_AllQuotedAsOne()
+    {
+        var all = new Dictionary<string, double>
+        {
+            ["A"] = double.NaN,
+            ["B"] = double.NaN,
+        };
+
+        var q = MultipleComparisons.BenjaminiHochbergAdjust(all);
+
+        q["A"].ShouldBe(1.0, tolerance: 1e-12);
+        q["B"].ShouldBe(1.0, tolerance: 1e-12);
     }
 
     // ─── Helpers ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two latent correctness bugs surfaced by a deep code review of the SailDiff Tier 1/2/3 work. Each is a one-line fix backed by regression tests.

### 1. Mann-Whitney with unequal samples reports `p=1` for maximally-separated data

`MannWhitneyDistribution.InnerComplementaryDistributionFunction` (line 129) branched on `n1 ≤ n2` and returned `DistributionFunction(x)` — the **CDF** — when `n1 > n2`. A leftover from the pre-DP era when the caller swapped samples and the distribution carried no CCDF table. The wrapper's two-sided p-value formula

```
p = min(2 · min(F(U), F_c(U)), 1)
```

then collapsed to `min(2·F(U2), 1)` because the wrapper picks `Statistic = U2` whenever `n1 ≥ n2`. For maximally-separated data `U2 = n1·n2 = max`, `F(U2) = 1.0`, and the test reported `p = 1.0` — silently failing to reject.

**Concrete trigger:** `before = [1,2,3,4,5], after = [6,7,8,9]` (5 vs 4) → pre-fix `p = 1.0`, post-fix `p ≈ 0.016`. Outlier detection routinely produces unequal post-processing sample sizes, so this fired in real runs.

Fix: always use the discrete CCDF lookup; the symmetric U-statistic distribution doesn't need a sample-size flip.

### 2. BH-FDR contaminated by NaN p-values

`MultipleComparisons.ClampP(NaN)` returned `0.0`, placing failed pairs at the **head** of the sorted-ascending vector and dragging every other pair's q-value down via BH's right-to-left running min. A single Welch test that hit zero variance could therefore **fabricate** significance for unrelated pairs in the same family.

Fix: map `NaN` to `1.0` (most conservative placement) — failed pairs now land at the tail of the family with `q = 1.0` and cannot lower any other pair's q.

## Test plan

7 new regression tests, all passing on net9.0 and net10.0:

**Distribution level** (`MannWhitneyDistributionTests.cs`):
- [x] `Ccdf_NLargerThanM_ReturnsCcdfNotCdf` — verifies the discrete CDF/CCDF identity `F + F_c = 1 + PMF`
- [x] `Ccdf_IsConsistentAcrossSampleSizeOrientations` — `(n1,n2)` and `(n2,n1)` produce identical CCDFs everywhere
- [x] `TwoSidedPValue_MaxSeparation_NLargerThanM_RejectsCorrectly` — agent's concrete example, `p < 0.05` post-fix

**Wrapper level + BH NaN** (`Tier2CompleteTests.cs`):
- [x] `MannWhitney_NLargerThanM_MaximallySeparatedSamples_RejectsAtAlpha005` — end-to-end through `MannWhitneyWilcoxonTest`
- [x] `MannWhitney_NLargerThanM_AndNSmallerThanM_GivesConsistentPValue` — sample-order swap pins symmetry
- [x] `BenjaminiHochberg_NaNPValuesDoNotContaminateOtherPairsQValues` — adding a NaN pair cannot lower another pair's q
- [x] `BenjaminiHochberg_OnlyNaNPValues_AllQuotedAsOne` — degenerate "everything failed" case

Full `Tests.Library` net9.0 suite — **1415 tests, all green**.

## Discovery

These were surfaced in a multi-angle review of the Tier 1/2/3 work after the Tier 3 PR merged. I dispatched three parallel review agents (statistical math correctness, test coverage & quality, integration & API design) and verified every load-bearing claim against the code myself before treating it as actionable. The MW asymmetric branch predates this session (Apr 2024) but the Tier 2 distribution rewrite missed the chance to remove it. `ClampP(NaN) = 0` was introduced this session by the Tier 2 BH-FDR work (commit `9a2f74b9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Mann-Whitney statistical test p-value computation that previously returned incorrect results when sample sizes were unequal.
  * Fixed handling of invalid p-values in multiple comparison correction to prevent contamination of adjusted results.

* **Tests**
  * Added regression tests to verify correct Mann-Whitney test behavior and multiple comparison correction with invalid values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->