### PR TITLE
Centralize steady-state warmup detector thresholds

### DIFF
--- a/source/Sailfish/Execution/SteadyStateWarmupDetector.cs
+++ b/source/Sailfish/Execution/SteadyStateWarmupDetector.cs
@@ -31,6 +31,15 @@ public sealed class SteadyStateWarmupResult
 /// </summary>
 public sealed class SteadyStateWarmupDetector
 {
+    /// <summary>Default detector window — recent warmup samples examined (and the effective minimum before a decision).</summary>
+    internal const int DefaultWindow = 6;
+
+    /// <summary>Default max |recentMedian - priorMedian| / priorMedian for the trend to count as flat.</summary>
+    internal const double DefaultMaxRelativeDrift = 0.05;
+
+    /// <summary>Default max coefficient of variation over the window for the timing to count as stable.</summary>
+    internal const double DefaultMaxCoefficientOfVariation = 0.15;
+
     /// <summary>
     ///     Returns whether the tail of <paramref name="warmupDurations" /> looks steady. A decision is only
     ///     made once at least <paramref name="window" /> measurements are available.

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -197,13 +197,9 @@ internal class TestCaseIterator : ITestCaseIterator
         TestInstanceContainer testInstanceContainer,
         CancellationToken cancellationToken)
     {
-        const int window = 6;
-        const double maxRelativeDrift = 0.05;
-        const double maxCoefficientOfVariation = 0.15;
-
         var settings = testInstanceContainer.ExecutionSettings;
         var floor = Math.Max(0, testInstanceContainer.NumWarmupIterations);
-        var max = Math.Max(Math.Max(floor, window), settings.MaxWarmupIterations);
+        var max = Math.Max(Math.Max(floor, SteadyStateWarmupDetector.DefaultWindow), settings.MaxWarmupIterations);
         var detector = new SteadyStateWarmupDetector();
         var durations = new List<double>(max);
 
@@ -233,9 +229,9 @@ internal class TestCaseIterator : ITestCaseIterator
             }
 
             var count = i + 1;
-            if (count >= floor && count >= window)
+            if (count >= floor && count >= SteadyStateWarmupDetector.DefaultWindow)
             {
-                var result = detector.Check(durations, window, maxRelativeDrift, maxCoefficientOfVariation);
+                var result = detector.Check(durations, SteadyStateWarmupDetector.DefaultWindow, SteadyStateWarmupDetector.DefaultMaxRelativeDrift, SteadyStateWarmupDetector.DefaultMaxCoefficientOfVariation);
                 if (result.ReachedSteadyState)
                 {
                     _logger.Log(LogLevel.Information, "      ---- warmup reached steady state after {Count} iterations ({Reason})", count, result.Reason);

--- a/source/Tests.Library/Execution/SteadyStateWarmupDetectorTests.cs
+++ b/source/Tests.Library/Execution/SteadyStateWarmupDetectorTests.cs
@@ -7,9 +7,10 @@ namespace Tests.Library.Execution;
 
 public class SteadyStateWarmupDetectorTests
 {
-    private const int Window = 6;
-    private const double MaxDrift = 0.05;
-    private const double MaxCv = 0.15;
+    // Single source of truth: the production tuning values defined on the detector.
+    private const int Window = SteadyStateWarmupDetector.DefaultWindow;
+    private const double MaxDrift = SteadyStateWarmupDetector.DefaultMaxRelativeDrift;
+    private const double MaxCv = SteadyStateWarmupDetector.DefaultMaxCoefficientOfVariation;
 
     private static SteadyStateWarmupResult Check(IReadOnlyList<double> xs) =>
         new SteadyStateWarmupDetector().Check(xs, Window, MaxDrift, MaxCv);

--- a/source/Tests.Library/Integration/SteadyStateWarmupIntegrationTests.cs
+++ b/source/Tests.Library/Integration/SteadyStateWarmupIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace Tests.Library.Integration;
 
 public class SteadyStateWarmupIntegrationTests
 {
-    private const int Window = 6; // detector window (effective minimum before a steady-state decision)
+    private const int Window = SteadyStateWarmupDetector.DefaultWindow; // detector window (effective minimum before a decision)
 
     private static TestCaseIterator NewIterator()
     {


### PR DESCRIPTION
## Summary

Small follow-up to #256. The CodeRabbit review on #256 flagged that the steady-state warmup tuning values (`window`, `maxRelativeDrift`, `maxCoefficientOfVariation`) were hardcoded in `TestCaseIterator` and independently re-declared in the tests — so they could silently drift apart. The fix was pushed just after #256 was merged, so it missed the merge; this PR lands it on its own.

## Change

- Move the three tuning values to `internal const` on `SteadyStateWarmupDetector` (`DefaultWindow`, `DefaultMaxRelativeDrift`, `DefaultMaxCoefficientOfVariation`) — a single authoritative source.
- `TestCaseIterator` and both steady-state test files reference those consts instead of duplicating literals.

No behavior change — same values (window 6, drift 0.05, CV 0.15). 8 steady-state tests pass; builds on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
