### PR TITLE
Steady-state warmup: warm up until timings stabilize (opt-in)

### DIFF
--- a/site/src/components/Layout.jsx
+++ b/site/src/components/Layout.jsx
@@ -38,6 +38,7 @@ const navigation = [
             { title: 'Configuration Recipes', href: '/docs/1/presets', badge: 'NEW' },
             { title: 'Iteration Tuning', href: '/docs/1/iteration-tuning', badge: 'NEW' },
             { title: 'Measurement & Overhead', href: '/docs/1/measurement-and-overhead', badge: 'NEW' },
+            { title: 'Steady-State Warmup', href: '/docs/1/steady-state-warmup', badge: 'NEW' },
             { title: 'Confidence Intervals', href: '/docs/1/confidence-intervals', badge: 'NEW' },
             { title: 'Outlier Handling', href: '/docs/1/outlier-handling', badge: 'NEW' },
             { title: 'Environment Health Check', href: '/docs/1/environment-health', badge: 'NEW' },

--- a/site/src/pages/docs/1/steady-state-warmup.md
+++ b/site/src/pages/docs/1/steady-state-warmup.md
@@ -1,0 +1,42 @@
+---
+title: Steady-State Warmup
+---
+
+## Overview
+
+By default Sailfish runs a fixed number of warmup iterations (`NumWarmupIterations`, default 3) before it starts measuring. For code whose performance shifts while the runtime tiers up (tiered JIT compilation and on-stack replacement), a fixed count can start measuring too early — capturing the tail of compilation — or waste time warming up longer than needed.
+
+Steady-state warmup (opt-in) instead warms up **until the per-iteration timing stops trending and stabilizes**, bounded by a floor and a cap.
+
+## How it works
+
+Each warmup iteration is timed locally (it is *not* recorded into your measured samples) and fed to a detector. The detector looks at a sliding window of recent warmup durations and declares steady state when both:
+
+- **The trend has flattened** — the median of the most recent half of the window is within ~5% of the median of the prior half (timings have stopped falling). Medians are used so a single cold-start spike doesn't dominate.
+- **Dispersion is low** — the coefficient of variation across the window is within ~15%.
+
+Warmup runs at least `NumWarmupIterations` (the floor) and at most `MaxWarmupIterations` (the cap, default 50), stopping as soon as steady state is detected. The detector needs a full window (6 samples) before it can decide, so that is the effective minimum.
+
+## Usage
+
+```csharp
+[Sailfish(
+    UseSteadyStateWarmup = true,  // opt in
+    NumWarmupIterations = 4,      // floor: always warm up at least this many
+    MaxWarmupIterations = 50,     // cap: never warm up more than this
+    SampleSize = 100)]
+public class MyBenchmarks
+{
+    [SailfishMethod]
+    public void Work() { /* ... */ }
+}
+```
+
+Configured per class on the `[Sailfish]` attribute (like `OperationsPerInvoke`). Defaults: `UseSteadyStateWarmup = false` (fixed-count warmup), `MaxWarmupIterations = 50`.
+
+## Notes
+
+- **Opt-in and backward compatible.** With the default (`false`), warmup is the existing fixed `NumWarmupIterations` loop — unchanged.
+- **Bounded.** A noisy method whose timing never settles will warm up to `MaxWarmupIterations` and then proceed; it won't loop forever.
+- The detector thresholds (window 6, ~5% drift, ~15% CV) are tuned internally and not currently exposed.
+- This shapes *warmup* only; it's independent of [Adaptive Sampling](/docs/1/adaptive-sampling) (which decides how many *measured* samples to collect) and composes with it.

--- a/site/src/pages/docs/4/releasenotes.md
+++ b/site/src/pages/docs/4/releasenotes.md
@@ -16,6 +16,10 @@ Sailfish, `Sailfish.TestAdapter`, and `Sailfish.Analyzers` now target `net9.0` a
 When `OperationsPerInvoke` > 1 (set explicitly, or chosen by `TargetIterationDurationMs` auto-tuning), Sailfish now divides each measured iteration by the batch size, so reported mean/median/etc. represent the cost of a **single operation** and stay comparable across methods and runs regardless of the batch size. Previously the per-iteration aggregate was reported, which inflated results by the OPI factor. If you use OPI > 1, expect reported durations to drop accordingly — they now reflect true per-op cost. If you persist tracking data for SailDiff history on OPI > 1 tests, baselines recorded before this change will read as a one-time drop; re-baseline after upgrading. [Learn more →](/docs/1/iteration-tuning)
 {% /callout %}
 
+{% callout title="Feature: steady-state warmup (opt-in)" type="note" %}
+`[Sailfish(UseSteadyStateWarmup = true)]` warms up until per-iteration timing stops trending and stabilizes (tiered JIT/OSR has settled) rather than using a fixed count — bounded by `NumWarmupIterations` (floor) and `MaxWarmupIterations` (cap, default 50), stopping early when stable. Default off; the fixed-count warmup path is unchanged. [Learn more →](/docs/1/steady-state-warmup)
+{% /callout %}
+
 {% callout title="Performance: compiled-delegate invocation" type="success" %}
 The timed method is now invoked through a compiled, allocation-free delegate instead of per-call reflection. On .NET 10 this drops per-invocation harness overhead from ~40 ns to ~1.5 ns and eliminates per-call allocations (272 B → 0 B); the overhead baseline is measured with a structurally identical idle delegate so the subtraction cancels almost exactly. The result is a lower, more stable noise floor, so Sailfish resolves smaller differences. Behavior note: a method returning `Task`/`ValueTask` *without* the `async` keyword is now correctly awaited and timed (previously under-measured). [Learn more →](/docs/1/measurement-and-overhead)
 {% /callout %}

--- a/source/Sailfish/Attributes/SailfishAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishAttribute.cs
@@ -60,10 +60,26 @@ public sealed class SailfishAttribute : Attribute
 
     /// <summary>
     ///     Gets or sets the number of warm-up iterations for each SailfishMethod.
+    ///     When <see cref="UseSteadyStateWarmup" /> is enabled this acts as the lower bound (floor).
     /// </summary>
     /// <value>The number of warm-up iterations.</value>
     [Range(0, int.MaxValue)]
     public int NumWarmupIterations { get; set; }
+
+    /// <summary>
+    ///     Opt-in: warm up until per-iteration timing reaches steady state (the runtime has finished
+    ///     tiered JIT/OSR and timings stop trending) instead of a fixed count. Runs at least
+    ///     <see cref="NumWarmupIterations" /> and at most <see cref="MaxWarmupIterations" /> warmups,
+    ///     stopping early when stable. Default false (fixed-count warmup).
+    /// </summary>
+    public bool UseSteadyStateWarmup { get; set; } = false;
+
+    /// <summary>
+    ///     Upper bound on warmup iterations when <see cref="UseSteadyStateWarmup" /> is enabled. Ignored
+    ///     for fixed-count warmup. Default 50.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int MaxWarmupIterations { get; set; } = 50;
 
     /// <summary>
     ///     Gets or sets a value indicating whether the Sailfish test is disabled.

--- a/source/Sailfish/Execution/ExecutionSettings.cs
+++ b/source/Sailfish/Execution/ExecutionSettings.cs
@@ -42,6 +42,10 @@ public interface IExecutionSettings
     public System.TimeSpan? MaxMeasurementTimePerMethod { get; set; }
     public bool EnableDefaultDiagnosers { get; set; }
     public int? Seed { get; set; }
+
+    // NEW: Steady-state warmup (opt-in). NumWarmupIterations is the floor; MaxWarmupIterations the cap.
+    public bool UseSteadyStateWarmup { get; set; }
+    public int MaxWarmupIterations { get; set; }
 }
 
 public class ExecutionSettings : IExecutionSettings
