### PR TITLE
Fix false-positive global-setup detection for attribute-less methods

### DIFF
--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldBePublicAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldBePublicAnalyzer.cs
@@ -30,7 +30,7 @@ public class ShouldBePublicAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributesWithNames("SailfishGlobalSetup"))
+            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldBePublicAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldBePublicAnalyzer.cs
@@ -30,7 +30,7 @@ public class ShouldBePublicAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            .Where(m => m.IsSailfishGlobalSetupMethod(semanticModel))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicGettersAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicGettersAnalyzer.cs
@@ -31,7 +31,7 @@ public class ShouldHavePublicGettersAnalyzer : AnalyzerBase<ClassDeclarationSynt
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributesWithNames("SailfishGlobalSetup"))
+            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicGettersAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicGettersAnalyzer.cs
@@ -31,7 +31,7 @@ public class ShouldHavePublicGettersAnalyzer : AnalyzerBase<ClassDeclarationSynt
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            .Where(m => m.IsSailfishGlobalSetupMethod(semanticModel))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicSettersAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicSettersAnalyzer.cs
@@ -31,7 +31,7 @@ public class ShouldHavePublicSettersAnalyzer : AnalyzerBase<ClassDeclarationSynt
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            .Where(m => m.IsSailfishGlobalSetupMethod(semanticModel))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicSettersAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/PropertiesSetInAnySailfishGlobalSetup/ShouldHavePublicSettersAnalyzer.cs
@@ -31,7 +31,7 @@ public class ShouldHavePublicSettersAnalyzer : AnalyzerBase<ClassDeclarationSynt
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributesWithNames("SailfishGlobalSetup"))
+            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod.cs
@@ -31,7 +31,7 @@ public class SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod : An
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            .Where(m => m.IsSailfishGlobalSetupMethod(semanticModel))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod.cs
@@ -31,7 +31,7 @@ public class SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod : An
         var globalSetupMethods = classDeclaration
             .Members
             .OfType<MethodDeclarationSyntax>()
-            .Where(m => m.HasAttributesWithNames("SailfishGlobalSetup"))
+            .Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" }) || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
             .ToList();
 
         var thingsAssignedInsideOfTheGlobalSetupMethods = globalSetupMethods

--- a/source/Sailfish.Analyzers/Utils/TreeParsingExtensionMethods/SailfishFeatureDiscoveryExtensionMethods.cs
+++ b/source/Sailfish.Analyzers/Utils/TreeParsingExtensionMethods/SailfishFeatureDiscoveryExtensionMethods.cs
@@ -70,4 +70,32 @@ public static class NodeExtensionMethods
         if (!foundAttributes.Any()) return false;
         return attributeNames.Intersect(foundAttributes).Count() == attributeNames.Length;
     }
+
+    /// <summary>
+    ///     Determines whether a method participates in Sailfish global setup: either it is directly decorated with
+    ///     <c>[SailfishGlobalSetup]</c>, or it is an <c>override</c> of a base "template" method whose declaring type
+    ///     itself defines a <c>[SailfishGlobalSetup]</c> hook (the common pattern where a base global-setup hook invokes
+    ///     a virtual method that derived classes override). Unrelated overrides (e.g. <c>object.ToString</c>,
+    ///     <c>IDisposable.Dispose</c>) are excluded because their declaring types declare no global-setup hook.
+    /// </summary>
+    public static bool IsSailfishGlobalSetupMethod(this MethodDeclarationSyntax method, SemanticModel semanticModel)
+    {
+        if (method.HasAttributeAmong(new[] { "SailfishGlobalSetup" })) return true;
+        if (!method.Modifiers.Any(SyntaxKind.OverrideKeyword)) return false;
+
+        if (semanticModel.GetDeclaredSymbol(method) is not IMethodSymbol methodSymbol) return false;
+
+        for (var overridden = methodSymbol.OverriddenMethod; overridden is not null; overridden = overridden.OverriddenMethod)
+        {
+            var members = overridden.ContainingType?.GetMembers().OfType<IMethodSymbol>();
+            if (members is not null && members.Any(DeclaresGlobalSetup)) return true;
+        }
+
+        return false;
+    }
+
+    private static bool DeclaresGlobalSetup(IMethodSymbol method)
+    {
+        return method.GetAttributes().Any(a => a.AttributeClass?.Name == "SailfishGlobalSetupAttribute");
+    }
 }

--- a/source/Tests.Analyzers/PropertiesSetInGlobalSetup/PropertiesShouldBePublic.cs
+++ b/source/Tests.Analyzers/PropertiesSetInGlobalSetup/PropertiesShouldBePublic.cs
@@ -118,4 +118,31 @@ public class TestCode
             new DiagnosticResult(ShouldBePublicAnalyzer.Descriptor).WithLocation(1).WithArguments("NonPublicModifier")
         );
     }
