### PR TITLE
Add SF1016 analyzer: flag SailfishVariable reads in GlobalSetup

### DIFF
--- a/site/src/pages/docs/1/sailfish-test-lifecycle.md
+++ b/site/src/pages/docs/1/sailfish-test-lifecycle.md
@@ -96,6 +96,27 @@ public Task ShareFixture(CancellationToken ct) => InitializeOnce(ct);
 
 When multiple test cases are created for a class, distinct instances of the class are created. Properties and Fields that are set in the global lifecycle methods must therefore be cloned to new instances that do not execute the global lifecycle method.
 
+> ⚠️ **Do not build `[SailfishVariable]`-dependent state in `[SailfishGlobalSetup]`.**
+>
+> `GlobalSetup` runs **once** for the whole class — only for the first variable set. The field/property state it produces is captured and then *replayed* onto every later test-case instance, while the `[SailfishVariable]` property itself is re-injected per case. So any field you derive from a variable inside `GlobalSetup` is silently **frozen at its first value**: every test case measures the same input size, and `ScaleFish` fits ~`O(1)` no matter how the variable scales.
+>
+> Build variable-dependent state in **`[SailfishMethodSetup]`** instead — it runs once per variable set, after injection and after the replay. The `SF1016` analyzer flags variable reads inside `[SailfishGlobalSetup]`/`[SailfishGlobalTeardown]`.
+>
+> ```csharp
+> [SailfishVariable(scaleFish: true, 100, 1_000, 10_000)]
+> public int N { get; set; }
+>
+> private int[] _buffer = [];
+>
+> // ❌ frozen at N = 100 for every case
+> [SailfishGlobalSetup]
+> public void GlobalSetup() => _buffer = new int[N];
+>
+> // ✅ rebuilt for each value of N
+> [SailfishMethodSetup]
+> public void MethodSetup() => _buffer = new int[N];
+> ```
+
 The following modifiers are allowed when creating a property or field where the data is a set during lifecycle invocation:
 
 ### Properties

--- a/site/src/pages/docs/1/sailfish-variables.md
+++ b/site/src/pages/docs/1/sailfish-variables.md
@@ -457,3 +457,7 @@ When using ScaleFish:
 
 `SailfishRangeVariable` also has a ScaleFish overload — `(bool scaleFish, int start, int count, int step = 1)`.
 {% /callout %}
+
+{% callout title="Build variable-dependent input in MethodSetup, not GlobalSetup" type="warning" %}
+A frequent cause of a ScaleFish fit that collapses to ~`O(1)` is building the variable-dependent input inside `[SailfishGlobalSetup]`. GlobalSetup runs **once** for the whole class, and the field/property state it produces is captured and replayed onto every test case — so the input is frozen at the first variable value while the variable property keeps advancing. Build the scaling input in `[SailfishMethodSetup]` instead, which runs once per variable set. The `SF1016` analyzer flags this at compile time. See [The Sailfish Test Lifecycle](/docs/1/sailfish-test-lifecycle) for the full mechanism.
+{% /callout %}

--- a/source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,6 +13,7 @@ SF1012 | Sailfish.Usage | Error | Properties decorated with the SailfishVariable
 SF1013 | Sailfish.Usage | Error | Properties initialized in the global setup must be public
 SF1014 | Sailfish.Usage | Error | Properties assigned in the global setup must have public getters
 SF1015 | Sailfish.Usage | Error | Properties assigned in the global setup must have public setters