@@ -99,5 +103,9 @@ public class ExecutionSettings : IExecutionSettings
     public System.TimeSpan? MaxMeasurementTimePerMethod { get; set; } = null;
     public bool EnableDefaultDiagnosers { get; set; } = false;
     public int? Seed { get; set; } = null;
+
+    // NEW: Steady-state warmup (opt-in)
+    public bool UseSteadyStateWarmup { get; set; } = false;
+    public int MaxWarmupIterations { get; set; } = 50;
 
 }

--- a/source/Sailfish/Execution/SteadyStateWarmupDetector.cs
+++ b/source/Sailfish/Execution/SteadyStateWarmupDetector.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MathNet.Numerics.Statistics;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Outcome of a steady-state warmup check.
+/// </summary>
+public sealed class SteadyStateWarmupResult
+{
+    public bool ReachedSteadyState { get; init; }
+    public double RelativeDrift { get; init; }
+    public double CoefficientOfVariation { get; init; }
+    public int WindowSize { get; init; }
+    public string Reason { get; init; } = string.Empty;
+}
+
+/// <summary>
+///     Detects when warmup measurements have reached steady state — i.e. the per-iteration duration has
+///     stopped trending (tiered JIT compilation/OSR has settled) and is now stable.
+///     <para>
+///         This is distinct from sampling convergence (<see cref="Sailfish.Analysis.StatisticalConvergenceDetector" />),
+///         which only looks at dispersion. Warmup needs to detect that the central tendency has stopped
+///         <i>moving</i>: durations start high and fall as the runtime tiers up, then flatten. So this
+///         compares the median of the most recent half of a sliding window against the prior half (the
+///         trend), and additionally requires the recent window's dispersion (CV) to be low. Medians are
+///         used so a single cold-start spike doesn't dominate the decision.
+///     </para>
+/// </summary>
+public sealed class SteadyStateWarmupDetector
+{
+    /// <summary>
+    ///     Returns whether the tail of <paramref name="warmupDurations" /> looks steady. A decision is only
+    ///     made once at least <paramref name="window" /> measurements are available.
+    /// </summary>
+    /// <param name="warmupDurations">Per-iteration warmup durations in chronological order (any consistent unit).</param>
+    /// <param name="window">Number of most-recent measurements to examine (split into prior/recent halves).</param>
+    /// <param name="maxRelativeDrift">Max allowed |recentMedian - priorMedian| / priorMedian to be considered "no longer trending".</param>
+    /// <param name="maxCoefficientOfVariation">Max allowed CV over the recent window to be considered "stable".</param>
+    public SteadyStateWarmupResult Check(
+        IReadOnlyList<double> warmupDurations,
+        int window,
+        double maxRelativeDrift,
+        double maxCoefficientOfVariation)
+    {
+        if (warmupDurations is null || window < 2)
+            return new SteadyStateWarmupResult { WindowSize = window, Reason = "insufficient configuration" };
+
+        var n = warmupDurations.Count;
+        if (n < window)
+            return new SteadyStateWarmupResult { WindowSize = window, Reason = $"need {window} samples, have {n}" };
+
+        var half = window / 2;
+        var recent = new double[half];
+        var prior = new double[half];
+        for (var i = 0; i < half; i++)
+        {
+            recent[i] = warmupDurations[n - 1 - i];        // newest `half`
+            prior[i] = warmupDurations[n - 1 - half - i];  // the `half` immediately before
+        }
+
+        var recentMedian = recent.Median();
+        var priorMedian = prior.Median();
+        var relativeDrift = Math.Abs(priorMedian) <= 1e-9 ? 0.0 : Math.Abs(recentMedian - priorMedian) / Math.Abs(priorMedian);
+
+        var win = new double[window];
+        for (var i = 0; i < window; i++) win[i] = warmupDurations[n - window + i];
+        var mean = win.Mean();
+        var cv = Math.Abs(mean) <= 1e-9 ? 0.0 : Math.Abs(win.StandardDeviation() / mean);
+
+        var steady = relativeDrift <= maxRelativeDrift && cv <= maxCoefficientOfVariation;
+        return new SteadyStateWarmupResult
+        {
+            ReachedSteadyState = steady,
+            RelativeDrift = relativeDrift,
+            CoefficientOfVariation = cv,
+            WindowSize = window,
+            Reason = steady
+                ? $"drift {relativeDrift:F3} <= {maxRelativeDrift:F3}, CV {cv:F3} <= {maxCoefficientOfVariation:F3}"
+                : $"not steady: drift {relativeDrift:F3} (max {maxRelativeDrift:F3}), CV {cv:F3} (max {maxCoefficientOfVariation:F3})"
+        };
+    }
+}

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Sailfish.Contracts.Public.Models;
@@ -152,6 +154,15 @@ internal class TestCaseIterator : ITestCaseIterator
         TestInstanceContainer testInstanceContainer,
         CancellationToken cancellationToken)
     {
+        return testInstanceContainer.ExecutionSettings.UseSteadyStateWarmup
+            ? await SteadyStateWarmupIterations(testInstanceContainer, cancellationToken).ConfigureAwait(false)
+            : await FixedWarmupIterations(testInstanceContainer, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<TestCaseExecutionResult> FixedWarmupIterations(
+        TestInstanceContainer testInstanceContainer,
+        CancellationToken cancellationToken)
+    {
         for (var i = 0; i < testInstanceContainer.NumWarmupIterations; i++)
         {
             _logger.Log(LogLevel.Information, "      ---- warmup iteration {CurrentIteration} of {TotalIterations}", i + 1, testInstanceContainer.NumWarmupIterations);
@@ -177,6 +188,65 @@ internal class TestCaseIterator : ITestCaseIterator
             }
         }
 
+        return new TestCaseExecutionResult(testInstanceContainer);
+    }
+
+    // Warm up until per-iteration timing stops trending and stabilizes (or the cap is hit). Each warmup
+    // is timed locally (and NOT recorded into the real samples) and fed to the steady-state detector.
+    private async Task<TestCaseExecutionResult> SteadyStateWarmupIterations(
+        TestInstanceContainer testInstanceContainer,
+        CancellationToken cancellationToken)
+    {
+        const int window = 6;
+        const double maxRelativeDrift = 0.05;
+        const double maxCoefficientOfVariation = 0.15;
+
+        var settings = testInstanceContainer.ExecutionSettings;
+        var floor = Math.Max(0, testInstanceContainer.NumWarmupIterations);
+        var max = Math.Max(Math.Max(floor, window), settings.MaxWarmupIterations);
+        var detector = new SteadyStateWarmupDetector();
+        var durations = new List<double>(max);
+
+        for (var i = 0; i < max; i++)
+        {
+            try
+            {
+                await testInstanceContainer.CoreInvoker.IterationSetup(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                return CatchAndReturn(testInstanceContainer, ex);
+            }
+
+            var sw = Stopwatch.StartNew();
+            await testInstanceContainer.CoreInvoker.ExecutionMethod(cancellationToken, false).ConfigureAwait(false);
+            sw.Stop();
+            durations.Add(sw.Elapsed.TotalMilliseconds);
+
+            try
+            {
+                await testInstanceContainer.CoreInvoker.IterationTearDown(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                return CatchAndReturn(testInstanceContainer, ex);
+            }
+
+            var count = i + 1;
+            if (count >= floor && count >= window)
+            {
+                var result = detector.Check(durations, window, maxRelativeDrift, maxCoefficientOfVariation);
+                if (result.ReachedSteadyState)
+                {
+                    _logger.Log(LogLevel.Information, "      ---- warmup reached steady state after {Count} iterations ({Reason})", count, result.Reason);
+                    return new TestCaseExecutionResult(testInstanceContainer);
+                }
+            }
+
+            _logger.Log(LogLevel.Information, "      ---- warmup iteration {Count} (steady-state; floor {Floor}, max {Max})", count, floor, max);
+        }
+
+        _logger.Log(LogLevel.Information, "      ---- warmup reached max {Max} iterations without detecting steady state", max);
         return new TestCaseExecutionResult(testInstanceContainer);
     }
 

--- a/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
@@ -46,7 +46,11 @@ internal static class ExecutionExtensionMethods
             TargetIterationDuration = TimeSpan.FromMilliseconds(sailfishAttribute.TargetIterationDurationMs),
             MaxMeasurementTimePerMethod = sailfishAttribute.MaxMeasurementTimePerMethodMs > 0 ? TimeSpan.FromMilliseconds(sailfishAttribute.MaxMeasurementTimePerMethodMs) : (TimeSpan?)null,
             EnableDefaultDiagnosers = sailfishAttribute.EnableDefaultDiagnosers,
-            UseTimeBudgetController = sailfishAttribute.UseTimeBudgetController
+            UseTimeBudgetController = sailfishAttribute.UseTimeBudgetController,
+
+            // NEW: Steady-state warmup
+            UseSteadyStateWarmup = sailfishAttribute.UseSteadyStateWarmup,
+            MaxWarmupIterations = sailfishAttribute.MaxWarmupIterations
         };
     }
 

--- a/source/Tests.Library/Execution/SteadyStateWarmupDetectorTests.cs
+++ b/source/Tests.Library/Execution/SteadyStateWarmupDetectorTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Execution;
+
+public class SteadyStateWarmupDetectorTests
+{
+    private const int Window = 6;
+    private const double MaxDrift = 0.05;
+    private const double MaxCv = 0.15;
+
+    private static SteadyStateWarmupResult Check(IReadOnlyList<double> xs) =>
+        new SteadyStateWarmupDetector().Check(xs, Window, MaxDrift, MaxCv);
+
+    [Fact]
+    public void Stable_Flat_IsSteady()
+    {
+        Check(new double[] { 10, 10, 10, 10, 10, 10 }).ReachedSteadyState.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DecreasingThenFlat_OnceWindowClearsTheTransient_IsSteady()
+    {
+        // JIT-tiering shape: high then falling, then flat. Once the recent window is past the
+        // transient, it should read as steady.
+        var r = Check(new double[] { 100, 80, 40, 20, 10, 10, 10, 10, 10, 10 });
+        r.ReachedSteadyState.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StillTrendingDown_NotSteady()
+    {
+        Check(new double[] { 60, 50, 40, 30, 20, 10 }).ReachedSteadyState.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FlatTrendButHighDispersion_NotSteady()
+    {
+        // Prior/recent medians match (drift ~0) but the window is noisy → CV gate rejects it.
+        var r = Check(new double[] { 20, 20, 20, 20, 40, 0 });
+        r.ReachedSteadyState.ShouldBeFalse();
+        r.RelativeDrift.ShouldBeLessThan(MaxDrift);          // trend looks flat...
+        r.CoefficientOfVariation.ShouldBeGreaterThan(MaxCv); // ...but dispersion is too high
+    }
+
+    [Fact]
+    public void FewerThanWindowSamples_NotSteady()
+    {
+        var r = Check(new double[] { 10, 10, 10 });
+        r.ReachedSteadyState.ShouldBeFalse();
+        r.Reason.ShouldContain("need");
+    }
+
+    [Fact]
+    public void ColdStartSpikeOutsideWindow_DoesNotBlockSteadyState()
+    {
+        // A huge first sample shouldn't matter once it's outside the window.
+        var r = Check(new double[] { 100000, 12, 12, 11, 12, 12, 11, 12 });
+        r.ReachedSteadyState.ShouldBeTrue();
+    }
+}

--- a/source/Tests.Library/Integration/SteadyStateWarmupIntegrationTests.cs
+++ b/source/Tests.Library/Integration/SteadyStateWarmupIntegrationTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Sailfish.Analysis;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Integration;
+
+public class SteadyStateWarmupIntegrationTests
+{
+    private const int Window = 6; // detector window (effective minimum before a steady-state decision)
+
+    private static TestCaseIterator NewIterator()
+    {
+        var logger = Substitute.For<ILogger>();
+        var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder().Build();
+        return new TestCaseIterator(runSettings, logger,
+            new FixedIterationStrategy(logger),
+            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()));
+    }
+
+    [Fact]
+    public async Task SteadyStateWarmup_StableMethod_StopsEarly()
+    {
+        const int sampleSize = 2;
+        const int maxWarmup = 50;
+        var instance = new CountingStableWork(3); // stable ~3ms/call
+        var method = typeof(CountingStableWork).GetMethod(nameof(CountingStableWork.Run))!;
+        var settings = new ExecutionSettings
+        {
+            NumWarmupIterations = 2, // floor
+            SampleSize = sampleSize,
+            UseSteadyStateWarmup = true,
+            MaxWarmupIterations = maxWarmup,
+            UseAdaptiveSampling = false
+        };
+        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+
+        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        var warmups = instance.Calls - sampleSize; // total invocations minus measured samples
+        warmups.ShouldBeGreaterThanOrEqualTo(Window); // can't decide before the window fills
+        warmups.ShouldBeLessThan(maxWarmup);          // stopped early — did not hit the cap
+    }
+
+    [Fact]
+    public async Task SteadyStateWarmup_RespectsFloor()
+    {
+        const int sampleSize = 2;
+        const int floor = 12; // floor > window, so the floor governs the minimum
+        var instance = new CountingStableWork(3);
+        var method = typeof(CountingStableWork).GetMethod(nameof(CountingStableWork.Run))!;
+        var settings = new ExecutionSettings
+        {
+            NumWarmupIterations = floor,
+            SampleSize = sampleSize,
+            UseSteadyStateWarmup = true,
+            MaxWarmupIterations = 50,
+            UseAdaptiveSampling = false
+        };
+        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+
+        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        var warmups = instance.Calls - sampleSize;
+        warmups.ShouldBeGreaterThanOrEqualTo(floor); // never stops before the configured floor
+    }
+
+    private sealed class CountingStableWork
+    {
+        private readonly int _ms;
+        public int Calls;
+        public CountingStableWork(int ms) => _ms = ms;
+
+        public Task Run(CancellationToken ct)
+        {
+            Calls++;
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds < _ms)
+            {
+                if (ct.IsCancellationRequested) break;
+                Thread.SpinWait(1000);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #254/#255. Sailfish warms up a fixed number of iterations (`NumWarmupIterations`, default 3) before measuring. For code whose performance shifts while the runtime tiers up (tiered JIT + OSR), a fixed count can start measuring before steady state — or warm up longer than needed. This adds **opt-in auto steady-state warmup**: warm up until per-iteration timing stops trending and stabilizes, bounded by a floor and a cap.

## How it works

`SteadyStateWarmupDetector` examines a sliding window of recent warmup durations and declares steady state when **both**:

- **the trend has flattened** — the median of the recent half of the window is within ~5% of the median of the prior half (timings stopped falling; medians so a cold-start spike doesn't dominate), and
- **dispersion is low** — the window's coefficient of variation is ≤ ~15%.

`TestCaseIterator.WarmupIterations` dispatches to the steady-state loop (when enabled) or the unchanged fixed loop. Warmups run at least `NumWarmupIterations` (floor) and at most `MaxWarmupIterations` (cap, default 50), stopping early when stable. Each warmup is timed locally and is **not** recorded into your measured samples.

## Public API (opt-in)

```csharp
[Sailfish(UseSteadyStateWarmup = true, NumWarmupIterations = 4, MaxWarmupIterations = 50)]
```

Configured on the `[Sailfish]` attribute, **deliberately attribute-only** — consistent with the other execution-tuning knobs (`OperationsPerInvoke`, `TargetIterationDurationMs`, time budget, diagnosers), none of which expose `WithGlobal*` builder methods (only the core knobs do). Default `false` ⇒ the fixed-count warmup path is byte-for-byte unchanged. Detector thresholds (window 6, ~5% drift, ~15% CV) are internal for now.

## Validation

- **1442 `Tests.Library` tests pass.** 6 detector unit tests (JIT-tiering shape, still-trending, flat-but-noisy, cold-start spike, insufficient data) + 2 integration tests through the real iterator (stable method stops early; floor respected).
- Full solution builds on **net9.0 + net10.0**, 0 errors.

## Files

Code: `SteadyStateWarmupDetector.cs` (new), `SailfishAttribute.cs`, `ExecutionSettings.cs`, `ExecutionExtensionMethods.cs`, `TestCaseIterator.cs`. Tests: 2 new files. Docs: new `docs/1/steady-state-warmup.md` page + nav entry + release-note callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced steady-state warmup detection that automatically identifies when performance has stabilized and terminates the warmup phase early instead of running a fixed number of iterations. Includes configurable upper iteration bounds for controlled execution time.

* **Documentation**
  * Added documentation link for the steady-state warmup feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->