+
+    [Fact]
+    public async Task UnrelatedOverrideAssigningNonPublicPropertyShouldNotBeFlagged()
+    {
+        // Regression: an `override` of a non-Sailfish base method (here object.ToString) is not part of global setup,
+        // so assignments inside it must not be flagged. Only overrides whose base type itself declares a
+        // [SailfishGlobalSetup] hook participate in global setup (the base-class template pattern).
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    int NonPublicModifier { get; set; }
+
+    public override string ToString()
+    {
+        NonPublicModifier = 5;
+        return string.Empty;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        // do nothing
+    }
+}";
+        await AnalyzerVerifier<ShouldBePublicAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
 }

--- a/source/Tests.Analyzers/PropertiesSetInGlobalSetup/PropertiesShouldBePublic.cs
+++ b/source/Tests.Analyzers/PropertiesSetInGlobalSetup/PropertiesShouldBePublic.cs
@@ -61,4 +61,61 @@ public class PrivateSettersShouldError
 ";
         await AnalyzerVerifier<ShouldBePublicAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
     }
+
+    [Fact]
+    public async Task AttributelessHelperAssigningNonPublicPropertyShouldNotBeFlagged()
+    {
+        // Regression: a method with NO attributes must not be treated as a global-setup method.
+        // Previously the .All(...) over an empty attribute sequence returned true, so attribute-less
+        // helpers were scanned and produced a false-positive "must be public" diagnostic.
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    int NonPublicModifier { get; set; }
+
+    private void Helper()
+    {
+        NonPublicModifier = 5;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        // do nothing
+    }
+}";
+        await AnalyzerVerifier<ShouldBePublicAnalyzer>.VerifyAnalyzerAsync(source.AddSailfishAttributeDependencies());
+    }
+
+    [Fact]
+    public async Task GlobalSetupWithAdditionalUnrelatedAttributeShouldStillBeDiscovered()
+    {
+        // The detection uses an intersection check, so a [SailfishGlobalSetup] method that also
+        // carries an unrelated attribute (here [Obsolete]) must still be recognized as global setup.
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    int {|#0:NonPublicModifier|} { get; set; }
+
+    [Obsolete]
+    [SailfishGlobalSetup]
+    public void GlobalSetup()
+    {
+        {|#1:NonPublicModifier|} = 77;
+    }
+
+    [SailfishMethod]
+    public void MainMethod()
+    {
+        // do nothing
+    }
+}";
+        await AnalyzerVerifier<ShouldBePublicAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(ShouldBePublicAnalyzer.Descriptor).WithLocation(0).WithArguments("NonPublicModifier"),
+            new DiagnosticResult(ShouldBePublicAnalyzer.Descriptor).WithLocation(1).WithArguments("NonPublicModifier")
+        );
+    }
 }


### PR DESCRIPTION
## The bug

Four analyzers locate `[SailfishGlobalSetup]` methods and then scan their bodies for assignments to non-public members:

- `ShouldBePublicAnalyzer` (**SF1013**)
- `ShouldHavePublicGettersAnalyzer` (**SF1014**)
- `ShouldHavePublicSettersAnalyzer` (**SF1015**)
- `SuppressNonNullablePropertiesWarningWhenSetInGlobalSetupMethod` (**SF7000** suppressor)

Each selected the global-setup methods with:

```csharp
.Where(m => m.HasAttributesWithNames("SailfishGlobalSetup"))
```

`HasAttributesWithNames` (the `MethodDeclarationSyntax` overload) is implemented as:

```csharp
methodDeclarationSyntax.AttributeLists.SelectMany(x => x.Attributes)
    .All(a => attributeName.Contains(a.Name.ToString()));
```

`.All(...)` over an **empty** sequence returns `true`. So a method with **no attributes** matches `HasAttributesWithNames("SailfishGlobalSetup")`. A perfectly ordinary private helper in a Sailfish test class —

```csharp
void Helper() { _nonPublicProp = 5; }
```

— was therefore treated as a global-setup method, its body scanned, and a spurious "must be public" diagnostic (SF1013/1014/1015) was raised on the assigned non-public member.

## The override-discovery entanglement

There is an existing, intentional test `OverridesShouldBeDiscoveredToo` (in `Tests.Analyzers/PropertiesSetInGlobalSetup/PropertiesShouldHavePublicSetters.cs`). It models an abstract base whose `[SailfishGlobalSetup]` method calls a `protected virtual MySetup(...)`, and a derived `[Sailfish]` class that **overrides** `MySetup` and assigns a private-setter property in the override — and it expects that assignment to be flagged.

