### PR TITLE
Add ScaleFish ~O(1) runtime backstop for frozen scaling variables

### DIFF
--- a/source/Sailfish/Analysis/ScaleFish/ConstantComplexityDetector.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ConstantComplexityDetector.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Sailfish.Analysis.ScaleFish;
+
+/// <summary>
+/// Runtime backstop for the "frozen scaling variable" trap. A <c>[SailfishVariable(scaleFish: true)]</c>
+/// property is meant to drive the amount of timed work so ScaleFish can model how runtime grows with it.
+/// If the N-dependent state is built in <c>[SailfishGlobalSetup]</c> — which runs once per class and is
+/// cached/replayed across every variable set — every case measures the <em>first</em> N, the timing is
+/// flat across the variable, and ScaleFish fits a near-constant curve. The benchmark looks ~O(1) even
+/// though the code under test is not.
+///
+/// <para>
+/// This detector inspects an <em>already-computed</em> <see cref="ScaleFishModel"/> (no curve refitting)
+/// and decides whether the fit is effectively constant. It is intentionally a small pure function so the
+/// decision can be unit-tested directly, independent of the run/reporting plumbing.
+/// </para>
+///
+/// <para>
+/// Detection is a <em>hint</em>, never an error: genuinely constant-time code (hash lookups, fixed-size
+/// work, etc.) is perfectly legitimate. The reporting layer therefore phrases the result as a question.
+/// </para>
+/// </summary>
+public static class ConstantComplexityDetector
+{
+    /// <summary>
+    /// Default fraction by which the fitted curve must change across the measured X range before the
+    /// variable is considered to be meaningfully driving runtime. A fitted curve that varies by less
+    /// than 5% from its smallest to its largest measured X is treated as effectively flat (~O(1)).
+    /// </summary>
+    public const double DefaultRelativeSpanThreshold = 0.05;
+
+    /// <summary>
+    /// When the continuous power-log diagnostic is available, an exponent below this magnitude is treated
+    /// as "no real power-law growth" — corroborating a constant classification. (b ≈ 0 ⇒ x^b ≈ 1.)
+    /// </summary>
+    public const double DefaultPowerExponentThreshold = 0.10;
+
+    /// <summary>
+    /// Decides whether the supplied fit looks effectively constant (~O(1)).
+    ///
+    /// <para>
+    /// The primary, family-agnostic signal is the <em>relative span</em> of the fitted curve over the
+    /// observed X range: every built-in family evaluates to <c>scale·Basis(x) + bias</c>, so when the
+    /// measured timings are flat the fitted slope collapses toward zero and the curve barely moves between
+    /// the smallest and largest measured N. We compute how much the curve changes across that range
+    /// relative to its level; below <paramref name="relativeSpanThreshold"/> the variable is not
+    /// meaningfully reaching the timed work.
+    /// </para>
+    ///
+    /// <para>
+    /// To avoid false positives on data that clearly <em>does</em> scale, a near-flat curve is only flagged
+    /// when the classification is <em>not</em> statistically distinguishable
+    /// (<see cref="ScaleFishModel.IsDistinguishable"/> is false) — i.e. the per-variable-value timing
+    /// distributions cannot separate one growth family from another, which is exactly the signature of a
+    /// frozen variable. A confidently-distinguishable scaling fit (clear Linear, Quadratic, …) is never
+    /// flagged even if its measured span happens to be modest.
+    /// </para>
+    ///
+    /// <para>
+    /// When measurements are unavailable (e.g. a deserialised model with no raw points) the detector falls
+    /// back to the continuous power-log exponent: an indistinguishable fit whose power exponent
+    /// <c>b ≈ 0</c> is treated as constant. With neither measurements nor a usable power-log diagnostic the
+    /// detector conservatively returns false rather than guessing.
+    /// </para>
+    /// </summary>
+    /// <param name="model">The fit produced by the estimator. Must not be null.</param>
+    /// <param name="measurements">
+    /// The (X, Y) points the fit was computed from, used to bound the relative-span calculation to the
+    /// range the user actually measured. May be null/empty, in which case the power-log fallback is used.
+    /// </param>
+    /// <param name="relativeSpanThreshold">Override for <see cref="DefaultRelativeSpanThreshold"/>.</param>
+    /// <param name="powerExponentThreshold">Override for <see cref="DefaultPowerExponentThreshold"/>.</param>
+    public static bool IsLikelyConstant(
+        ScaleFishModel model,
+        IReadOnlyList<ComplexityMeasurement>? measurements,
+        double relativeSpanThreshold = DefaultRelativeSpanThreshold,
+        double powerExponentThreshold = DefaultPowerExponentThreshold)
+    {
+        if (model is null) throw new ArgumentNullException(nameof(model));
+
+        // A fit the data can confidently separate into a specific growth family is, by definition, not the
+        // ambiguous-flat signature we are looking for. Never second-guess a distinguishable classification.
+        if (model.IsDistinguishable) return false;
+
+        var function = model.ScaleFishModelFunction;
+        var fit = function?.FunctionParameters;
+
+        // Preferred signal: how much does the fitted curve move across the measured X range?
+        if (function is not null && fit is not null && TryGetXRange(measurements, out var xMin, out var xMax))
+        {
+            double yLow, yHigh;
+            try
+            {
+                yLow = function.Compute(fit.Bias, fit.Scale, xMin);
+                yHigh = function.Compute(fit.Bias, fit.Scale, xMax);
+            }
+            catch
+            {
+                // A family whose Compute throws/overflows on the observed range can't be reasoned about
+                // here; defer to the power-log fallback below.
+                return PowerLogSaysConstant(model, powerExponentThreshold);
+            }
+
+            if (double.IsFinite(yLow) && double.IsFinite(yHigh))
+            {
+                var denominator = Math.Max(Math.Max(Math.Abs(yLow), Math.Abs(yHigh)), double.Epsilon);
+                var relativeSpan = Math.Abs(yHigh - yLow) / denominator;
+                return relativeSpan < relativeSpanThreshold;
+            }
+        }
+
+        // Fallback when measurements/parameters are unavailable: lean on the continuous exponent.
+        return PowerLogSaysConstant(model, powerExponentThreshold);
+    }
+
+    private static bool PowerLogSaysConstant(ScaleFishModel model, double powerExponentThreshold)
+    {
+        var powerLog = model.PowerLog;
+        if (powerLog is null) return false;
+        if (!double.IsFinite(powerLog.B) || !double.IsFinite(powerLog.C)) return false;
+
+        // x^b·(log x)^c ≈ constant only when both exponents are negligible.
+        return Math.Abs(powerLog.B) < powerExponentThreshold
+               && Math.Abs(powerLog.C) < powerExponentThreshold;
+    }
+
+    private static bool TryGetXRange(IReadOnlyList<ComplexityMeasurement>? measurements, out double xMin, out double xMax)
+    {
+        xMin = 0;
+        xMax = 0;
+        if (measurements is null || measurements.Count == 0) return false;
+
+        var finiteXs = measurements
+            .Select(m => m.X)
+            .Where(x => double.IsFinite(x))
+            .ToList();
+        if (finiteXs.Count < 2) return false;
+
+        xMin = finiteXs.Min();
+        xMax = finiteXs.Max();
+        // A degenerate range (all X equal) tells us nothing about growth.
+        return xMax > xMin;
+    }
+
+    /// <summary>
+    /// Builds the Warning-level hint shown for a variable whose fit looks ~O(1). Phrased as a question so a
+    /// legitimately constant benchmark reads as a prompt to double-check, not a failure. Pure/string-only
+    /// so the exact wording can be asserted in tests.
+    /// </summary>
+    public static string BuildWarningMessage(string variableName, ScaleFishModel model)
+    {
+        var oName = model.ScaleFishModelFunction?.OName ?? "O(1)";
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "ScaleFish: variable '{0}' shows ~O(1) (best fit {1}) — it may not be reaching the timed work. "
+            + "A common cause is building {0}-dependent state in [SailfishGlobalSetup], which runs once and is "
+            + "cached/replayed across all variable sets; build it in [SailfishMethodSetup] instead. "
+            + "If the work really is constant in {0}, you can ignore this.",
+            variableName,
+            oName);
+    }
+}

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
@@ -10,6 +10,7 @@ using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Contracts.Public.Requests;
 using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+using Sailfish.Logging;
 using Sailfish.Presentation;
 using Sailfish.Presentation.Console;
 
