### PR TITLE
Report class-activation/fixture failures as Failed in VSTest adapter

### DIFF
--- a/source/Sailfish.TestAdapter/Handlers/TestCaseEvents/TestCaseExceptionNotificationHandler.cs
+++ b/source/Sailfish.TestAdapter/Handlers/TestCaseEvents/TestCaseExceptionNotificationHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -27,10 +29,13 @@ internal class TestCaseExceptionNotificationHandler : INotificationHandler<TestC
         _logger.Log(LogLevel.Error, notification.Exception ?? new TestAdapterException("Undefined Exception"), "Encountered exception during test case execution");
         if (notification.TestInstanceContainer is null)
         {
-            foreach (var testCase in notification.TestCaseGroup)
+            // Whole-class activation/enumeration failure: the test instance was never built
+            // (e.g. the constructor threw, an ISailfishFixture<T> failed to activate, or a
+            // constructor dependency couldn't be resolved). Fail every test case in the group.
+            foreach (var testCase in notification.TestCaseGroup.Cast<TestCase>())
             {
                 _testFrameworkWriter.RecordEnd(testCase, TestOutcome.Failed);
-                _testFrameworkWriter.RecordResult(new TestResult(testCase));
+                _testFrameworkWriter.RecordResult(CreateFailedResult(testCase, notification.Exception));
             }
         }
         else
@@ -39,7 +44,31 @@ internal class TestCaseExceptionNotificationHandler : INotificationHandler<TestC
                 .TestInstanceContainer
                 .GetTestCaseFromTestCaseGroupMatchingCurrentContainer(notification.TestCaseGroup.Cast<TestCase>());
             _testFrameworkWriter.RecordEnd(currentTestCase, TestOutcome.Failed);
-            _testFrameworkWriter.RecordResult(new TestResult(currentTestCase));
+            _testFrameworkWriter.RecordResult(CreateFailedResult(currentTestCase, notification.Exception));
         }
+    }
+
+    // The TestResult.Outcome defaults to TestOutcome.None; if we record it as-is, VSTest/Rider
+    // reports the cryptic "Outcome value None is not understood" (rendered as Inconclusive)
+    // instead of a clean failure — the RecordEnd outcome above is not what Rider keys off.
+    // We must set Outcome = Failed on the TestResult itself and attach the (flattened) exception
+    // so the user sees the real reason. This mirrors FrameworkTestCaseEndNotificationHandler.ConfigureTestResult.
+    private static TestResult CreateFailedResult(TestCase testCase, Exception? exception) => new(testCase)
+    {
+        Outcome = TestOutcome.Failed,
+        DisplayName = testCase.DisplayName,
+        ErrorMessage = FlattenMessage(exception),
+        ErrorStackTrace = exception?.ToString() // ToString() already includes the inner-exception chain + stacks
+    };
+
+    // The actionable cause is usually an inner exception: TypeActivator wraps the original throw as
+    // TestClassInstantiationException("Failed to resolve constructor dependencies..."), so flatten the
+    // whole chain rather than surfacing only the outermost (uninformative) message.
+    private static string FlattenMessage(Exception? exception)
+    {
+        if (exception is null) return "Test case failed before execution (no exception was captured).";
+        var messages = new List<string>();
+        for (var e = exception; e is not null; e = e.InnerException) messages.Add(e.Message);
+        return string.Join("\n ---> ", messages);
     }
 }

--- a/source/Tests.TestAdapter/TestAdapterHandlerTests.cs
+++ b/source/Tests.TestAdapter/TestAdapterHandlerTests.cs
@@ -99,6 +99,61 @@ public class TestAdapterHandlerTests
         recordResultArgs.Length.ShouldBe(1);
         var result = recordResultArgs.First() as TestResult;
         result.ShouldNotBeNull();