That override method carries **no** `[SailfishGlobalSetup]` attribute. It was only being discovered because of the same empty-`.All()` quirk. A naive migration to a strict intersection check (`HasAttributeAmong`) fixes the false positive but silently **breaks override discovery** and that test.

## The fix

Treat a method as a global-setup method if it is attributed `[SailfishGlobalSetup]` **OR** it carries the `override` modifier:

```csharp
.Where(m => m.HasAttributeAmong(new[] { "SailfishGlobalSetup" })
            || m.Modifiers.Any(SyntaxKind.OverrideKeyword))
```

`HasAttributeAmong(IEnumerable<string>)` already exists in the same file and is intersection-based (it is the helper `LifecycleMethodsShouldBePublicAnalyzer` uses correctly). `Modifiers.Any(SyntaxKind.OverrideKeyword)` mirrors the existing `Modifiers.Any(SyntaxKind.PublicKeyword)` usage in that same lifecycle analyzer.

This:

- **stops matching plain attribute-less helpers** → fixes the false positive;
- **still matches `override` methods** → preserves `OverridesShouldBeDiscoveredToo`;
- **still matches a `[SailfishGlobalSetup]` method that also carries an unrelated attribute** (e.g. `[Obsolete]`) because the check is an intersection, not `.All()`.

### Residual heuristic / tradeoff

Override discovery is intentionally **name-agnostic** (it keys off the `override` keyword, not the overridden method's identity). Consequently, an `override` of an *unrelated* (non-Sailfish) base method that happens to assign a non-public member inside a `[Sailfish]` test class would still be flagged. This is a deliberate tradeoff: it preserves the prior override behavior that the suite depends on, and it is the behavior the existing `OverridesShouldBeDiscoveredToo` test encodes. Tightening this further (resolving overrides back to a base `[SailfishGlobalSetup]` method via the semantic model) would be a larger, separate change.

### What was deliberately left alone

`HasAttributesWithNames` itself is **not** changed and **not** deleted. The direct unit test `MethodAttributeHelpers_WorkAsExpected` (in `Tests.Analyzers/Utils/SailfishFeatureDiscoveryExtensionMethodsTests.cs`) locks in its current "all attributes are among the given names" subset semantics, and the `PropertyDeclarationSyntax` overload (used by `IsSailfishVariableProperty`) is correct as-is.

## Tests

Added to `Tests.Analyzers/PropertiesSetInGlobalSetup/PropertiesShouldBePublic.cs` (mirroring the existing `AnalyzerVerifier<...>` style):

1. `AttributelessHelperAssigningNonPublicPropertyShouldNotBeFlagged` — a `[Sailfish]` class with an attribute-less private helper assigning a non-public property produces **no** diagnostic (regression test for the false positive).
2. `GlobalSetupWithAdditionalUnrelatedAttributeShouldStillBeDiscovered` — a `[SailfishGlobalSetup]` method that also carries `[Obsolete]` is **still** discovered and the non-public property is flagged (proves intersection semantics).

The existing `OverridesShouldBeDiscoveredToo`, `MethodAttributeHelpers_WorkAsExpected`, and all other analyzer tests continue to pass.

## Verification

- `dotnet build source/Sailfish.Analyzers` → 0 warnings, 0 errors.
- `dotnet test source/Tests.Analyzers/Tests.Analyzers.csproj` (multi-targets `net9.0;net10.0`, both run) → **68 passed, 0 failed** on each TFM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how diagnostic analyzers detect global setup methods to now include both attribute-marked and overridden methods, ensuring comprehensive property visibility enforcement across various scenarios.

* **Tests**
  * Added test coverage for edge cases in global setup detection, including verification for attribute-less helper methods and methods with multiple attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Related PRs

Part of a small cluster addressing the **variable-dependent-state-in-`[SailfishGlobalSetup]`** footgun and adjacent analyzer correctness. All three are independent — branched off `main` with non-overlapping files — so they merge cleanly in any order.

- **#261 — SF1016 static analyzer + code fix.** Flags reading a `[SailfishVariable]` inside a once-per-class hook and offers to move it to `[SailfishMethodSetup]`.
- **#263 — ScaleFish ~O(1) runtime backstop.** Complements the SF1016 analyzer at runtime, catching cases static analysis can't see (helper-method indirection, DCE).
- **#262 — attribute-less GlobalSetup detection fix _(this PR)_.** Fixes a latent false-positive in the existing SF1013–1015 / SF7000 GlobalSetup analyzers, discovered while building SF1016.