+SF1016 | Sailfish.Usage | Warning | Variable-dependent state built in a once-per-class hook (GlobalSetup/GlobalTeardown) is silently frozen; build it in MethodSetup
 SF1020 | Sailfish.Usage | Error | Sailfish lifecycle methods must be public
 SF1021 | Sailfish.Usage | Error | Only one Sailfish lifecycle attribute is allowed per method
 SF7000 | Sailfish.Suppression | Hidden | Suppresses warnings when a non nullable property is set in the global setup method

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupAnalyzer.cs
@@ -1,0 +1,127 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.PropertiesSetInAnySailfishGlobalSetup;
+
+/// <summary>
+///     Flags reads of a Sailfish variable member (<c>[SailfishVariable]</c>, <c>[SailfishRangeVariable]</c>, or an
+///     <c>ISailfishVariables&lt;,&gt;</c> property) inside a once-per-class lifecycle hook
+///     (<c>[SailfishGlobalSetup]</c> / <c>[SailfishGlobalTeardown]</c>).
+///     <para>
+///         GlobalSetup runs exactly once for the whole class (at the first method's first variable set). The instance
+///         state it produces is captured by the engine and replayed onto every subsequent test-case instance, while the
+///         variable property itself is re-injected per case. So any field built from a variable inside GlobalSetup is
+///         silently frozen at a single value for every test case — the benchmark measures one input size for all cases
+///         and ScaleFish reports ~O(1). Variable-dependent state belongs in <c>[SailfishMethodSetup]</c>, which runs per
+///         variable set after the replay.
+///     </para>
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class VariableDependentStateInGlobalSetupAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: "SF1016",
+        title: "Sailfish variable read inside a once-per-class lifecycle hook",
+        messageFormat:
+        "'{0}' is a Sailfish variable read inside [{1}], which runs once per class. State derived from '{0}' there is frozen at a single value while '{0}' advances for every test case, so the benchmark silently measures one value of '{0}'. Build variable-dependent state in [SailfishMethodSetup] instead.",
+        category: AnalyzerGroups.EssentialAnalyzers.Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: AnalyzerGroups.EssentialAnalyzers.IsEnabledByDefault,
+        description:
+        "Reading a [SailfishVariable] (or [SailfishRangeVariable], or an ISailfishVariables<,> property) inside [SailfishGlobalSetup]/[SailfishGlobalTeardown] is almost always a bug. These hooks run once per class, and any field state derived from the variable is captured and replayed across every variable set, so the variable is silently frozen at a single value. Build variable-dependent state in [SailfishMethodSetup], which runs once per variable set.",
+        helpLinkUri: AnalyzerGroups.EssentialAnalyzers.HelpLink);
+
+    /// <summary>
+    ///     The once-per-class lifecycle hooks. Reads of a variable here cannot vary across test cases.
+    ///     Per-variable-set hooks (MethodSetup/IterationSetup) and the benchmark body are intentionally excluded.
+    /// </summary>
+    private static readonly string[] OncePerClassHookAttributeNames =
+    [
+        "SailfishGlobalSetup",
+        "SailfishGlobalTeardown"
+    ];
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    protected override void AnalyzeNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        var hookMethods = classDeclaration
+            .Members
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.HasAttributeAmong(OncePerClassHookAttributeNames))
+            .ToList();
+
+        // One diagnostic per (statement-or-hook, variable) so that `N + N` or repeated reads don't double-report.
+        var reported = new HashSet<(SyntaxNode Unit, string Variable)>();
+
+        foreach (var hookMethod in hookMethods)
+        {
+            var hookName = hookMethod.GetAllAttributesAmong(OncePerClassHookAttributeNames).First();
+
+            foreach (var identifier in hookMethod.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                // nameof(N) is a compile-time constant string, not a read of the variable's value.
+                if (IsInsideNameof(identifier)) continue;
+
+                // `N = ...` is a write to the variable, not a read of its (frozen) value.
+                if (IsSimpleAssignmentTarget(identifier)) continue;
+
+                if (semanticModel.GetSymbolInfo(identifier).Symbol is not IPropertySymbol propertySymbol) continue;
+                if (!IsSailfishVariableMember(propertySymbol)) continue;
+
+                var unit = (SyntaxNode?)identifier.FirstAncestorOrSelf<StatementSyntax>() ?? hookMethod;
+                if (!reported.Add((unit, propertySymbol.Name))) continue;
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Descriptor,
+                    identifier.GetLocation(),
+                    propertySymbol.Name,
+                    hookName));
+            }
+        }
+    }
+
+    private static bool IsSailfishVariableMember(IPropertySymbol property)
+    {
+        // Attribute-based variables: [SailfishVariable] / [SailfishRangeVariable].
+        // Matched by attribute class name to stay consistent with the rest of the analyzers and to work even when the
+        // attribute type is only available through a reference (no need to bind to ISailfishVariableAttribute).
+        if (property.GetAttributes().Any(a =>
+                a.AttributeClass is { } attributeClass &&
+                attributeClass.Name is "SailfishVariableAttribute" or "SailfishRangeVariableAttribute"))
+            return true;
+
+        // Interface/class-based variables: a property whose type is (or implements) ISailfishVariables<,>.
+        var propertyType = property.Type;
+        return propertyType.Name == "ISailfishVariables" ||
+               propertyType.AllInterfaces.Any(i => i.Name == "ISailfishVariables");
+    }
+
+    private static bool IsSimpleAssignmentTarget(IdentifierNameSyntax identifier)
+    {
+        return identifier.Parent is AssignmentExpressionSyntax assignment &&
+               assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) &&
+               assignment.Left == identifier;
+    }
+
+    private static bool IsInsideNameof(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.Text: "nameof" } })
+                return true;
+
+            // nameof arguments are syntactically shallow; stop at the first statement/member boundary.
+            if (current is StatementSyntax or MemberDeclarationSyntax) break;
+        }
+
+        return false;
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupAnalyzer.cs
@@ -98,10 +98,14 @@ public sealed class VariableDependentStateInGlobalSetupAnalyzer : AnalyzerBase<C
                 attributeClass.Name is "SailfishVariableAttribute" or "SailfishRangeVariableAttribute"))
             return true;
 
