### PR TITLE
TestAdapter: pin Roslyn floor to 4.14.0 to fix consumer install failures

### DIFF
--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -34,7 +34,12 @@
 
         <PackageReference Include="System.ComponentModel.Composition" Version="10.0.8" />
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.6.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+        <!-- Floor pinned to 4.14.0 (the mainstream .NET 9 / VS 17.14 Roslyn) for consumer compatibility.
+             Roslyn sub-packages use exact version pins, so a higher floor here forces that exact Common
+             on every consumer and breaks installs for anyone on the 4.x line. As a >= floor, consumers
+             on a newer Roslyn (e.g. 5.3.0) still float up automatically. Keep in lockstep with
+             Sailfish.Analyzers' Microsoft.CodeAnalysis.* version. Only used for CSharpSyntaxTree.ParseText. -->
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Sailfish\Sailfish.csproj" />


### PR DESCRIPTION
## Problem

Customers cannot install `Sailfish.TestAdapter` 4.0.65 — NuGet fails the restore and rolls back the package change:

> Detected package version outside of dependency constraint: Microsoft.CodeAnalysis.CSharp.Workspaces 4.14.0 requires Microsoft.CodeAnalysis.Common (= 4.14.0) but version Microsoft.CodeAnalysis.Common 5.3.0 ...

## Root cause

`Sailfish.TestAdapter` 4.0.65 declares a **public** dependency on `Microsoft.CodeAnalysis.CSharp` **5.3.0** (the `release/dev18.3` Roslyn). The Roslyn package family is version-locked with **exact** pins, so:

- `Microsoft.CodeAnalysis.CSharp 5.3.0` → `Microsoft.CodeAnalysis.Common = [5.3.0, 5.3.0]`
- `Microsoft.CodeAnalysis.CSharp.Workspaces 4.14.0` (present in the consumer's graph; ships in-box with the .NET 9 SDK / VS 17.14) → `Microsoft.CodeAnalysis.Common = [4.14.0, 4.14.0]`

Two exact pins on `Common`, two different versions → unsatisfiable restore.

The 5.3.0 bump landed in ccfcefd (a blanket dependency upgrade) while `Sailfish.Analyzers` stayed on 4.14.0, so the two halves of the package drifted onto different Roslyn majors. The adapter's only Roslyn use is `CSharpSyntaxTree.ParseText` in `Discovery/DiscoveryAnalysisMethods.cs` — a stable API that does not require 5.3.0.

## Fix

Pin the adapter's `Microsoft.CodeAnalysis.CSharp` back to **4.14.0**. A `PackageReference` version becomes a `>=` **floor** in the published nuspec, so this:

- ✅ resolves cleanly for consumers on 4.14.0 (fixes the reported failure)
- ✅ still lets consumers on a newer Roslyn line **float up** automatically — we no longer *force* bleeding-edge Roslyn on everyone
- ✅ puts the adapter and analyzer back in lockstep on the 4.14.0 line

## Verification

- Release build compiles against 4.14.0 for both `net9.0` and `net10.0`.
- The freshly packed nuspec now declares `<dependency id="Microsoft.CodeAnalysis.CSharp" version="4.14.0" />`.

## Note

The `Microsoft.Extensions.DependencyInjection` 10.0.7-vs-10.0.8 lines in the original error are a separate, non-fatal downgrade warning and are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)