@@ -24,6 +25,7 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
 {
     private readonly IComplexityComputer _complexityComputer;
     private readonly IConsoleWriter _consoleWriter;
+    private readonly ILogger _logger;
     private readonly IMarkdownTableConverter _markdownTableConverter;
     private readonly IMediator _mediator;
     private readonly IRunSettings _runSettings;
@@ -32,10 +34,12 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         IRunSettings runSettings,
         IComplexityComputer complexityComputer,
         IMarkdownTableConverter markdownTableConverter,
-        IConsoleWriter consoleWriter)
+        IConsoleWriter consoleWriter,
+        ILogger logger)
     {
         _complexityComputer = complexityComputer;
         _consoleWriter = consoleWriter;
+        _logger = logger;
         _markdownTableConverter = markdownTableConverter;
         _mediator = mediator;
         _runSettings = runSettings;
@@ -58,6 +62,19 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         {
             var analysisResult = _complexityComputer.AnalyzeComplexityWithMeasurements(executionSummaries);
             var complexityResults = analysisResult.Classes.ToList();
+
+            // Runtime backstop for the "frozen scaling variable" trap: warn (never fail) when a
+            // scaleFish variable's fit looks ~O(1). Complements the static SF1016 analyzer by also
+            // catching indirection that static analysis can't see. Wrapped so a hint never breaks output.
+            try
+            {
+                WarnOnConstantScalingVariables(complexityResults, analysisResult.MeasurementsByPropertyKey);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Debug, "ScaleFish ~O(1) backstop skipped: {0}", ex.Message);
+            }
+
             var complexityMarkdown = _markdownTableConverter.ConvertScaleFishResultToMarkdown(complexityResults);
 
             // Optional trend tracking — persist a snapshot of every fit and diff against the most-recent
@@ -112,6 +129,33 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         catch (Exception ex)
         {
             _consoleWriter.WriteString(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Emits a Warning-level hint for every scaleFish variable whose already-computed fit looks ~O(1).
+    /// Phrased as a question — genuinely constant work is legitimate, so this never fails the run. Reuses
+    /// the fit and the measurement vectors already on hand (no curve refitting).
+    /// </summary>
+    private void WarnOnConstantScalingVariables(
+        IReadOnlyList<ScalefishClassModel> complexityResults,
+        IReadOnlyDictionary<string, ComplexityMeasurement[]> measurementsByKey)
+    {
+        foreach (var classModel in complexityResults)
+        foreach (var methodModel in classModel.ScaleFishMethodModels)
+        foreach (var propModel in methodModel.ScaleFishPropertyModels)
+        {
+            var model = propModel.ScaleFishModel;
+            if (model?.ScaleFishModelFunction is null) continue;
+
+            // PropertyName is the "MethodName.PropertyName" key the computer used to store measurements.
+            measurementsByKey.TryGetValue(propModel.PropertyName, out var measurements);
+
+            if (!ConstantComplexityDetector.IsLikelyConstant(model, measurements)) continue;
+
+            // Report the bare variable name (drop the "Method." prefix) so the message reads naturally.
+            var variableName = propModel.PropertyName.Split('.').Last();
+            _logger.Log(LogLevel.Warning, "{0}", ConstantComplexityDetector.BuildWarningMessage(variableName, model));
         }
     }
 

--- a/source/Tests.Library/Analysis/ScaleFish/ConstantComplexityDetectorTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ConstantComplexityDetectorTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Sailfish.Analysis.ScaleFish.CurveFitting;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+/// <summary>
+/// Unit tests for <see cref="ConstantComplexityDetector"/> — the runtime backstop that flags a scaleFish
+/// variable whose fit looks ~O(1) (the classic "N-dependent state built in [SailfishGlobalSetup] and
+/// frozen across all variable sets" trap). The decision is exercised against real
+/// <see cref="ComplexityEstimator"/> fits so the test proves end-to-end behaviour, plus a few constructed
+/// models to pin the guards.
+/// </summary>
+public class ConstantComplexityDetectorTests
+{
+    /// <summary>
+    /// Flat timings across the whole variable range — the signature of a frozen variable — must be flagged
+    /// as ~O(1). Mirrors the noisy-fit style used elsewhere in the ScaleFish suite.
+    /// </summary>
+    [Fact]
+    public void FlatTimings_AcrossVariableRange_AreFlaggedConstant()
+    {
+        var rng = new Random(1234);
+        // Every X measures essentially the same time (the GlobalSetup-frozen-state case).
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            trueFunction: _ => 500.0,
+            xs: ScaleFishTestHelpers.LogSpacedX(4, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.03,
+            rng);
+
+        var model = new ComplexityEstimator().EstimateComplexity(measurements);
+        model.ShouldNotBeNull();
+
+        ConstantComplexityDetector
+            .IsLikelyConstant(model, measurements)
+            .ShouldBeTrue("flat timings across the variable range should read as ~O(1)");
+    }
+
+    /// <summary>
+    /// A clearly-linear benchmark must NOT be flagged — the variable genuinely drives runtime.
+    /// </summary>
+    [Fact]
+    public void LinearScaling_IsNotFlaggedConstant()
+    {
+        var rng = new Random(1234);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            trueFunction: x => 10.0 * x + 50.0,
+            xs: ScaleFishTestHelpers.LogSpacedX(4, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.05,
+            rng);
+
+        var model = new ComplexityEstimator().EstimateComplexity(measurements);
+        model.ShouldNotBeNull();
+        model.ScaleFishModelFunction.Name.ShouldBe(nameof(Linear));
+
+        ConstantComplexityDetector
+            .IsLikelyConstant(model, measurements)
+            .ShouldBeFalse("a clearly-linear fit must not be mistaken for ~O(1)");
+    }
+
+    /// <summary>
+    /// A clearly-quadratic benchmark must NOT be flagged either.
+    /// </summary>
+    [Fact]
+    public void QuadraticScaling_IsNotFlaggedConstant()
+    {
+        var rng = new Random(99);
+        var quadratic = new Quadratic();
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            trueFunction: x => quadratic.Compute(0, 1, x),
+            xs: ScaleFishTestHelpers.LogSpacedX(4, 256, 6),
+            sampleSize: 30,
+            relativeNoise: 0.05,
+            rng);
+
+        var model = new ComplexityEstimator().EstimateComplexity(measurements);
+        model.ShouldNotBeNull();
+
+        ConstantComplexityDetector
+            .IsLikelyConstant(model, measurements)
+            .ShouldBeFalse("a clearly-quadratic fit must not be mistaken for ~O(1)");
+    }
+
+    /// <summary>
+    /// The guard: a fit the data can confidently separate into a growth family is never flagged, even if
+    /// its measured span over the supplied range happens to be small. Distinguishability wins.
+    /// </summary>
+    [Fact]
+    public void DistinguishableFit_IsNeverFlagged_EvenWithFlatLookingRange()
+    {
+        var linear = new Linear { FunctionParameters = new FittedCurve(scale: 1.0, bias: 1_000_000.0) };
+        var next = new Quadratic { FunctionParameters = new FittedCurve(scale: 1.0, bias: 0.0) };
+        // Distinguishable = true ⇒ detector must short-circuit to false regardless of span.
+        var model = new ScaleFishModel(
+            linear, goodnessOfFit: 0.999,
+            next, nextClosestGoodnessOfFit: 0.5,
+            bestAicc: 1.0, nextBestAicc: 50.0, akaikeWeight: 0.99,
+            isDistinguishable: true, sampleSize: 6, powerLog: null);
+
+        // Even over a range where scale*x is tiny next to the bias, distinguishability must win.
+        var measurements = new List<ComplexityMeasurement>
+        {
+            new(1, 1_000_001), new(2, 1_000_002)
+        };
+
+        ConstantComplexityDetector.IsLikelyConstant(model, measurements).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Indistinguishable + near-zero slope over the measured range ⇒ flagged. Pins the relative-span path
+    /// with a hand-built model so the threshold behaviour is explicit.
+    /// </summary>
+    [Fact]
+    public void Indistinguishable_NearZeroSlope_IsFlagged()
+    {
+        // f(x) = 0.0001*x + 500 ⇒ over [4, 256] the curve moves ~0.025 on a level of ~500 ⇒ <5%.
+        var linear = new Linear { FunctionParameters = new FittedCurve(scale: 0.0001, bias: 500.0) };
+        var next = new NLogN { FunctionParameters = new FittedCurve(scale: 0.0001, bias: 500.0) };
+        var model = new ScaleFishModel(
+            linear, goodnessOfFit: 0.2,
+            next, nextClosestGoodnessOfFit: 0.2,
+            bestAicc: 10.0, nextBestAicc: 10.5, akaikeWeight: 0.4,
+            isDistinguishable: false, sampleSize: 6, powerLog: null);
+
+        var measurements = new List<ComplexityMeasurement> { new(4, 500), new(256, 500) };
+
+        ConstantComplexityDetector.IsLikelyConstant(model, measurements).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Indistinguishable but with a real slope over the measured range ⇒ NOT flagged. Confirms the span
+    /// threshold rejects genuinely-moving curves even when the family is ambiguous (e.g. Linear vs NLogN).
+    /// </summary>
+    [Fact]
+    public void Indistinguishable_WithRealSlope_IsNotFlagged()
+    {
+        // f(x) = 10*x + 50 ⇒ over [4, 256] the curve moves from 90 to 2610 ⇒ ~97% span.
+        var linear = new Linear { FunctionParameters = new FittedCurve(scale: 10.0, bias: 50.0) };
+        var next = new NLogN { FunctionParameters = new FittedCurve(scale: 10.0, bias: 50.0) };
+        var model = new ScaleFishModel(
+            linear, goodnessOfFit: 0.98,
+            next, nextClosestGoodnessOfFit: 0.97,
+            bestAicc: 10.0, nextBestAicc: 10.5, akaikeWeight: 0.4,
+            isDistinguishable: false, sampleSize: 6, powerLog: null);
+
+        var measurements = new List<ComplexityMeasurement> { new(4, 90), new(256, 2610) };
+
+        ConstantComplexityDetector.IsLikelyConstant(model, measurements).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Fallback path: with no measurements available, an indistinguishable fit whose continuous power-log
+    /// exponents are ~0 is treated as constant.
+    /// </summary>
+    [Fact]
+    public void NoMeasurements_FlatPowerLog_IsFlagged()
+    {
+        var linear = new Linear { FunctionParameters = new FittedCurve(scale: 0.0, bias: 500.0) };
+        var next = new NLogN { FunctionParameters = new FittedCurve(scale: 0.0, bias: 500.0) };
+        var powerLog = new PowerLogResult(a: 1.0, b: 0.01, c: 0.01, d: 500.0, rSquared: 0.1);
+        var model = new ScaleFishModel(
+            linear, goodnessOfFit: 0.2,
+            next, nextClosestGoodnessOfFit: 0.2,
+            bestAicc: 10.0, nextBestAicc: 10.4, akaikeWeight: 0.4,
+            isDistinguishable: false, sampleSize: 6, powerLog: powerLog);
+
+        ConstantComplexityDetector.IsLikelyConstant(model, measurements: null).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Fallback path: with no measurements and a power-log exponent that indicates real growth (b ≈ 1),
+    /// the fit is not flagged.
+    /// </summary>
+    [Fact]
+    public void NoMeasurements_GrowingPowerLog_IsNotFlagged()
+    {
+        var linear = new Linear { FunctionParameters = new FittedCurve(scale: 10.0, bias: 50.0) };
+        var next = new NLogN { FunctionParameters = new FittedCurve(scale: 10.0, bias: 50.0) };
+        var powerLog = new PowerLogResult(a: 10.0, b: 1.0, c: 0.0, d: 50.0, rSquared: 0.98);
+        var model = new ScaleFishModel(
+            linear, goodnessOfFit: 0.98,
+            next, nextClosestGoodnessOfFit: 0.97,
+            bestAicc: 10.0, nextBestAicc: 10.4, akaikeWeight: 0.4,
+            isDistinguishable: false, sampleSize: 6, powerLog: powerLog);
+
+        ConstantComplexityDetector.IsLikelyConstant(model, measurements: null).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// With neither measurements nor a power-log diagnostic, the detector is conservative and returns false
+    /// rather than guessing — avoids spurious warnings on deserialised/legacy models.
+    /// </summary>
+    [Fact]
+    public void NoMeasurements_NoPowerLog_IsConservativelyFalse()
+    {
+        var linear = new Linear { FunctionParameters = new FittedCurve(scale: 0.0, bias: 500.0) };
+        var next = new NLogN { FunctionParameters = new FittedCurve(scale: 0.0, bias: 500.0) };
+        var model = new ScaleFishModel(
+            linear, goodnessOfFit: 0.2,
+            next, nextClosestGoodnessOfFit: 0.2,
+            bestAicc: 10.0, nextBestAicc: 10.4, akaikeWeight: 0.4,
+            isDistinguishable: false, sampleSize: 6, powerLog: null);
+
+        ConstantComplexityDetector.IsLikelyConstant(model, measurements: null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NullModel_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ConstantComplexityDetector.IsLikelyConstant(null!, measurements: null));
+    }
+
+    /// <summary>
+    /// The hint must name the offending variable and point at the GlobalSetup/MethodSetup cause so the user
+    /// can act on it. Phrased as a question/hint, never an assertion of error.
+    /// </summary>
+    [Fact]
+    public void BuildWarningMessage_NamesVariable_AndPointsAtSetupCause()
+    {
+        var fn = new Linear { FunctionParameters = new FittedCurve(scale: 0.0, bias: 500.0) };
+        var model = ScaleFishModelBuilderModel(fn);
+
+        var message = ConstantComplexityDetector.BuildWarningMessage("N", model);
+
+        message.ShouldContain("'N'");
+        message.ShouldContain("~O(1)");
+        message.ShouldContain("[SailfishGlobalSetup]");
+        message.ShouldContain("[SailfishMethodSetup]");
+    }
+
+    private static ScaleFishModel ScaleFishModelBuilderModel(ScaleFishModelFunction primary)
+    {
+        return new ScaleFishModel(
+            primary, goodnessOfFit: 0.2,
+            new Quadratic { FunctionParameters = new FittedCurve(scale: 0.0, bias: 500.0) },
+            nextClosestGoodnessOfFit: 0.2,
+            bestAicc: 10.0, nextBestAicc: 10.4, akaikeWeight: 0.4,
+            isDistinguishable: false, sampleSize: 6, powerLog: null);
+    }
+}


### PR DESCRIPTION
## Why

ScaleFish models how a benchmark's runtime grows with a `[SailfishVariable(scaleFish: true)]` property. There is a silent trap: `[SailfishGlobalSetup]` runs **exactly once per class**, and the state it builds is captured and replayed onto every test case, while a `[SailfishVariable]` property is re-injected per case.

So if you derive N-dependent state from a scaling variable inside `[SailfishGlobalSetup]`, that state is **frozen at the first variable value** for every case. Every case then measures the same input size, the per-variable timings are flat, and ScaleFish fits a near-constant curve — the benchmark reports ~O(1) even though the code under test is not. This is easy to ship without noticing.

PR #261 adds a static Roslyn analyzer (`SF1016`) that flags the *direct* case (reading a `SailfishVariable` property in `GlobalSetup`). **This PR adds a complementary runtime backstop** that also catches indirection static analysis can't see — N-dependent state built through helper methods, factories, dead-code-eliminated paths, etc. If the work genuinely became constant at runtime, the fit shows it, and we ask the question regardless of how the freezing happened.

## What

After ScaleFish computes its complexity fit, `ScaleFish.Analyze` now runs a backstop pass over the already-computed models (it does **not** recompute any curve fitting) and, for any scaleFish variable whose fit looks effectively constant, emits a **Warning-level hint phrased as a question**:

> ScaleFish: variable 'N' shows ~O(1) (best fit O(n)) — it may not be reaching the timed work. A common cause is building N-dependent state in `[SailfishGlobalSetup]`, which runs once and is cached/replayed across all variable sets; build it in `[SailfishMethodSetup]` instead. If the work really is constant in N, you can ignore this.

- **Warning-level only; never fails the run.** Genuinely constant-time code (hash lookups, fixed-size work) is legitimate — that is exactly why it is a hint, not an assertion.
- Emitted via the codebase's idiomatic `ILogger` at `LogLevel.Warning` (same mechanism SailDiff and the comparison handlers use for warnings). `ILogger` is injected into `ScaleFish` through the existing DI registration.
- The whole pass is wrapped in try/catch so a hint can never break the headline analysis output.
- Only scaleFish variables can reach this code at all — the observation compiler already filters to `IsSailfishComplexityVariable()` properties — so the warning is naturally scoped to `scaleFish: true`.

## How ~O(1) is detected

There is no explicit `Constant`/`O(1)` family in `ComplexityFunctionRegistry` (the built-ins are Linear, NLogN, Quadratic, Cubic, LogLinear, Exponential, Factorial, SqrtN). So ~O(1) is detected from the fit itself, in a small **pure, unit-testable** method — `ConstantComplexityDetector.IsLikelyConstant(model, measurements)`:

1. **Primary signal — relative span of the fitted curve over the measured X range.** Every built-in family evaluates to `scale·Basis(x) + bias`, so when the measured timings are flat the fitted slope collapses toward zero and the curve barely moves between the smallest and largest measured N. The detector computes `|f(xMax) − f(xMin)| / max(|f(xMax)|, |f(xMin)|)`; below 5% the variable is treated as not meaningfully reaching the timed work. This is magnitude-aware and family-agnostic. The measured X range comes from the same `MethodName.PropertyName`-keyed measurement vectors the HTML report already joins against.
2. **Guard against false positives — `IsDistinguishable`.** A near-flat curve is only flagged when the classification is *not* statistically distinguishable (`ScaleFishModel.IsDistinguishable == false`), i.e. the per-variable-value timing distributions can't separate one growth family from another — the precise signature of a frozen variable. A confidently-distinguishable scaling fit (clear Linear/Quadratic/…) is never flagged, even if its measured span happens to be modest.
3. **Fallback when measurements are unavailable** (e.g. a deserialised model with no raw points): the continuous power-log diagnostic. An indistinguishable fit whose exponents `b, c ≈ 0` (so `x^b·(log x)^c ≈ 1`) is treated as constant. With neither measurements nor a usable power-log diagnostic the detector conservatively returns `false` rather than guessing.

## Tests

`Tests.Library/Analysis/ScaleFish/ConstantComplexityDetectorTests.cs` (11 tests, mirroring the existing ScaleFish suite's xUnit + Shouldly + `ScaleFishTestHelpers` style):

- A real ~O(1) fit (flat noisy timings across the variable range via `ComplexityEstimator`) → flagged constant.
- A clearly-linear fit and a clearly-quadratic fit → not flagged.
- The `IsDistinguishable` guard short-circuits to `false` even over a flat-looking range.
- The relative-span threshold both ways (near-zero slope → flagged; real slope under an ambiguous family → not flagged).
- The power-log fallback both ways (flat exponents → flagged; growing exponent → not flagged) and the conservative no-signal case.
- `null` model throws; `BuildWarningMessage` names the variable and points at the `[SailfishGlobalSetup]`/`[SailfishMethodSetup]` cause.

All 1489 `Tests.Library` tests pass on net9.0; `Sailfish` and `Tests.Library` build clean across net9.0 and net10.0.

## Note

A small throwaway probe test was used during development to confirm the empirical fit behaviour of flat data; it is not part of this change. The shipped detector logic is validated directly by the real-fit unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Related PRs

Part of a small cluster addressing the **variable-dependent-state-in-`[SailfishGlobalSetup]`** footgun and adjacent analyzer correctness. All three are independent — branched off `main` with non-overlapping files — so they merge cleanly in any order.

- **#261 — SF1016 static analyzer + code fix.** Flags reading a `[SailfishVariable]` inside a once-per-class hook and offers to move it to `[SailfishMethodSetup]`.
- **#263 — ScaleFish ~O(1) runtime backstop _(this PR)_.** Complements the SF1016 analyzer at runtime, catching cases static analysis can't see (helper-method indirection, DCE).
- **#262 — attribute-less GlobalSetup detection fix.** Fixes a latent false-positive in the existing SF1013–1015 / SF7000 GlobalSetup analyzers, discovered while building SF1016.