-        // Interface/class-based variables: a property whose type is (or implements) ISailfishVariables<,>.
-        var propertyType = property.Type;
-        return propertyType.Name == "ISailfishVariables" ||
-               propertyType.AllInterfaces.Any(i => i.Name == "ISailfishVariables");
+        // Interface/class-based variables: a property whose type is (or implements) the generic ISailfishVariables<,>.
+        // Match on arity 2 (not just the simple name) so an unrelated type named "ISailfishVariables" can't false-positive.
+        static bool IsSailfishVariablesInterface(INamedTypeSymbol type) => type is { Name: "ISailfishVariables", Arity: 2 };
+
+        if (property.Type is INamedTypeSymbol namedType && IsSailfishVariablesInterface(namedType))
+            return true;
+
+        return property.Type.AllInterfaces.Any(IsSailfishVariablesInterface);
     }
 
     private static bool IsSimpleAssignmentTarget(IdentifierNameSyntax identifier)

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupCodeFixProvider.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupCodeFixProvider.cs
@@ -1,0 +1,167 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.PropertiesSetInAnySailfishGlobalSetup;
+
+/// <summary>
+///     Moves variable-dependent state out of <c>[SailfishGlobalSetup]</c> and into <c>[SailfishMethodSetup]</c>, the
+///     hook that runs once per variable set. When GlobalSetup does nothing but build the variable-dependent state, the
+///     attribute is simply re-applied; otherwise only the offending assignment is moved and the rest of GlobalSetup is
+///     left untouched.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(VariableDependentStateInGlobalSetupCodeFixProvider))]
+[Shared]
+public sealed class VariableDependentStateInGlobalSetupCodeFixProvider : CodeFixProvider
+{
+    private const string MethodSetupAttributeName = "SailfishMethodSetup";
+    private const string GlobalSetupAttributeName = "SailfishGlobalSetup";
+    private const string AttributeSuffix = "Attribute";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(VariableDependentStateInGlobalSetupAnalyzer.Descriptor.Id);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var diagnostic = context.Diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        var identifier = node.FirstAncestorOrSelf<IdentifierNameSyntax>();
+
+        // We can only move the variable read if it lives inside an assignment. A bare read (e.g. logging the variable)
+        // is still flagged by the analyzer, but there is no statement we can safely relocate.
+        var assignment = identifier?.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        if (assignment is null) return;
+
+        var hookMethod = assignment.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+        // Only offer the fix for GlobalSetup. A variable read inside GlobalTeardown is still diagnosed, but relocating
+        // teardown logic into MethodSetup is not a meaningful transform.
+        if (hookMethod is null || !HasAttribute(hookMethod, GlobalSetupAttributeName)) return;
+        if (hookMethod.Parent is not TypeDeclarationSyntax) return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Move variable-dependent setup to [SailfishMethodSetup]",
+                c => MoveToMethodSetupAsync(context.Document, hookMethod, assignment, c),
+                nameof(VariableDependentStateInGlobalSetupCodeFixProvider)),
+            diagnostic);
+    }
+
+    private static async Task<Document> MoveToMethodSetupAsync(
+        Document document,
+        MethodDeclarationSyntax globalSetup,
+        AssignmentExpressionSyntax assignment,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null || globalSetup.Parent is not TypeDeclarationSyntax classDeclaration) return document;
+
+        var offendingStatement = assignment.FirstAncestorOrSelf<StatementSyntax>();
+
+        // Sole-purpose GlobalSetup: its entire body is this assignment, so the method should simply have been a
+        // MethodSetup. Re-attribute it in place — minimal change, preserves the body and its formatting verbatim.
+        var isSolePurpose =
+            (globalSetup.ExpressionBody is not null && globalSetup.ExpressionBody.Expression == assignment) ||
+            (globalSetup.Body is { } soleBody && soleBody.Statements.Count == 1 && soleBody.Statements[0] == offendingStatement);
+
+        if (isSolePurpose)
+        {
+            var reAttributed = RenameAttribute(globalSetup, GlobalSetupAttributeName, MethodSetupAttributeName);
+            return document.WithSyntaxRoot(root.ReplaceNode(globalSetup, reAttributed));
+        }
+
+        // Mixed body: split. Move only the offending statement; leave every unrelated GlobalSetup statement in place.
+        if (offendingStatement is null || globalSetup.Body is null) return document;
+
+        var movedStatement = SyntaxFactory.ExpressionStatement(assignment.WithoutTrivia())
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var trimmedGlobalSetup = globalSetup.WithBody(
+            globalSetup.Body.WithStatements(globalSetup.Body.Statements.Remove(offendingStatement)));
+
+        var existingMethodSetup = classDeclaration.Members
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => HasAttribute(m, MethodSetupAttributeName));
+
+        // Work by index against the original member list. Reference equality against a post-Replace list is unreliable
+        // because Replace re-wraps the surrounding red nodes, so IndexOf on the new list would not find them.
+        var members = classDeclaration.Members.ToList();
+        var globalSetupIndex = members.IndexOf(globalSetup);
+        members[globalSetupIndex] = trimmedGlobalSetup;
+
+        if (existingMethodSetup is not null)
+            members[members.IndexOf(existingMethodSetup)] = AppendStatement(existingMethodSetup, movedStatement);
+        else
+            members.Insert(globalSetupIndex + 1, CreateMethodSetup(movedStatement));
+
+        return document.WithSyntaxRoot(
+            root.ReplaceNode(classDeclaration, classDeclaration.WithMembers(SyntaxFactory.List(members))));
+    }
+
+    private static MethodDeclarationSyntax RenameAttribute(MethodDeclarationSyntax method, string fromName, string toName)
+    {
+        var attribute = method.AttributeLists
+            .SelectMany(list => list.Attributes)
+            .First(a => SimpleAttributeName(a.Name) == fromName);
+
+        var renamed = attribute.WithName(SyntaxFactory.IdentifierName(toName).WithTriviaFrom(attribute.Name));
+        return method.ReplaceNode(attribute, renamed);
+    }
+
+    private static MethodDeclarationSyntax AppendStatement(MethodDeclarationSyntax method, StatementSyntax statement)
+    {
+        if (method.Body is not null)
+            return method.WithBody(method.Body.AddStatements(statement));
+
+        if (method.ExpressionBody is not null)
+            return method
+                .WithExpressionBody(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None))
+                .WithBody(SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(method.ExpressionBody.Expression), statement))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+        return method.WithBody(SyntaxFactory.Block(statement)).WithAdditionalAnnotations(Formatter.Annotation);
+    }
+
+    private static MethodDeclarationSyntax CreateMethodSetup(StatementSyntax statement)
+    {
+        return SyntaxFactory.MethodDeclaration(
+                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+                "MethodSetup")
+            .WithAttributeLists(SyntaxFactory.SingletonList(
+                SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.Attribute(SyntaxFactory.IdentifierName(MethodSetupAttributeName))))))
+            .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+            .WithBody(SyntaxFactory.Block(statement))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+
+    private static bool HasAttribute(MethodDeclarationSyntax method, string attributeName)
+    {
+        return method.AttributeLists
+            .SelectMany(list => list.Attributes)
+            .Any(a => SimpleAttributeName(a.Name) == attributeName);
+    }
+
+    private static string SimpleAttributeName(NameSyntax name)
+    {
+        var text = name switch
+        {
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            SimpleNameSyntax simple => simple.Identifier.Text,
+            _ => name.ToString()
+        };
+
+        return text.EndsWith(AttributeSuffix) ? text.Substring(0, text.Length - AttributeSuffix.Length) : text;
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupCodeFixProvider.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/VariableDependentStateInGlobalSetupCodeFixProvider.cs
@@ -66,13 +66,18 @@ public sealed class VariableDependentStateInGlobalSetupCodeFixProvider : CodeFix
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         if (root is null || globalSetup.Parent is not TypeDeclarationSyntax classDeclaration) return document;
 
-        var offendingStatement = assignment.FirstAncestorOrSelf<StatementSyntax>();
+        // The top-level statement directly under the GlobalSetup block that contains the assignment. The assignment
+        // may be nested (inside an if/for/while), so we relocate the whole containing top-level statement — removing
+        // the nested node from Body.Statements would be a no-op and would duplicate it into MethodSetup.
+        var topLevelStatement = globalSetup.Body is null
+            ? null
+            : assignment.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault(s => s.Parent == globalSetup.Body);
 
         // Sole-purpose GlobalSetup: its entire body is this assignment, so the method should simply have been a
         // MethodSetup. Re-attribute it in place — minimal change, preserves the body and its formatting verbatim.
         var isSolePurpose =
             (globalSetup.ExpressionBody is not null && globalSetup.ExpressionBody.Expression == assignment) ||
-            (globalSetup.Body is { } soleBody && soleBody.Statements.Count == 1 && soleBody.Statements[0] == offendingStatement);
+            (globalSetup.Body is { } soleBody && soleBody.Statements.Count == 1 && soleBody.Statements[0] == topLevelStatement);
 
         if (isSolePurpose)
         {
@@ -80,14 +85,14 @@ public sealed class VariableDependentStateInGlobalSetupCodeFixProvider : CodeFix
             return document.WithSyntaxRoot(root.ReplaceNode(globalSetup, reAttributed));
         }
 
-        // Mixed body: split. Move only the offending statement; leave every unrelated GlobalSetup statement in place.
-        if (offendingStatement is null || globalSetup.Body is null) return document;
+        // Mixed body: split. Move the whole top-level statement; leave every unrelated GlobalSetup statement in place.
+        if (topLevelStatement is null || globalSetup.Body is null) return document;
 
-        var movedStatement = SyntaxFactory.ExpressionStatement(assignment.WithoutTrivia())
+        var movedStatement = topLevelStatement.WithoutTrivia()
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var trimmedGlobalSetup = globalSetup.WithBody(
-            globalSetup.Body.WithStatements(globalSetup.Body.Statements.Remove(offendingStatement)));
+            globalSetup.Body.WithStatements(globalSetup.Body.Statements.Remove(topLevelStatement)));
 
         var existingMethodSetup = classDeclaration.Members
             .OfType<MethodDeclarationSyntax>()

