### PR TITLE
OperationsPerInvoke: report per-operation time (fix N× inflation)

### DIFF
--- a/site/src/pages/docs/1/iteration-tuning.md
+++ b/site/src/pages/docs/1/iteration-tuning.md
@@ -4,7 +4,7 @@ title: Iteration Tuning (Operations per Invoke)
 
 ## Overview
 
-Iteration tuning helps microbenchmarks reach a suitable per-iteration duration by executing multiple operations within a single measured iteration. This amortizes timer overhead and improves stability of very small operations.
+Iteration tuning helps microbenchmarks reach a suitable per-iteration duration by executing multiple operations within a single measured iteration. This amortizes timer overhead and improves stability of very small operations. Each measured iteration is normalized to per-operation time, so reported statistics always reflect the cost of a single operation regardless of the batch size.
 
 - OperationsPerInvoke (OPI): number of inner operations executed per measured iteration
 - TargetIterationDurationMs: target duration (milliseconds) for each measured iteration
@@ -44,6 +44,6 @@ public class Tuned { ... }
 ## FAQ
 
 - What if my operation is slower than the target? OPI will remain 1.
-- Does tuning change my results? It only changes how many operations are executed within a single measured iteration; statistics are computed from the per‑iteration timings as usual.
+- Does tuning change my reported numbers? Reported statistics are **per-operation**. When OperationsPerInvoke > 1, Sailfish divides each measured iteration by OPI, so results represent the cost of a single operation and stay comparable regardless of the OPI chosen (manually or by the tuner).
 - How do I disable it? Set TargetIterationDurationMs = 0 (the default) or explicitly specify OperationsPerInvoke > 1.
 