+        // The recorded TestResult must itself carry Outcome = Failed — recording it with the
+        // default TestOutcome.None makes Rider report "Outcome value None is not understood".
+        result.Outcome.ShouldBe(TestOutcome.Failed);
+    }
+
+    [Fact]
+    public async Task TestCaseExceptionNotificationHandler_WithNullInstanceContainer_FailsEveryCaseWithFlattenedException()
+    {
+        // Whole-class activation failure: the test instance was never built (constructor threw,
+        // a fixture failed to activate, or a constructor dependency couldn't be resolved), so the
+        // engine publishes a notification with TestInstanceContainer == null and the wrapped exception.
+        // Every test case in the group must be reported as Failed (not TestOutcome.None) with the
+        // real, innermost reason flattened into ErrorMessage.
+        var frameworkWriter = Substitute.For<ITestFrameworkWriter>();
+        var logger = Substitute.For<ILogger>();
+
+        var testCases = new[]
+        {
+            new TestCase(Some.RandomString(), TestExecutor.ExecutorUri, Some.RandomString()),
+            new TestCase(Some.RandomString(), TestExecutor.ExecutorUri, Some.RandomString()),
+            new TestCase(Some.RandomString(), TestExecutor.ExecutorUri, Some.RandomString())
+        };
+
+        // Mirror TypeActivator: the actionable cause ("Cannot reach the database...") is the
+        // InnerException of a TestClassInstantiationException-style outer message.
+        const string innerMessage = "Cannot reach the database — is it running?";
+        const string outerMessage = "Failed to resolve constructor dependencies for test class 'MyBenchmarks'.";
+        var exception = new InvalidOperationException(outerMessage, new InvalidOperationException(innerMessage));
+
+        var notification = new TestCaseExceptionNotification(null, testCases, exception);
+        var handler = new TestCaseExceptionNotificationHandler(frameworkWriter, logger);
+
+        await handler.Handle(notification, CancellationToken.None);
+
+        foreach (var testCase in testCases)
+        {
+            frameworkWriter.Received(1).RecordEnd(testCase, TestOutcome.Failed);
+        }
+
+        var recordedResults = frameworkWriter.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == "RecordResult")
+            .Select(call => call.GetArguments().First() as TestResult)
+            .ToList();
+
+        recordedResults.Count.ShouldBe(testCases.Length);
+        foreach (var result in recordedResults)
+        {
+            result.ShouldNotBeNull();
+            result.Outcome.ShouldBe(TestOutcome.Failed);
+            // The chain must be flattened so the user sees both the wrapper and the real cause.
+            result.ErrorMessage.ShouldNotBeNull();
+            result.ErrorMessage.ShouldContain(outerMessage);
+            result.ErrorMessage.ShouldContain(innerMessage);
+            result.ErrorStackTrace.ShouldNotBeNull();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

When a `[Sailfish]` test class throws **before any `SailfishMethod` runs** — its constructor throws, an injected `ISailfishFixture<T>` fails in its constructor, or a constructor dependency can't be resolved — the failure was reported to the IDE as the cryptic **"Outcome value None is not understood"** (Rider renders this as *Inconclusive*). Under `dotnet test` the case was logged `[FATAL]: Error resolving test from <Class>` and then silently dropped. The user never saw *why* it failed.

This is the same `TestOutcome.None` bug class already fixed in the queue/comparison processors (see the regression-test comments in `MethodComparisonProcessorTests` / `FrameworkPublishingProcessorTests` and `MethodComparisonBatchProcessor`). The class-activation/enumeration path was the one spot that was missed.

## Root cause

In `TestCaseExceptionNotificationHandler.Handle`, both branches recorded the result with `new TestResult(testCase)`, which leaves `.Outcome` at its default `TestOutcome.None`. `TestFrameworkWriter` is a pure pass-through to `IFrameworkHandle.RecordResult`, so the IDE received `Outcome = None` — the preceding `RecordEnd(testCase, TestOutcome.Failed)` is not what Rider keys off. The `notification.Exception` was also discarded, so `ErrorMessage`/`ErrorStackTrace` were never set.

On activation failure the engine publishes the notification with `TestInstanceContainer == null` (the null branch), and `TypeActivator` wraps the original throw as `TestClassInstantiationException("Failed to resolve constructor dependencies…")` — so the real cause (e.g. the user's fixture "cannot reach the database" message) is the **InnerException**.

## Fix

Both branches of `Handle` now build the `TestResult` via a private `CreateFailedResult` helper:
- `Outcome = TestOutcome.Failed` set **on the `TestResult` itself**.
- `ErrorMessage` = the exception chain **flattened** (walks `InnerException`, joined with `\n ---> `) so the innermost real reason is surfaced, not just the uninformative wrapper.
- `ErrorStackTrace = exception.ToString()` (already includes the inner-exception chain + stacks).

This mirrors the healthy path in `FrameworkTestCaseEndNotificationHandler.ConfigureTestResult`. Existing error-level logging is preserved. The change is confined to the adapter handler — no changes to public contracts, the notification record, the engine, or `TypeActivator`.

> Note: used `"\n"` literals rather than `Environment.NewLine` because the adapter is compiled under analyzer rules that ban `System.Environment` (RS1035); this matches the existing convention in `FrameworkTestCaseEndNotification`.

## Before / after

| | Before | After |
|---|---|---|
| **Rider** | "Inconclusive — Outcome value None is not understood" | **Failed**, with the innermost reason in the message |
| **`dotnet test`** | `[FATAL]: Error resolving test…`, then silently dropped | Clean **Failed** result carrying the flattened message + stack |

## Tests

- Tightened `TestCaseExceptionNotificationHandlerTests` to assert the recorded `TestResult.Outcome == TestOutcome.Failed`.
- Added `TestCaseExceptionNotificationHandler_WithNullInstanceContainer_FailsEveryCaseWithFlattenedException`: builds a notification with `TestInstanceContainer = null`, a 3-case group, and a nested exception; asserts every case is recorded `Failed` with both the outer **and** inner messages present (proving the chain is flattened) and a non-null `ErrorStackTrace`.

Both tests **fail without the handler change** (`should be TestOutcome.Failed but was TestOutcome.None`) and **pass with it**.

## Verification

- `dotnet test source/Tests.TestAdapter/Tests.TestAdapter.csproj -f net10.0` — **557/557 passed**
- `dotnet test source/Tests.TestAdapter/Tests.TestAdapter.csproj -f net9.0` — **557/557 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test case exceptions are now properly recorded and reported as failed results, improving visibility of test failures.
  * Error messages and full exception stack traces are now captured and displayed, providing better diagnostic information for debugging test issues.
  * Test outcome reporting is now consistent across all test execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->