--- a/source/Sailfish/Attributes/SailfishGlobalSetupAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishGlobalSetupAttribute.cs
@@ -11,8 +11,9 @@ namespace Sailfish.Attributes;
 ///         This attribute should be placed on a single method. Only one method is allowed per Sailfish test class.
 ///     </para>
 ///     <para>
-///         <b>Do not build <see cref="SailfishVariableAttribute" />- or <see cref="SailfishRangeVariableAttribute" />-dependent
-///         state here.</b> GlobalSetup runs only for the first variable set, and the field/property state it produces is
+///         <b>Do not build Sailfish-variable-dependent state here</b> — whether the variable is a
+///         <see cref="SailfishVariableAttribute" />, a <see cref="SailfishRangeVariableAttribute" />, or an
+///         <c>ISailfishVariables&lt;,&gt;</c> property. GlobalSetup runs only for the first variable set, and the field/property state it produces is
 ///         captured and replayed onto every subsequent test-case instance — while the variable property itself is
 ///         re-injected per case. Any field derived from a variable inside GlobalSetup is therefore silently frozen at its
 ///         first value, so the benchmark measures a single input size for all cases (and ScaleFish reports ~O(1)). Build

--- a/source/Sailfish/Attributes/SailfishGlobalSetupAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishGlobalSetupAttribute.cs
@@ -3,10 +3,22 @@
 namespace Sailfish.Attributes;
 
 /// <summary>