--- a/site/src/pages/docs/4/releasenotes.md
+++ b/site/src/pages/docs/4/releasenotes.md
@@ -12,6 +12,10 @@ Sailfish has moved off Autofac onto the standard .NET DI abstraction (`IServiceC
 Sailfish, `Sailfish.TestAdapter`, and `Sailfish.Analyzers` now target `net9.0` and `net10.0` only. If you're on `net8.0`, stay on Sailfish 0.0.115 or upgrade your project.
 {% /callout %}
 
+{% callout title="Behavior change: OperationsPerInvoke reports per-operation time" type="warning" %}
+When `OperationsPerInvoke` > 1 (set explicitly, or chosen by `TargetIterationDurationMs` auto-tuning), Sailfish now divides each measured iteration by the batch size, so reported mean/median/etc. represent the cost of a **single operation** and stay comparable across methods and runs regardless of the batch size. Previously the per-iteration aggregate was reported, which inflated results by the OPI factor. If you use OPI > 1, expect reported durations to drop accordingly — they now reflect true per-op cost. If you persist tracking data for SailDiff history on OPI > 1 tests, baselines recorded before this change will read as a one-time drop; re-baseline after upgrading. [Learn more →](/docs/1/iteration-tuning)
+{% /callout %}
+
 {% callout title="Performance: compiled-delegate invocation" type="success" %}
 The timed method is now invoked through a compiled, allocation-free delegate instead of per-call reflection. On .NET 10 this drops per-invocation harness overhead from ~40 ns to ~1.5 ns and eliminates per-call allocations (272 B → 0 B); the overhead baseline is measured with a structurally identical idle delegate so the subtraction cancels almost exactly. The result is a lower, more stable noise floor, so Sailfish resolves smaller differences. Behavior note: a method returning `Task`/`ValueTask` *without* the `async` keyword is now correctly awaited and timed (previously under-measured). [Learn more →](/docs/1/measurement-and-overhead)
 {% /callout %}

--- a/source/Sailfish/Execution/CoreInvoker.cs
+++ b/source/Sailfish/Execution/CoreInvoker.cs
@@ -106,7 +106,8 @@ internal class CoreInvoker
             return;
         }
 
-        // Aggregate timing over multiple direct invocations within a single measured iteration.
+        // Time a batch of N direct invocations in a single window; StopSailfishMethodExecutionTimer
+        // divides by N so the recorded sample is the per-operation duration, not the batch aggregate.
         var invoke = CompiledMainMethod;
         _testCasePerformanceTimer.StartSailfishMethodExecutionTimer();
         try
@@ -118,7 +119,7 @@ internal class CoreInvoker
         }
         finally
         {
-            _testCasePerformanceTimer.StopSailfishMethodExecutionTimer();
+            _testCasePerformanceTimer.StopSailfishMethodExecutionTimer(operationsPerInvoke);
         }
     }
 

--- a/source/Sailfish/Execution/PerformanceTimer.cs
+++ b/source/Sailfish/Execution/PerformanceTimer.cs
@@ -64,12 +64,19 @@ public sealed class PerformanceTimer
         _iterationTimer.Start();
     }
 
-    public void StopSailfishMethodExecutionTimer()
+    public void StopSailfishMethodExecutionTimer(int operationsPerInvoke = 1)
     {
         if (!_iterationTimer.IsRunning) return;
         _iterationTimer.Stop();
         var executionIterationStop = DateTimeOffset.Now;
-        ExecutionIterationPerformances.Add(new IterationPerformance(_executionIterationStart, executionIterationStop, _iterationTimer.ElapsedTicks));
+        // Normalize to per-operation time. When a measured iteration batches N invocations
+        // (OperationsPerInvoke), divide the aggregate by N so the recorded sample is the cost of a
+        // single operation. This keeps reported statistics per-operation and comparable across
+        // methods and runs regardless of batch size. Dividing here (before overhead subtraction)
+        // is required: the overhead estimate is per-call, so it must be subtracted from a per-op value.
+        var ops = operationsPerInvoke < 1 ? 1 : operationsPerInvoke;
+        var perOperationTicks = _iterationTimer.ElapsedTicks / ops;
+        ExecutionIterationPerformances.Add(new IterationPerformance(_executionIterationStart, executionIterationStop, perOperationTicks));
         _iterationTimer.Reset();
     }
 

--- a/source/Tests.Library/Integration/OperationsPerInvokeTuningIntegrationTests.cs
+++ b/source/Tests.Library/Integration/OperationsPerInvokeTuningIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace Tests.Library.Integration;
 public class OperationsPerInvokeTuningIntegrationTests
 {
     [Fact]
-    public async Task TestCaseIterator_AutoTunesOPI_MedianNearTarget()
+    public async Task TestCaseIterator_AutoTunesOPI_RecordsPerOperationTime()
     {
         // Arrange: per-op ~15ms (busy-wait), target ~45ms should yield OPI >= 2
         var logger = Substitute.For<ILogger>();
@@ -23,7 +23,8 @@ public class OperationsPerInvokeTuningIntegrationTests
         var adaptiveStrategy = new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>());
         var iterator = new TestCaseIterator(runSettings, logger, fixedStrategy, adaptiveStrategy);
 
-        var instance = new DelayWork(15);
+        const double perOpMs = 15.0;
+        var instance = new DelayWork((int)perOpMs);
         var method = typeof(DelayWork).GetMethod(nameof(DelayWork.Run))!;
         var settings = new ExecutionSettings
         {
@@ -40,7 +41,8 @@ public class OperationsPerInvokeTuningIntegrationTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        container.ExecutionSettings.OperationsPerInvoke.ShouldBeGreaterThanOrEqualTo(2);
+        var opi = container.ExecutionSettings.OperationsPerInvoke;
+        opi.ShouldBeGreaterThanOrEqualTo(2);
 
         var durations = container.CoreInvoker.GetPerformanceResults().ExecutionIterationPerformances
             .Select(p => p.GetDurationFromTicks().MilliSeconds.Duration)
@@ -50,9 +52,41 @@ public class OperationsPerInvokeTuningIntegrationTests
         var median = durations[durations.Length / 2];
 
         var target = settings.TargetIterationDuration.TotalMilliseconds;
-        // Loose bounds to account for timer granularity on CI windows VMs
-        median.ShouldBeGreaterThan(target * 0.6);
-        median.ShouldBeLessThan(target * 1.6);
+
+        // The recorded sample is per-OPERATION (~15ms), NOT the per-ITERATION aggregate (~45ms target).
+        // Loose bounds to account for timer granularity on CI VMs.
+        median.ShouldBeGreaterThan(perOpMs * 0.5);
+        median.ShouldBeLessThan(perOpMs * 2.0); // < 30ms: also proves it is not the inflated ~45ms aggregate
+
+        // The tuned iteration (perOp * OPI) still lands near the target — tuning and normalization agree.
+        var iterationMs = median * opi;
+        iterationMs.ShouldBeGreaterThan(target * 0.5);
+        iterationMs.ShouldBeLessThan(target * 2.0);
+    }
+
+    [Fact]
+    public async Task OperationsPerInvoke_RecordsPerOperationTime_NotAggregate()
+    {
+        // Fixed OPI (no tuner): batching N ops must record per-op time, not the N× aggregate.
+        const double perOpMs = 10.0;
+        const int opi = 4;
+        var instance = new DelayWork((int)perOpMs);
+        var method = typeof(DelayWork).GetMethod(nameof(DelayWork.Run))!;
+        var settings = new ExecutionSettings { NumWarmupIterations = 0, SampleSize = 3, OperationsPerInvoke = opi };
+        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+
+        for (var i = 0; i < 3; i++)
+            await container.CoreInvoker.ExecutionMethodWithOperationsPerInvoke(opi, CancellationToken.None);
+
+        var durations = container.CoreInvoker.GetPerformanceResults().ExecutionIterationPerformances
+            .Select(p => p.GetDurationFromTicks().MilliSeconds.Duration)
+            .OrderBy(x => x)
+            .ToArray();
+        var median = durations[durations.Length / 2];
+
+        // ~10ms per op, NOT the ~40ms (4×) aggregate.
+        median.ShouldBeGreaterThan(perOpMs * 0.5);
+        median.ShouldBeLessThan(perOpMs * 2.5); // < 25ms, well below the ~40ms aggregate
     }
 
     private sealed class DelayWork
@@ -71,4 +105,3 @@ public class OperationsPerInvokeTuningIntegrationTests
         }
     }
 }
-


### PR DESCRIPTION
## Summary

Follow-up to #254. `OperationsPerInvoke` (OPI) batches N invocations into one timing window to amortize timer overhead for microbenchmarks — but it never divided the aggregate by N, so **OPI > 1 reported per-batch time, inflated by the OPI factor**. Worse, the auto-tuner (`TargetIterationDurationMs`) sizes OPI per method, so reported numbers weren't comparable across methods or runs. This PR records per-operation time, matching how BenchmarkDotNet divides by InvocationCount × UnrollFactor.

## The fix

`PerformanceTimer.StopSailfishMethodExecutionTimer(int operationsPerInvoke = 1)` now records `ElapsedTicks / N`, and the batch path in `CoreInvoker` passes `N`.

- **Default `1` ⇒ the common OPI=1 path is unchanged.**
- **Division happens in `Stop`, before overhead subtraction.** The overhead estimate is per-*call*, so it must be subtracted from a per-*op* value; dividing at report-time would under-subtract overhead by a factor of N.
- **Adaptive sampling is unaffected** — CV and relative-CI-width convergence are scale-invariant. The time-budget controller and the wall-clock `StartTime`/`StopTime` fields don't consume the recorded durations (verified before changing).

## Validation

- **1434 `Tests.Library` tests pass**, full solution builds on **net9.0 + net10.0**.
- Updated `OperationsPerInvokeTuningIntegrationTests` — it previously *pinned the inflated behavior* (asserted the recorded median ≈ the 45 ms iteration target). It now asserts per-op (~15 ms) and that `perOp × OPI` still lands near the target.
- Added `OperationsPerInvoke_RecordsPerOperationTime_NotAggregate`: OPI=4 on a ~10 ms/op method records ~10 ms, not the ~40 ms aggregate (fails without the fix).

## Behavior change

If you use OPI > 1 (explicitly or via auto-tuning), reported mean/median/etc. now reflect true per-operation cost and **drop by the OPI factor**. The OPI=1 default path is unchanged. Documented with a `warning` callout in the release notes (including a note to re-baseline persisted SailDiff history on OPI > 1 tests), and the `iteration-tuning` FAQ/overview were corrected — they previously described the per-iteration behavior.

## Files

`PerformanceTimer.cs`, `CoreInvoker.cs`, `OperationsPerInvokeTuningIntegrationTests.cs`, `docs/1/iteration-tuning.md`, `docs/4/releasenotes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