-///     Specifies that the attributed method is responsible for Sailfish global setup.
+///     Specifies that the attributed method runs <b>once per test class</b>, before any test case executes. Use it for
+///     expensive setup that is shared, unchanged, across every variable set (opening a connection, loading a fixture).
 /// </summary>
 /// <remarks>
-///     This attribute should be placed on a single method. Only one method is allowed per Sailfish test class.
+///     <para>
+///         This attribute should be placed on a single method. Only one method is allowed per Sailfish test class.
+///     </para>
+///     <para>
+///         <b>Do not build <see cref="SailfishVariableAttribute" />- or <see cref="SailfishRangeVariableAttribute" />-dependent
+///         state here.</b> GlobalSetup runs only for the first variable set, and the field/property state it produces is
+///         captured and replayed onto every subsequent test-case instance — while the variable property itself is
+///         re-injected per case. Any field derived from a variable inside GlobalSetup is therefore silently frozen at its
+///         first value, so the benchmark measures a single input size for all cases (and ScaleFish reports ~O(1)). Build
+///         variable-dependent state in <see cref="SailfishMethodSetupAttribute" />, which runs once per variable set after
+///         the replay. The <c>SF1016</c> analyzer flags this mistake.
+///     </para>
 /// </remarks>
 /// <seealso href="https://paulgradie.com/Sailfish/docs/2/sailfish-lifecycle-method-attributes">
 ///     Sailfish Lifecycle Method

--- a/source/Sailfish/Attributes/SailfishGlobalTeardownAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishGlobalTeardownAttribute.cs
@@ -10,8 +10,9 @@ namespace Sailfish.Attributes;
 ///         This attribute should be placed on a single method. Only one method is allowed per Sailfish test class.
 ///     </para>
 ///     <para>
-///         Because this hook runs only once, a <see cref="SailfishVariableAttribute" /> read here resolves to a single
-///         value rather than varying per test case. Per-case teardown belongs in
+///         Because this hook runs only once, reading a Sailfish variable here — a <see cref="SailfishVariableAttribute" />,
+///         a <see cref="SailfishRangeVariableAttribute" />, or an <c>ISailfishVariables&lt;,&gt;</c> property — resolves to a
+///         single value rather than varying per test case. Per-case teardown belongs in
 ///         <see cref="SailfishMethodTeardownAttribute" />. The <c>SF1016</c> analyzer flags variable reads in this hook.
 ///     </para>
 /// </remarks>

--- a/source/Sailfish/Attributes/SailfishGlobalTeardownAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishGlobalTeardownAttribute.cs
@@ -3,10 +3,17 @@ using System;
 namespace Sailfish.Attributes;
 
 /// <summary>
-///     Specifies that the attributed method is responsible for Sailfish global teardown.
+///     Specifies that the attributed method runs <b>once per test class</b>, after all test cases have executed.
 /// </summary>
 /// <remarks>
-///     This attribute should be placed on a single method. Only one method is allowed per Sailfish test class.
+///     <para>
+///         This attribute should be placed on a single method. Only one method is allowed per Sailfish test class.
+///     </para>
+///     <para>
+///         Because this hook runs only once, a <see cref="SailfishVariableAttribute" /> read here resolves to a single
+///         value rather than varying per test case. Per-case teardown belongs in
+///         <see cref="SailfishMethodTeardownAttribute" />. The <c>SF1016</c> analyzer flags variable reads in this hook.
+///     </para>
 /// </remarks>
 /// <seealso href="https://paulgradie.com/Sailfish/docs/2/sailfish-lifecycle-method-attributes">
 ///     Sailfish Lifecycle Method

--- a/source/Tests.Analyzers/PropertiesSetInGlobalSetup/VariableDependentStateInGlobalSetup.cs
+++ b/source/Tests.Analyzers/PropertiesSetInGlobalSetup/VariableDependentStateInGlobalSetup.cs
@@ -1,0 +1,312 @@
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.PropertiesSetInAnySailfishGlobalSetup;
+using Tests.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Analyzers.PropertiesSetInGlobalSetup;
+
+public class VariableDependentStateInGlobalSetup
+{
+    [Fact]
+    public async Task FlagsVariableDerivedAssignmentInGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _size = {|#0:N|} * 2;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+    }
+
+    [Fact]
+    public async Task FlagsExpressionBodiedGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int[] _buffer = new int[0];
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup() => _buffer = new int[{|#0:N|}];
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+    }
+
+    [Fact]
+    public async Task FlagsRangeVariableInGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishRangeVariable(1, 5)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _size = {|#0:N|};
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+    }
+
+    [Fact]
+    public async Task FlagsSailfishVariablesInterfacePropertyInGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    public Sizes Size { get; set; }
+
+    private Sizes _captured;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _captured = {|#0:Size|};
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}
+
+public class Sizes : ISailfishVariables<int, SizesProvider>
+{
+}
+
+public class SizesProvider
+{
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("Size", "SailfishGlobalSetup"));
+    }
+
+    [Fact]
+    public async Task FlagsVariableReadInGlobalTeardown()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishGlobalTeardown]
+    public void GlobalTeardown()
+    {
+        _size = {|#0:N|};
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalTeardown"));
+    }
+
+    [Fact]
+    public async Task DoesNotDoubleReportMultipleReadsInTheSameStatement()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _size = {|#0:N|} + N;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+    }
+
+    [Fact]
+    public async Task DoesNotFlagVariableUseInMethodSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishMethodSetup]
+    public void MethodSetup()
+    {
+        _size = N * 2;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task DoesNotFlagVariableUseInIterationSetupOrSailfishMethod()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishIterationSetup]
+    public void IterationSetup()
+    {
+        _size = N * 2;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        var local = N + 1;
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task DoesNotFlagLiteralAssignmentInGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _size;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _size = 77;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task DoesNotFlagNonVariablePropertyReadInGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    public int NotAVariable { get; set; }
+
+    private int _size;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _size = NotAVariable * 2;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task DoesNotFlagNameofVariableInGlobalSetup()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private string _name;
+
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        _name = nameof(N);
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+    }
+}";
+        await AnalyzerVerifier<VariableDependentStateInGlobalSetupAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
+}

--- a/source/Tests.Analyzers/PropertiesSetInGlobalSetup/VariableDependentStateInGlobalSetupCodeFixTests.cs
+++ b/source/Tests.Analyzers/PropertiesSetInGlobalSetup/VariableDependentStateInGlobalSetupCodeFixTests.cs
@@ -1,0 +1,232 @@
+#if HAS_CODEFIX_TESTING
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Sailfish.Analyzers.DiagnosticAnalyzers.PropertiesSetInAnySailfishGlobalSetup;
+using Tests.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Analyzers.PropertiesSetInGlobalSetup;
+
+public class VariableDependentStateInGlobalSetupCodeFixTests
+{
+    private static string DepsAttributes => "".AddSailfishAttributeDependencies();
+
+    [Fact]
+    public async Task SolePurposeExpressionBodiedGlobalSetup_IsReAttributedAsMethodSetup()
+    {
+        var testCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int[] _buffer = new int[0];
+
+    [SailfishGlobalSetup]
+    public void Setup() => _buffer = new int[{|#0:N|}];
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var fixedCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int[] _buffer = new int[0];
+
+    [SailfishMethodSetup]
+    public void Setup() => _buffer = new int[N];
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var test = new CSharpCodeFixTest<VariableDependentStateInGlobalSetupAnalyzer, VariableDependentStateInGlobalSetupCodeFixProvider, XUnitVerifier>
+        {
+            TestState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", testCode) },
+            },
+            FixedState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", fixedCode) },
+            },
+        };
+
+        test.TestState.ExpectedDiagnostics.Add(
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MixedGlobalSetup_MovesOnlyTheOffendingStatement_AndLeavesTheRest()
+    {
+        var testCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _connection;
+    private int[] _buffer = new int[0];
+
+    [SailfishGlobalSetup]
+    public void Setup()
+    {
+        _connection = 5;
+        _buffer = new int[{|#0:N|}];
+    }
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var fixedCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _connection;
+    private int[] _buffer = new int[0];
+
+    [SailfishGlobalSetup]
+    public void Setup()
+    {
+        _connection = 5;
+    }
+
+    [SailfishMethodSetup]
+    public void MethodSetup()
+    {
+        _buffer = new int[N];
+    }
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var test = new CSharpCodeFixTest<VariableDependentStateInGlobalSetupAnalyzer, VariableDependentStateInGlobalSetupCodeFixProvider, XUnitVerifier>
+        {
+            TestState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", testCode) },
+            },
+            FixedState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", fixedCode) },
+            },
+        };
+
+        test.TestState.ExpectedDiagnostics.Add(
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MixedGlobalSetup_AppendsToAnExistingMethodSetup()
+    {
+        var testCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _connection;
+    private int[] _buffer = new int[0];
+
+    [SailfishMethodSetup]
+    public void MethodSetup()
+    {
+        _connection = 1;
+    }
+
+    [SailfishGlobalSetup]
+    public void Setup()
+    {
+        _connection = 5;
+        _buffer = new int[{|#0:N|}];
+    }
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var fixedCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _connection;
+    private int[] _buffer = new int[0];
+
+    [SailfishMethodSetup]
+    public void MethodSetup()
+    {
+        _connection = 1;
+        _buffer = new int[N];
+    }
+
+    [SailfishGlobalSetup]
+    public void Setup()
+    {
+        _connection = 5;
+    }
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var test = new CSharpCodeFixTest<VariableDependentStateInGlobalSetupAnalyzer, VariableDependentStateInGlobalSetupCodeFixProvider, XUnitVerifier>
+        {
+            TestState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", testCode) },
+            },
+            FixedState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", fixedCode) },
+            },
+        };
+
+        test.TestState.ExpectedDiagnostics.Add(
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+        await test.RunAsync();
+    }
+}
+#endif

--- a/source/Tests.Analyzers/PropertiesSetInGlobalSetup/VariableDependentStateInGlobalSetupCodeFixTests.cs
+++ b/source/Tests.Analyzers/PropertiesSetInGlobalSetup/VariableDependentStateInGlobalSetupCodeFixTests.cs
@@ -228,5 +228,86 @@ public class Bench
             new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task NestedAssignment_MovesTheWholeTopLevelStatement_WithoutDuplicating()
+    {
+        var testCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _connection;
+    private int[] _buffer = new int[0];
+
+    [SailfishGlobalSetup]
+    public void Setup()
+    {
+        _connection = 5;
+        if (_connection > 0)
+        {
+            _buffer = new int[{|#0:N|}];
+        }
+    }
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var fixedCode = (@"
+using Sailfish.AnalyzerTests;
+[Sailfish]
+public class Bench
+{
+    [SailfishVariable(100, 1000, 10000)]
+    public int N { get; set; }
+
+    private int _connection;
+    private int[] _buffer = new int[0];
+
+    [SailfishGlobalSetup]
+    public void Setup()
+    {
+        _connection = 5;
+    }
+
+    [SailfishMethodSetup]
+    public void MethodSetup()
+    {
+        if (_connection > 0)
+        {
+            _buffer = new int[N];
+        }
+    }
+
+    [SailfishMethod]
+    public void Join()
+    {
+    }
+}
+").NormalizeLineEndings();
+
+        var test = new CSharpCodeFixTest<VariableDependentStateInGlobalSetupAnalyzer, VariableDependentStateInGlobalSetupCodeFixProvider, XUnitVerifier>
+        {
+            TestState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", testCode) },
+            },
+            FixedState =
+            {
+                Sources = { ("DepsA.cs", DepsAttributes), ("Test.cs", fixedCode) },
+            },
+        };
+
+        test.TestState.ExpectedDiagnostics.Add(
+            new DiagnosticResult(VariableDependentStateInGlobalSetupAnalyzer.Descriptor).WithLocation(0).WithArguments("N", "SailfishGlobalSetup"));
+        await test.RunAsync();
+    }
 }
 #endif

--- a/source/Tests.Analyzers/Utils/TestDependencyExtensionMethods.cs
+++ b/source/Tests.Analyzers/Utils/TestDependencyExtensionMethods.cs
@@ -147,6 +147,31 @@ public class SailfishVariableAttribute : Attribute
     }
 }
 
+[AttributeUsage(AttributeTargets.Property)]
+public class SailfishRangeVariableAttribute : Attribute
+{
+    public SailfishRangeVariableAttribute(int start, int count, int step = 1)
+    {
+        Start = start;
+        Count = count;
+        Step = step;
+    }
+
+    public SailfishRangeVariableAttribute(bool scaleFish, int start, int count, int step = 1) : this(start, count, step)
+    {
+        ScaleFish = scaleFish;
+    }
+
+    public int Start { get; }
+    public int Count { get; }
+    public int Step { get; }
+    public bool ScaleFish { get; }
+}
+
+public interface ISailfishVariables<TType, TTypeProvider>
+{
+}
+
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class SuppressConsoleAttribute : Attribute
 {


### PR DESCRIPTION
## Why

A benchmark class with a `[SailfishVariable]` (e.g. a scaling variable) that builds state from it in `[SailfishGlobalSetup]` compiles and runs clean but produces **wrong results with no warning**.

`[SailfishGlobalSetup]` runs exactly once per class (first method's first variable set — see `ShouldCallGlobalSetup`). Right after it runs, instance state is captured by `TestCasePropertyCloner.RetrievePropertiesAndFields` — which **excludes** `[SailfishVariable]` properties but **captures** all non-backing instance fields — and replayed onto every later test-case instance via `ApplyPropertiesAndFieldsTo` before `MethodSetup`. Net effect: a field derived from a variable in GlobalSetup is **silently frozen at the first variable value** for every case, while the variable property itself advances. The benchmark measures one input size for all cases and ScaleFish fits ~`O(1)`.

```csharp
[SailfishVariable(scaleFish: true, 100, 1_000, 10_000)]
public int N { get; set; }

private string[] _parts = [];

[SailfishGlobalSetup]                          // ❌ frozen at N = 100 for every case
public void Setup() => _parts = Enumerable.Range(0, N).Select(i => i.ToString()).ToArray();

[SailfishMethod] public string Join() => string.Join("", _parts);
```

The fix is **detection + guidance**, not a behavior change — the cache/replay is intentional for expensive shared setup.

## What

**New analyzer `SF1016`** (`EssentialAnalyzers` / `Warning`, next free ID in the SF1013-1015 neighborhood) — flags reads of any variable-family member (`[SailfishVariable]`, `[SailfishRangeVariable]`, `ISailfishVariables<,>`) inside `[SailfishGlobalSetup]` / `[SailfishGlobalTeardown]`. It does **not** fire inside `[SailfishMethodSetup]` / `[SailfishIterationSetup]` / `[SailfishMethod]`, and is orthogonal to SF1013-1015 (those inspect LHS property accessibility; this inspects RHS variable reads). Guards `nameof`, write-targets, and de-dupes multiple reads.

**Code fix** — moves the work to `[SailfishMethodSetup]`: a clean attribute rename when GlobalSetup is sole-purpose (the repro), or a statement split (move only the offending assignment, leave the rest) for mixed bodies, creating or appending to a MethodSetup as needed.

**Docs at point of use** — `SailfishGlobalSetupAttribute` / `SailfishGlobalTeardownAttribute` XML docs (IntelliSense), plus the lifecycle and variables guides.

## Implementation notes

- Detects variable members semantically by attribute class name + `ISailfishVariables<,>` interface (works regardless of how the attribute type is referenced).
- Uses the robust `HasAttributeAmong` helper rather than the `MethodDeclarationSyntax` overload of `HasAttributesWithNames` (the latter is `.All()`-based and matches attribute-less methods).
- Engine GlobalSetup gating and cache/replay behavior are untouched; no existing analyzers modified.

## Tests

14 new tests mirroring the SF1013-1015 style:
- Analyzer: GlobalSetup positive (block + expression-bodied repro), range/interface variants, GlobalTeardown, multi-read dedupe; negatives for MethodSetup / IterationSetup / SailfishMethod / literal / non-variable property / `nameof`.
- Code fix: repro → MethodSetup form (compiles), plus both split paths (create new MethodSetup; append to existing).

`Sailfish.Analyzers` and `Sailfish` build clean (0/0); **full analyzer suite 80/80 on net9.0 and net10.0**.

## Follow-ups (not in this PR)

- **ScaleFish runtime backstop** (Deliverable 3, explicitly splittable): emit a runtime warning when a `scaleFish: true` variable fits ~`O(1)`, naming the GlobalSetup pitfall as a likely cause.
- **Latent bug in `HasAttributesWithNames`**: its `MethodDeclarationSyntax` overload uses `.All()`, so it matches attribute-less methods — meaning SF1013/1014/1015 can false-positive on private helper methods. Left untouched here (kept the change additive); worth a focused fix + regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analyzer SF1016 to detect variable-dependent state reads in global setup/teardown hooks and a code fix to move offending setup into method-level hooks.

* **Documentation**
  * Expanded guidance for global setup/teardown attributes and safe handling of variable-backed state.

* **Tests**
  * Added comprehensive analyzer and code-fix tests plus test helpers for range-variable and variables-interface scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Related PRs

Part of a small cluster addressing the **variable-dependent-state-in-`[SailfishGlobalSetup]`** footgun and adjacent analyzer correctness. All three are independent — branched off `main` with non-overlapping files — so they merge cleanly in any order.

- **#261 — SF1016 static analyzer + code fix _(this PR)_.** Flags reading a `[SailfishVariable]` inside a once-per-class hook and offers to move it to `[SailfishMethodSetup]`.
- **#263 — ScaleFish ~O(1) runtime backstop.** Complements the SF1016 analyzer at runtime, catching cases static analysis can't see (helper-method indirection, DCE).
- **#262 — attribute-less GlobalSetup detection fix.** Fixes a latent false-positive in the existing SF1013–1015 / SF7000 GlobalSetup analyzers, discovered while building SF1016.
