### PR TITLE
Distribution plots for readouts (histogram default, box plot optional)

### DIFF
--- a/source/PerformanceTests/ExamplePerformanceTests/MinimalTestExample.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/MinimalTestExample.cs
@@ -5,7 +5,7 @@ namespace PerformanceTests.ExamplePerformanceTests;
 
 [WriteToCsv]
 [WriteToMarkdown]
-[Sailfish(SampleSize = 3, DisableOverheadEstimation = true, NumWarmupIterations = 0)]
+[Sailfish(SampleSize = 300, DisableOverheadEstimation = true, NumWarmupIterations = 0)]
 public class MinimalTestExample
 {
     [SailfishMethod(Order = 3)]

--- a/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailfishConsoleWindowFormatter.cs
+++ b/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailfishConsoleWindowFormatter.cs
@@ -138,6 +138,31 @@ internal class SailfishConsoleWindowFormatter : ISailfishConsoleWindowFormatter
             ["Stat", $" Time ({unitLabel})"],
             x => x.Name, x => x.Item));
 
+        // distribution plot (histogram) — sits directly under Descriptive Statistics; the raw outlier
+        // and distribution dumps follow below.
+        if ((_runSettings?.EnableDistributionPlots ?? true) && hasClean)
+        {
+            var series = new[]
+            {
+                new DistributionPlotRenderer.Series(
+                    string.Empty,
+                    results.DataWithOutliersRemoved,
+                    results.Mean,
+                    results.Median,
+                    results.UpperOutliers.Concat(results.LowerOutliers).ToArray())
+            };
+            var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+            var plot = DistributionPlotRenderer.Render(series, unit, style);
+            if (!string.IsNullOrEmpty(plot))
+            {
+                stringBuilder.AppendLine();
+                const string textLinePlot = "Distribution Plot";
+                stringBuilder.AppendLine(textLinePlot);
+                stringBuilder.AppendLine(new string('-', textLinePlot.Length));
+                stringBuilder.Append(plot);
+            }
+        }
+
         // outliers section
         stringBuilder.AppendLine();
         var textLineOutliers = $"Outliers Removed ({testCaseResult.PerformanceRunResult.TotalNumOutliers})";
@@ -156,31 +181,12 @@ internal class SailfishConsoleWindowFormatter : ISailfishConsoleWindowFormatter
                                          testCaseResult.PerformanceRunResult.LowerOutliers
                                              .Select(x => DurationFormatter.Format(x, unit, DecimalsInUnit))));
 
-        // distribution
+        // distribution (raw cleaned samples)
         var textLineDist = $"Distribution ({unitLabel})";
         stringBuilder.AppendLine();
         stringBuilder.AppendLine(textLineDist);
         stringBuilder.AppendLine(new string('-', textLineDist.Length));
         stringBuilder.AppendLine(string.Join(", ", results.DataWithOutliersRemoved.Select(x => DurationFormatter.Format(x, unit, DecimalsInUnit))));
-
-        // box-and-whisker plot of the cleaned distribution (reuses the unit picked above)
-        if ((_runSettings?.EnableDistributionPlots ?? true) && hasClean)
-        {
-            var series = BoxPlotData.FromSamples(
-                string.Empty,
-                results.DataWithOutliersRemoved,
-                results.Mean,
-                results.UpperOutliers.Concat(results.LowerOutliers).ToArray());
-            var plot = AsciiBoxPlotRenderer.Render(new[] { series }, unit);
-            if (!string.IsNullOrEmpty(plot))
-            {
-                stringBuilder.AppendLine();
-                const string textLinePlot = "Distribution Plot";
-                stringBuilder.AppendLine(textLinePlot);
-                stringBuilder.AppendLine(new string('-', textLinePlot.Length));
-                stringBuilder.Append(plot);
-            }
-        }
 
         // validation warnings (if any)
         if (results.Validation?.HasWarnings == true)

--- a/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailfishConsoleWindowFormatter.cs
+++ b/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailfishConsoleWindowFormatter.cs
@@ -19,10 +19,12 @@ internal interface ISailfishConsoleWindowFormatter
 internal class SailfishConsoleWindowFormatter : ISailfishConsoleWindowFormatter
 {
     private readonly ILogger _logger;
+    private readonly IRunSettings? _runSettings;
 
-    public SailfishConsoleWindowFormatter(ILogger logger)
+    public SailfishConsoleWindowFormatter(ILogger logger, IRunSettings? runSettings = null)
     {
         _logger = logger;
+        _runSettings = runSettings;
     }
 
     // Decimals to show within the auto-selected time unit (e.g. "1.100 µs").
@@ -59,7 +61,7 @@ internal class SailfishConsoleWindowFormatter : ISailfishConsoleWindowFormatter
         return consoleOutputString;
     }
 
-    private static string FormOutputTable(ICompiledTestCaseResult testCaseResult)
+    private string FormOutputTable(ICompiledTestCaseResult testCaseResult)
     {
         if (testCaseResult.PerformanceRunResult == null || testCaseResult.PerformanceRunResult.SampleSize == 0)
             return string.Empty;
@@ -160,6 +162,25 @@ internal class SailfishConsoleWindowFormatter : ISailfishConsoleWindowFormatter
         stringBuilder.AppendLine(textLineDist);
         stringBuilder.AppendLine(new string('-', textLineDist.Length));
         stringBuilder.AppendLine(string.Join(", ", results.DataWithOutliersRemoved.Select(x => DurationFormatter.Format(x, unit, DecimalsInUnit))));
+
+        // box-and-whisker plot of the cleaned distribution (reuses the unit picked above)
+        if ((_runSettings?.EnableDistributionPlots ?? true) && hasClean)
+        {
+            var series = BoxPlotData.FromSamples(
+                string.Empty,
+                results.DataWithOutliersRemoved,
+                results.Mean,
+                results.UpperOutliers.Concat(results.LowerOutliers).ToArray());
+            var plot = AsciiBoxPlotRenderer.Render(new[] { series }, unit);
+            if (!string.IsNullOrEmpty(plot))
+            {
+                stringBuilder.AppendLine();
+                const string textLinePlot = "Distribution Plot";
+                stringBuilder.AppendLine(textLinePlot);
+                stringBuilder.AppendLine(new string('-', textLinePlot.Length));
+                stringBuilder.Append(plot);
+            }
+        }
 
         // validation warnings (if any)
         if (results.Validation?.HasWarnings == true)

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -39,6 +39,10 @@ public static class AdapterRunSettingsLoader
         if (parsedSettings.GlobalSettings.EnableDistributionPlots is not null)
             runSettingsBuilder = runSettingsBuilder.WithDistributionPlots(parsedSettings.GlobalSettings.EnableDistributionPlots.Value);
 
+        if (!string.IsNullOrWhiteSpace(parsedSettings.GlobalSettings.DistributionPlotStyle)
+            && System.Enum.TryParse<Sailfish.Presentation.DistributionPlotStyle>(parsedSettings.GlobalSettings.DistributionPlotStyle, ignoreCase: true, out var plotStyle))
+            runSettingsBuilder = runSettingsBuilder.WithDistributionPlotStyle(plotStyle);
+
         if (parsedSettings.GlobalSettings.EmitDistributionHtmlReport is not null)
             runSettingsBuilder = runSettingsBuilder.WithDistributionHtmlReport(parsedSettings.GlobalSettings.EmitDistributionHtmlReport.Value);
 

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -36,6 +36,12 @@ public static class AdapterRunSettingsLoader
         if (parsedSettings.SailfishSettings.TimerCalibration is not null)
             runSettingsBuilder = runSettingsBuilder.WithTimerCalibration(parsedSettings.SailfishSettings.TimerCalibration.Value);
 
+        if (parsedSettings.GlobalSettings.EnableDistributionPlots is not null)
+            runSettingsBuilder = runSettingsBuilder.WithDistributionPlots(parsedSettings.GlobalSettings.EnableDistributionPlots.Value);
+
+        if (parsedSettings.GlobalSettings.EmitDistributionHtmlReport is not null)
+            runSettingsBuilder = runSettingsBuilder.WithDistributionHtmlReport(parsedSettings.GlobalSettings.EmitDistributionHtmlReport.Value);
+
         var testSettings = MapToTestSettings(parsedSettings);
         var scaleFishSettings = MapToScaleFishSettings(parsedSettings);
         var runSettings = runSettingsBuilder

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -39,8 +39,10 @@ public static class AdapterRunSettingsLoader
         if (parsedSettings.GlobalSettings.EnableDistributionPlots is not null)
             runSettingsBuilder = runSettingsBuilder.WithDistributionPlots(parsedSettings.GlobalSettings.EnableDistributionPlots.Value);
 
-        if (!string.IsNullOrWhiteSpace(parsedSettings.GlobalSettings.DistributionPlotStyle)
-            && System.Enum.TryParse<Sailfish.Presentation.DistributionPlotStyle>(parsedSettings.GlobalSettings.DistributionPlotStyle, ignoreCase: true, out var plotStyle))
+        // Canonical home is GlobalSettings; also accept it under SailDiffSettings as a convenience.
+        var plotStyleRaw = parsedSettings.GlobalSettings.DistributionPlotStyle ?? parsedSettings.SailDiffSettings.DistributionPlotStyle;
+        if (!string.IsNullOrWhiteSpace(plotStyleRaw)
+            && System.Enum.TryParse<Sailfish.Presentation.DistributionPlotStyle>(plotStyleRaw, ignoreCase: true, out var plotStyle))
             runSettingsBuilder = runSettingsBuilder.WithDistributionPlotStyle(plotStyle);
 
         if (parsedSettings.GlobalSettings.EmitDistributionHtmlReport is not null)

--- a/source/Sailfish.TestAdapter/Registrations/TestAdapterRegistrations.cs
+++ b/source/Sailfish.TestAdapter/Registrations/TestAdapterRegistrations.cs
@@ -151,6 +151,7 @@ internal static class TestAdapterRegistrations
             services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IImpactSummaryFormatter, Sailfish.Analysis.SailDiff.Formatting.ImpactSummaryFormatter>();
             services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IDetailedTableFormatter, Sailfish.Analysis.SailDiff.Formatting.DetailedTableFormatter>();
             services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IOutputContextAdapter, Sailfish.Analysis.SailDiff.Formatting.OutputContextAdapter>();
+            services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IDistributionPlotFormatter, Sailfish.Analysis.SailDiff.Formatting.DistributionPlotFormatter>();
             services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.ISailDiffUnifiedFormatter, Sailfish.Analysis.SailDiff.Formatting.SailDiffUnifiedFormatter>();
 
             services.AddTransient<ITestCompletionQueueProcessor, MethodComparisonProcessor>();

--- a/source/Sailfish.TestAdapter/TestSettingsParser/GlobalSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/GlobalSettings.cs
@@ -19,6 +19,10 @@ public class GlobalSettings
     [JsonPropertyName("EnableDistributionPlots")]
     public bool? EnableDistributionPlots { get; set; }
 
+    // "Histogram" (default) or "BoxPlot"
+    [JsonPropertyName("DistributionPlotStyle")]
+    public string? DistributionPlotStyle { get; set; }
+
     [JsonPropertyName("EmitDistributionHtmlReport")]
     public bool? EmitDistributionHtmlReport { get; set; }
 }

--- a/source/Sailfish.TestAdapter/TestSettingsParser/GlobalSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/GlobalSettings.cs
@@ -15,4 +15,10 @@ public class GlobalSettings
 
     [JsonPropertyName("DisableEverything")]
     public bool DisableEverything { get; set; }
+
+    [JsonPropertyName("EnableDistributionPlots")]
+    public bool? EnableDistributionPlots { get; set; }
+
+    [JsonPropertyName("EmitDistributionHtmlReport")]
+    public bool? EmitDistributionHtmlReport { get; set; }
 }

--- a/source/Sailfish.TestAdapter/TestSettingsParser/SailDiffSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/SailDiffSettings.cs
@@ -14,4 +14,9 @@ public class SailDiffSettings
 
     [JsonPropertyName("Disabled")]
     public bool Disabled { get; set; }
+
+    // Accepted here as a convenience too — the canonical home is GlobalSettings.DistributionPlotStyle.
+    // "Histogram" (default) or "BoxPlot".
+    [JsonPropertyName("DistributionPlotStyle")]
+    public string? DistributionPlotStyle { get; set; }
 }

--- a/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
@@ -7,25 +7,25 @@ using Sailfish.Presentation;
 namespace Sailfish.Analysis.SailDiff.Formatting;
 
 /// <summary>
-/// Builds the box-and-whisker distribution plot that accompanies a SailDiff comparison. For a single
-/// comparison it draws two boxes (primary vs compared) on a shared axis; for many comparisons it draws
-/// each distinct method once. The sample data comes from <see cref="StatisticalTestResult.RawDataBefore"/>
+/// Builds the histogram distribution plot that accompanies a SailDiff comparison. For a single
+/// comparison it draws two histogram rows (primary vs compared) on a shared axis; for many comparisons
+/// it draws each distinct method once. The sample data comes from <see cref="StatisticalTestResult.RawDataBefore"/>
 /// / <see cref="StatisticalTestResult.RawDataAfter"/> (already cleaned by the test), so no extra plumbing
-/// is needed. Rendering is delegated to <see cref="AsciiBoxPlotRenderer"/>.
+/// is needed. Rendering is delegated to <see cref="AsciiHistogramRenderer"/>.
 /// </summary>
 public interface IDistributionPlotFormatter
 {
-    /// <summary>Plot for a single comparison (two boxes). Empty string when plots are disabled or unavailable.</summary>
+    /// <summary>Plot for a single comparison (two histogram rows). Empty when plots are disabled or unavailable.</summary>
     string CreatePlot(SailDiffComparisonData data, OutputContext context);
 
-    /// <summary>Plot for several comparisons (one box per distinct method, shared axis).</summary>
+    /// <summary>Plot for several comparisons (one histogram row per distinct method, shared axis).</summary>
     string CreatePlot(IEnumerable<SailDiffComparisonData> comparisons, OutputContext context);
 }
 
 /// <inheritdoc cref="IDistributionPlotFormatter"/>
 public class DistributionPlotFormatter : IDistributionPlotFormatter
 {
-    private const int PlotWidth = 54;
+    private const int PlotWidth = 60;
     private readonly IRunSettings? _runSettings;
 
     /// <summary>Parameterless constructor — plots default on (used by the factory and tests).</summary>
@@ -51,10 +51,10 @@ public class DistributionPlotFormatter : IDistributionPlotFormatter
         if (data.Statistics is null || data.Statistics.Failed) return string.Empty;
 
         var (primaryData, comparedData) = OrientedSamples(data);
-        var series = new List<BoxPlotSeries>
+        var series = new List<DistributionPlotRenderer.Series>
         {
-            BoxPlotData.FromSamples(data.PrimaryMethodName, primaryData ?? Array.Empty<double>()),
-            BoxPlotData.FromSamples(data.ComparedMethodName, comparedData ?? Array.Empty<double>())
+            new(data.PrimaryMethodName, primaryData ?? Array.Empty<double>(), double.NaN, double.NaN, null),
+            new(data.ComparedMethodName, comparedData ?? Array.Empty<double>(), double.NaN, double.NaN, null)
         };
 
         return Wrap(RenderSeries(series), context);
@@ -66,9 +66,9 @@ public class DistributionPlotFormatter : IDistributionPlotFormatter
         if (list.Count == 0 || context == OutputContext.Csv) return string.Empty;
         if (!PlotsEnabled || !list[0].Metadata.IncludeDistributionPlot) return string.Empty;
 
-        // One box per distinct method (a method shared across comparisons is drawn once).
+        // One row per distinct method (a method shared across comparisons is drawn once).
         var seen = new HashSet<string>();
-        var series = new List<BoxPlotSeries>();
+        var series = new List<DistributionPlotRenderer.Series>();
         foreach (var data in list)
         {
             if (data.Statistics is null || data.Statistics.Failed) continue;
@@ -90,20 +90,21 @@ public class DistributionPlotFormatter : IDistributionPlotFormatter
             : (data.Statistics.RawDataBefore, data.Statistics.RawDataAfter);
     }
 
-    private static void AddDistinct(List<BoxPlotSeries> series, HashSet<string> seen, string label, double[]? data)
+    private static void AddDistinct(List<DistributionPlotRenderer.Series> series, HashSet<string> seen, string label, double[]? data)
     {
         if (data is null || data.Length == 0) return;
         if (!seen.Add(label)) return;
-        series.Add(BoxPlotData.FromSamples(label, data));
+        series.Add(new DistributionPlotRenderer.Series(label, data, double.NaN, double.NaN, null));
     }
 
-    private static string RenderSeries(IReadOnlyList<BoxPlotSeries> series)
+    private string RenderSeries(IReadOnlyList<DistributionPlotRenderer.Series> series)
     {
-        var drawable = series.Where(s => !s.IsEmpty).ToList();
+        var drawable = series.Where(s => s.Samples is { Count: > 0 }).ToList();
         if (drawable.Count == 0) return string.Empty;
 
-        var unit = DurationFormatter.SelectUnit(drawable.SelectMany(s => new[] { s.Min, s.Max }));
-        return AsciiBoxPlotRenderer.Render(drawable, unit, PlotWidth);
+        var unit = DurationFormatter.SelectUnit(drawable.SelectMany(s => s.Samples));
+        var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+        return DistributionPlotRenderer.Render(drawable, unit, style, PlotWidth);
     }
 
     private static string Wrap(string plot, OutputContext context)

--- a/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Presentation;
+
+namespace Sailfish.Analysis.SailDiff.Formatting;
+
+/// <summary>
+/// Builds the box-and-whisker distribution plot that accompanies a SailDiff comparison. For a single
+/// comparison it draws two boxes (primary vs compared) on a shared axis; for many comparisons it draws
+/// each distinct method once. The sample data comes from <see cref="StatisticalTestResult.RawDataBefore"/>
+/// / <see cref="StatisticalTestResult.RawDataAfter"/> (already cleaned by the test), so no extra plumbing
+/// is needed. Rendering is delegated to <see cref="AsciiBoxPlotRenderer"/>.
+/// </summary>
+public interface IDistributionPlotFormatter
+{
+    /// <summary>Plot for a single comparison (two boxes). Empty string when plots are disabled or unavailable.</summary>
+    string CreatePlot(SailDiffComparisonData data, OutputContext context);
+
+    /// <summary>Plot for several comparisons (one box per distinct method, shared axis).</summary>
+    string CreatePlot(IEnumerable<SailDiffComparisonData> comparisons, OutputContext context);
+}
+
+/// <inheritdoc cref="IDistributionPlotFormatter"/>
+public class DistributionPlotFormatter : IDistributionPlotFormatter
+{
+    private const int PlotWidth = 54;
+    private readonly IRunSettings? _runSettings;
+
+    /// <summary>Parameterless constructor — plots default on (used by the factory and tests).</summary>
+    public DistributionPlotFormatter()
+    {
+    }
+
+    /// <summary>
+    /// DI constructor. When <paramref name="runSettings"/> is supplied, the global
+    /// <see cref="IRunSettings.EnableDistributionPlots"/> flag gates every comparison plot in one place.
+    /// </summary>
+    public DistributionPlotFormatter(IRunSettings? runSettings)
+    {
+        _runSettings = runSettings;
+    }
+
+    private bool PlotsEnabled => _runSettings?.EnableDistributionPlots ?? true;
+
+    public string CreatePlot(SailDiffComparisonData data, OutputContext context)
+    {
+        if (data is null || context == OutputContext.Csv) return string.Empty;
+        if (!PlotsEnabled || !data.Metadata.IncludeDistributionPlot) return string.Empty;
+        if (data.Statistics is null || data.Statistics.Failed) return string.Empty;
+
+        var (primaryData, comparedData) = OrientedSamples(data);
+        var series = new List<BoxPlotSeries>
+        {
+            BoxPlotData.FromSamples(data.PrimaryMethodName, primaryData ?? Array.Empty<double>()),
+            BoxPlotData.FromSamples(data.ComparedMethodName, comparedData ?? Array.Empty<double>())
+        };
+
+        return Wrap(RenderSeries(series), context);
+    }
+
+    public string CreatePlot(IEnumerable<SailDiffComparisonData> comparisons, OutputContext context)
+    {
+        var list = comparisons?.ToList() ?? new List<SailDiffComparisonData>();
+        if (list.Count == 0 || context == OutputContext.Csv) return string.Empty;
+        if (!PlotsEnabled || !list[0].Metadata.IncludeDistributionPlot) return string.Empty;
+
+        // One box per distinct method (a method shared across comparisons is drawn once).
+        var seen = new HashSet<string>();
+        var series = new List<BoxPlotSeries>();
+        foreach (var data in list)
+        {
+            if (data.Statistics is null || data.Statistics.Failed) continue;
+            var (primaryData, comparedData) = OrientedSamples(data);
+            AddDistinct(series, seen, data.PrimaryMethodName, primaryData);
+            AddDistinct(series, seen, data.ComparedMethodName, comparedData);
+        }
+
+        return Wrap(RenderSeries(series), context);
+    }
+
+    // Honors the perspective swap the other SailDiff formatters apply: when the comparison is viewed
+    // from the compared method's perspective, before/after are exchanged.
+    private static (double[]? Primary, double[]? Compared) OrientedSamples(SailDiffComparisonData data)
+    {
+        var swap = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName;
+        return swap
+            ? (data.Statistics.RawDataAfter, data.Statistics.RawDataBefore)
+            : (data.Statistics.RawDataBefore, data.Statistics.RawDataAfter);
+    }
+
+    private static void AddDistinct(List<BoxPlotSeries> series, HashSet<string> seen, string label, double[]? data)
+    {
+        if (data is null || data.Length == 0) return;
+        if (!seen.Add(label)) return;
+        series.Add(BoxPlotData.FromSamples(label, data));
+    }
+
+    private static string RenderSeries(IReadOnlyList<BoxPlotSeries> series)
+    {
+        var drawable = series.Where(s => !s.IsEmpty).ToList();
+        if (drawable.Count == 0) return string.Empty;
+
+        var unit = DurationFormatter.SelectUnit(drawable.SelectMany(s => new[] { s.Min, s.Max }));
+        return AsciiBoxPlotRenderer.Render(drawable, unit, PlotWidth);
+    }
+
+    private static string Wrap(string plot, OutputContext context)
+    {
+        if (string.IsNullOrEmpty(plot)) return string.Empty;
+
+        return context switch
+        {
+            // Fenced so monospace alignment survives GitHub / IDE Markdown rendering.
+            OutputContext.Markdown => "**Distribution**\n\n```text\n" + plot + "```\n",
+            OutputContext.Ide => "📊 DISTRIBUTION\n" + plot,
+            OutputContext.Console => "DISTRIBUTION\n" + plot,
+            _ => string.Empty
+        };
+    }
+}

--- a/source/Sailfish/Analysis/SailDiff/Formatting/ISailDiffUnifiedFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/ISailDiffUnifiedFormatter.cs
@@ -124,6 +124,13 @@ public class ComparisonMetadata
     /// Additional context or notes about the comparison
     /// </summary>
     public string? Notes { get; set; }
+
+    /// <summary>
+    /// Per-comparison override for whether to draw the box-and-whisker distribution plot. Defaults to
+    /// <c>true</c>; the global <see cref="Sailfish.Contracts.Public.Models.IRunSettings.EnableDistributionPlots"/>
+    /// flag still applies on top of this.
+    /// </summary>
+    public bool IncludeDistributionPlot { get; set; } = true;
 }
 
 /// <summary>
@@ -140,6 +147,11 @@ public class SailDiffFormattedOutput
     /// Detailed statistical table with all metrics
     /// </summary>
     public string DetailedTable { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Box-and-whisker distribution plot (may be empty when disabled or unavailable)
+    /// </summary>
+    public string DistributionPlot { get; set; } = string.Empty;
 
     /// <summary>
     /// Complete formatted output combining impact summary and detailed table

--- a/source/Sailfish/Analysis/SailDiff/Formatting/OutputContextAdapter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/OutputContextAdapter.cs
@@ -15,8 +15,9 @@ public interface IOutputContextAdapter
     /// <param name="detailedTable">Formatted detailed table</param>
     /// <param name="context">Target output context</param>
     /// <param name="groupName">Optional group name for context</param>
+    /// <param name="distributionPlot">Optional box-and-whisker plot block, placed after the detailed table</param>
     /// <returns>Complete formatted output for the context</returns>
-    string AdaptToContext(string impactSummary, string detailedTable, OutputContext context, string? groupName = null);
+    string AdaptToContext(string impactSummary, string detailedTable, OutputContext context, string? groupName = null, string? distributionPlot = null);
 }
 
 /// <summary>
@@ -28,61 +29,68 @@ public class OutputContextAdapter : IOutputContextAdapter
     /// <summary>
     /// Adapts the impact summary and detailed table to the specified output context.
     /// </summary>
-    public string AdaptToContext(string impactSummary, string detailedTable, OutputContext context, string? groupName = null)
+    public string AdaptToContext(string impactSummary, string detailedTable, OutputContext context, string? groupName = null, string? distributionPlot = null)
     {
         return context switch
         {
-            OutputContext.Ide => AdaptForIde(impactSummary, detailedTable, groupName),
-            OutputContext.Markdown => AdaptForMarkdown(impactSummary, detailedTable, groupName),
-            OutputContext.Console => AdaptForConsole(impactSummary, detailedTable, groupName),
+            OutputContext.Ide => AdaptForIde(impactSummary, detailedTable, groupName, distributionPlot),
+            OutputContext.Markdown => AdaptForMarkdown(impactSummary, detailedTable, groupName, distributionPlot),
+            OutputContext.Console => AdaptForConsole(impactSummary, detailedTable, groupName, distributionPlot),
             OutputContext.Csv => AdaptForCsv(impactSummary, detailedTable, groupName),
-            _ => AdaptForConsole(impactSummary, detailedTable, groupName)
+            _ => AdaptForConsole(impactSummary, detailedTable, groupName, distributionPlot)
         };
     }
 
     /// <summary>
     /// Adapts output for IDE test output window with rich formatting and visual hierarchy.
     /// </summary>
-    private string AdaptForIde(string impactSummary, string detailedTable, string? groupName)
+    private string AdaptForIde(string impactSummary, string detailedTable, string? groupName, string? distributionPlot)
     {
         var sb = new StringBuilder();
-        
+
         // Add header with visual separator
         sb.AppendLine();
         sb.AppendLine("📊 PERFORMANCE COMPARISON");
-        
+
         if (!string.IsNullOrEmpty(groupName))
         {
             sb.AppendLine($"Group: {groupName}");
         }
-        
+
         sb.AppendLine(new string('=', 50));
         sb.AppendLine();
-        
+
         // Impact summary with emphasis
         sb.AppendLine(impactSummary);
-        
+
         // Detailed table if available
         if (!string.IsNullOrEmpty(detailedTable))
         {
             sb.AppendLine();
             sb.Append(detailedTable);
         }
-        
+
+        // Distribution plot if available
+        if (!string.IsNullOrEmpty(distributionPlot))
+        {
+            sb.AppendLine();
+            sb.Append(distributionPlot);
+        }
+
         // Footer separator
         sb.AppendLine();
         sb.AppendLine(new string('=', 50));
-        
+
         return sb.ToString();
     }
 
     /// <summary>
     /// Adapts output for Markdown files with GitHub-compatible formatting.
     /// </summary>
-    private string AdaptForMarkdown(string impactSummary, string detailedTable, string? groupName)
+    private string AdaptForMarkdown(string impactSummary, string detailedTable, string? groupName, string? distributionPlot)
     {
         var sb = new StringBuilder();
-        
+
         // Add markdown header
         if (!string.IsNullOrEmpty(groupName))
         {
@@ -94,50 +102,63 @@ public class OutputContextAdapter : IOutputContextAdapter
             sb.AppendLine("### Performance Comparison");
             sb.AppendLine();
         }
-        
+
         // Impact summary as emphasized text
         sb.AppendLine(impactSummary);
-        
+
         // Detailed table if available
         if (!string.IsNullOrEmpty(detailedTable))
         {
             sb.AppendLine();
             sb.Append(detailedTable);
         }
-        
+
+        // Distribution plot if available
+        if (!string.IsNullOrEmpty(distributionPlot))
+        {
+            sb.AppendLine();
+            sb.Append(distributionPlot);
+        }
+
         return sb.ToString();
     }
 
     /// <summary>
     /// Adapts output for console with plain text formatting and clear structure.
     /// </summary>
-    private string AdaptForConsole(string impactSummary, string detailedTable, string? groupName)
+    private string AdaptForConsole(string impactSummary, string detailedTable, string? groupName, string? distributionPlot)
     {
         var sb = new StringBuilder();
-        
+
         // Add console header
         sb.AppendLine();
         sb.AppendLine("PERFORMANCE COMPARISON");
-        
+
         if (!string.IsNullOrEmpty(groupName))
         {
             sb.AppendLine($"Group: {groupName}");
         }
-        
+
         sb.AppendLine(new string('=', 60));
         sb.AppendLine();
-        
+
         // Impact summary
         sb.AppendLine(impactSummary);
-        
+
         // Detailed table if available
         if (!string.IsNullOrEmpty(detailedTable))
         {
             sb.Append(detailedTable);
         }
-        
+
+        // Distribution plot if available
+        if (!string.IsNullOrEmpty(distributionPlot))
+        {
+            sb.Append(distributionPlot);
+        }
+
         sb.AppendLine(new string('=', 60));
-        
+
         return sb.ToString();
     }
 

--- a/source/Sailfish/Analysis/SailDiff/Formatting/SailDiffUnifiedFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/SailDiffUnifiedFormatter.cs
@@ -15,6 +15,7 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
     private readonly IImpactSummaryFormatter _impactFormatter;
     private readonly IDetailedTableFormatter _tableFormatter;
     private readonly IOutputContextAdapter _contextAdapter;
+    private readonly IDistributionPlotFormatter _distributionFormatter;
 
     /// <summary>
     /// Initializes a new instance of the SailDiffUnifiedFormatter.
@@ -22,14 +23,17 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
     /// <param name="impactFormatter">Formatter for creating impact summaries</param>
     /// <param name="tableFormatter">Formatter for creating detailed tables</param>
     /// <param name="contextAdapter">Adapter for context-specific formatting</param>
+    /// <param name="distributionFormatter">Formatter for the box-and-whisker distribution plot</param>
     public SailDiffUnifiedFormatter(
         IImpactSummaryFormatter impactFormatter,
         IDetailedTableFormatter tableFormatter,
-        IOutputContextAdapter contextAdapter)
+        IOutputContextAdapter contextAdapter,
+        IDistributionPlotFormatter distributionFormatter)
     {
         _impactFormatter = impactFormatter ?? throw new ArgumentNullException(nameof(impactFormatter));
         _tableFormatter = tableFormatter ?? throw new ArgumentNullException(nameof(tableFormatter));
         _contextAdapter = contextAdapter ?? throw new ArgumentNullException(nameof(contextAdapter));
+        _distributionFormatter = distributionFormatter ?? throw new ArgumentNullException(nameof(distributionFormatter));
     }
 
     /// <summary>
@@ -45,10 +49,13 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
         
         // Generate detailed table
         var detailedTable = _tableFormatter.CreateDetailedTable(data, context);
-        
+
+        // Generate distribution plot
+        var distributionPlot = _distributionFormatter.CreatePlot(data, context);
+
         // Adapt to context
-        var fullOutput = _contextAdapter.AdaptToContext(impactSummary, detailedTable, context, data.GroupName);
-        
+        var fullOutput = _contextAdapter.AdaptToContext(impactSummary, detailedTable, context, data.GroupName, distributionPlot);
+
         // Analyze significance
         var significance = DetermineSignificance(data.Statistics, data.Metadata.AlphaLevel);
         var percentageChange = CalculatePercentageChange(data);
@@ -58,6 +65,7 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
         {
             ImpactSummary = impactSummary,
             DetailedTable = detailedTable,
+            DistributionPlot = distributionPlot,
             FullOutput = fullOutput,
             Significance = significance,
             PercentageChange = Math.Abs(percentageChange),
@@ -93,12 +101,15 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
         // Create combined detailed table
         var detailedTable = _tableFormatter.CreateDetailedTable(comparisonList, context);
 
+        // Create combined distribution plot (one box per distinct method)
+        var distributionPlot = _distributionFormatter.CreatePlot(comparisonList, context);
+
         // Combine impact summaries based on context
         var combinedImpactSummary = CombineImpactSummaries(impactSummaries, context);
 
         // Use the first comparison's group name for context
         var groupName = comparisonList.First().GroupName;
-        var fullOutput = _contextAdapter.AdaptToContext(combinedImpactSummary, detailedTable, context, groupName);
+        var fullOutput = _contextAdapter.AdaptToContext(combinedImpactSummary, detailedTable, context, groupName, distributionPlot);
 
         // Determine overall significance (most significant change)
         var mostSignificantComparison = comparisonList
@@ -113,6 +124,7 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
         {
             ImpactSummary = combinedImpactSummary,
             DetailedTable = detailedTable,
+            DistributionPlot = distributionPlot,
             FullOutput = fullOutput,
             Significance = overallSignificance,
             PercentageChange = overallPercentageChange,
@@ -203,8 +215,9 @@ public static class SailDiffUnifiedFormatterFactory
         var impactFormatter = new ImpactSummaryFormatter();
         var tableFormatter = new DetailedTableFormatter();
         var contextAdapter = new OutputContextAdapter();
+        var distributionFormatter = new DistributionPlotFormatter();
 
-        return new SailDiffUnifiedFormatter(impactFormatter, tableFormatter, contextAdapter);
+        return new SailDiffUnifiedFormatter(impactFormatter, tableFormatter, contextAdapter, distributionFormatter);
     }
 }
 

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -42,6 +42,12 @@ public interface IRunSettings
     // Timer calibration toggle (default: true)
     bool TimerCalibration { get; }
 
+    // Inline Unicode box-and-whisker distribution plots in IDE / Markdown output (default: true)
+    bool EnableDistributionPlots { get; }
+
+    // Emit a standalone SVG distribution HTML report alongside the run output (default: false)
+    bool EmitDistributionHtmlReport { get; }
+
     // Global adaptive sampling overrides (null = no override)
     bool? GlobalUseAdaptiveSampling { get; }
     double? GlobalTargetCoefficientOfVariation { get; }

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -42,8 +42,11 @@ public interface IRunSettings
     // Timer calibration toggle (default: true)
     bool TimerCalibration { get; }
 
-    // Inline Unicode box-and-whisker distribution plots in IDE / Markdown output (default: true)
+    // Inline Unicode distribution plots in IDE / Markdown output (default: true)
     bool EnableDistributionPlots { get; }
+
+    // Which inline distribution plot to render — histogram (default) or box-and-whisker
+    Sailfish.Presentation.DistributionPlotStyle DistributionPlotStyle { get; }
 
     // Emit a standalone SVG distribution HTML report alongside the run output (default: false)
     bool EmitDistributionHtmlReport { get; }

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -397,6 +397,9 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                     sb.AppendLine($"| {method.TestCaseId?.DisplayName ?? "Unknown"} | {DurationFormatter.Format(meanTime, detailUnit, 3)} | {DurationFormatter.Format(medianTime, detailUnit, 3)} | {sampleSize} | {status} |");
                 }
                 sb.AppendLine();
+
+                // Box-and-whisker plot of every method in the group on a shared axis
+                AppendComparisonDistributionPlot(methods, sb);
             }
         }
 
@@ -428,6 +431,53 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Appends a fenced Unicode box-and-whisker plot showing every method in the group on one shared
+    /// axis. Gated by <see cref="IRunSettings.EnableDistributionPlots"/> (default on). Best-effort —
+    /// a rendering failure must never break the markdown report.
+    /// </summary>
+    private void AppendComparisonDistributionPlot(List<CompiledTestCaseResultTrackingFormat> methods, StringBuilder sb)
+    {
+        if (!(_runSettings?.EnableDistributionPlots ?? true)) return;
+
+        try
+        {
+            var series = methods
+                .Where(m => m.PerformanceRunResult is { } pr && pr.DataWithOutliersRemoved is { Length: > 0 })
+                .Select(m =>
+                {
+                    var pr = m.PerformanceRunResult!;
+                    var outliers = (pr.UpperOutliers ?? Array.Empty<double>())
+                        .Concat(pr.LowerOutliers ?? Array.Empty<double>())
+                        .ToArray();
+                    return BoxPlotData.FromSamples(
+                        GetMethodName(m.TestCaseId?.DisplayName ?? pr.DisplayName),
+                        pr.DataWithOutliersRemoved,
+                        pr.Mean,
+                        outliers);
+                })
+                .Where(s => !s.IsEmpty)
+                .ToList();
+
+            if (series.Count == 0) return;
+
+            var unit = DurationFormatter.SelectUnit(series.SelectMany(s => new[] { s.Min, s.Max }));
+            var plot = AsciiBoxPlotRenderer.Render(series, unit);
+            if (string.IsNullOrEmpty(plot)) return;
+
+            sb.AppendLine("### Distribution");
+            sb.AppendLine();
+            sb.AppendLine("```text");
+            sb.Append(plot);
+            sb.AppendLine("```");
+            sb.AppendLine();
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Debug, ex, "Failed to append comparison distribution plot: {0}", ex.Message);
+        }
     }
 
     /// <summary>

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -452,19 +452,21 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                     var outliers = (pr.UpperOutliers ?? Array.Empty<double>())
                         .Concat(pr.LowerOutliers ?? Array.Empty<double>())
                         .ToArray();
-                    return BoxPlotData.FromSamples(
+                    return new DistributionPlotRenderer.Series(
                         GetMethodName(m.TestCaseId?.DisplayName ?? pr.DisplayName),
                         pr.DataWithOutliersRemoved,
                         pr.Mean,
+                        pr.Median,
                         outliers);
                 })
-                .Where(s => !s.IsEmpty)
+                .Where(s => s.Samples is { Count: > 0 })
                 .ToList();
 
             if (series.Count == 0) return;
 
-            var unit = DurationFormatter.SelectUnit(series.SelectMany(s => new[] { s.Min, s.Max }));
-            var plot = AsciiBoxPlotRenderer.Render(series, unit);
+            var unit = DurationFormatter.SelectUnit(series.SelectMany(s => s.Samples));
+            var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+            var plot = DistributionPlotRenderer.Render(series, unit, style);
             if (string.IsNullOrEmpty(plot)) return;
 
             sb.AppendLine("### Distribution");

--- a/source/Sailfish/DefaultHandlers/Sailfish/SailfishWriteToMarkdownHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/SailfishWriteToMarkdownHandler.cs
@@ -38,5 +38,28 @@ internal class SailfishWriteToMarkdownHandler : INotificationHandler<WriteToMark
             // Fallback to legacy formatting if enhanced is not implemented
             await _markdownWriter.Write(notification.ClassExecutionSummaries, filePath, cancellationToken).ConfigureAwait(false);
         }
+
+        await EmitDistributionHtmlReport(notification, outputDirectory, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Optional standalone SVG distribution report, mirroring ScaleFish's EmitHtmlReport. Best-effort:
+    // a failure here must never fail the run or block the (already-written) markdown/CSV output.
+    private async Task EmitDistributionHtmlReport(WriteToMarkDownNotification notification, string outputDirectory, CancellationToken cancellationToken)
+    {
+        if (!_runSettings.EmitDistributionHtmlReport) return;
+
+        try
+        {
+            var html = PerformanceDistributionHtmlReportBuilder.Build(notification.ClassExecutionSummaries);
+            if (string.IsNullOrEmpty(html)) return;
+
+            var htmlName = DefaultFileSettings.AppendTagsToFilename(
+                $"DistributionReport_{_runSettings.TimeStamp:yyyyMMdd-HHmmss}.html", _runSettings.Tags);
+            await File.WriteAllTextAsync(Path.Combine(outputDirectory, htmlName), html, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // best-effort: optional report
+        }
     }
 }

--- a/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
+++ b/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
@@ -24,12 +24,10 @@ public static class AsciiBoxPlotRenderer
     private const int MaxLabelWidth = 28;
 
     private const char Space = ' ';
-    private const char WhiskerLine = '━';
-    private const char WhiskerCapLow = '┣';
-    private const char WhiskerCapHigh = '┫';
-    private const char BoxFill = '▒';
-    private const char BoxEdgeLow = '┫';
-    private const char BoxEdgeHigh = '┣';
+    private const char WhiskerLine = '─';
+    private const char WhiskerCapLow = '├';
+    private const char WhiskerCapHigh = '┤';
+    private const char BoxFill = '▓';
     private const char MedianMark = '┃';
     private const char MeanMark = '◆';
     private const char RulerLine = '─';
@@ -125,19 +123,18 @@ public static class AsciiBoxPlotRenderer
         var q1C = col(s.Q1);
         var q3C = col(s.Q3);
 
-        // Layers, painted low-to-high precedence (later overwrites earlier).
+        // Layers, painted low-to-high precedence (later overwrites earlier). The shaded run itself is
+        // the IQR box — set against the thin whisker line it reads as a crisp block with no need for
+        // bracket edges that could be mistaken for whisker caps.
         for (var i = minC; i <= maxC; i++)
         {
             if (buf[i] == Space) buf[i] = WhiskerLine;
         }
 
-        for (var i = q1C; i <= q3C; i++) buf[i] = BoxFill;
-
-        buf[q1C] = BoxEdgeLow;
-        buf[q3C] = BoxEdgeHigh;
-
         if (minC < q1C) buf[minC] = WhiskerCapLow;
         if (maxC > q3C) buf[maxC] = WhiskerCapHigh;
+
+        for (var i = q1C; i <= q3C; i++) buf[i] = BoxFill;
 
         var meanC = col(s.Mean);
         if (meanC >= 0 && meanC < width) buf[meanC] = MeanMark;

--- a/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
+++ b/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
@@ -23,6 +23,10 @@ public static class AsciiBoxPlotRenderer
     private const int MinWidth = 24;
     private const int MaxLabelWidth = 28;
 
+    // Fraction of the data range to pad onto each side of the axis. 0.25 each side leaves the data
+    // spanning the central 2/3 of the lane, so whiskers sit around 1/6 and 5/6 of the width.
+    private const double AxisPaddingFraction = 0.25;
+
     private const char Space = ' ';
     private const char WhiskerLine = '─';
     private const char WhiskerCapLow = '├';
@@ -57,8 +61,11 @@ public static class AsciiBoxPlotRenderer
         if (axisValuesMs.Count == 0) return string.Empty;
 
         width = Math.Max(MinWidth, width);
-        var axisMinMs = axisValuesMs.Min();
-        var axisMaxMs = axisValuesMs.Max();
+
+        // Pad the axis by a fraction of the data range on each side so the whiskers float inside the
+        // lane (data spans ~2/3 of the width) instead of always pinning to both edges — otherwise every
+        // plot looks maxed out and the shape is hard to read.
+        var (axisMinMs, axisMaxMs) = PadAxis(axisValuesMs.Min(), axisValuesMs.Max());
         var minU = DurationFormatter.ToUnit(axisMinMs, unit);
         var maxU = DurationFormatter.ToUnit(axisMaxMs, unit);
         var spanU = maxU - minU;
@@ -197,6 +204,16 @@ public static class AsciiBoxPlotRenderer
             var col = (int)Math.Round(fraction * (width - 1));
             if (seen.Add(col)) yield return col;
         }
+    }
+
+    // Symmetrically pads the data range so the whiskers don't pin to the lane edges. A zero-width
+    // range (single value / all equal) is left untouched — the renderer centres it instead.
+    private static (double Min, double Max) PadAxis(double dataMin, double dataMax)
+    {
+        var range = dataMax - dataMin;
+        if (range <= 0) return (dataMin, dataMax);
+        var pad = range * AxisPaddingFraction;
+        return (dataMin - pad, dataMax + pad);
     }
 
     private static int AxisDecimals(double spanU)

--- a/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
+++ b/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Renders one or more <see cref="BoxPlotSeries"/> as a horizontal Unicode box-and-whisker plot on a
+/// single shared axis. Output is plain monospace text, so it lines up in IDE test-output windows and
+/// inside fenced code blocks in Markdown. No external dependencies.
+/// <para>
+/// Glyphs: <c>┣━┫</c> whisker (min–max), <c>▒</c> IQR box, <c>┃</c> median, <c>◆</c> mean.
+/// The axis is scaled to the <em>cleaned</em> min–max so the distribution shape stays legible; any
+/// outliers Sailfish removed are reported as a count beside the lane rather than stretching the axis
+/// (their exact values are listed in the surrounding text). The axis unit (ns/µs/ms/s) is chosen by
+/// <see cref="DurationFormatter"/> so fast benchmarks aren't flattened to a single point.
+/// </para>
+/// </summary>
+public static class AsciiBoxPlotRenderer
+{
+    private const int DefaultWidth = 54;
+    private const int MinWidth = 24;
+    private const int MaxLabelWidth = 28;
+
+    private const char Space = ' ';
+    private const char WhiskerLine = '━';
+    private const char WhiskerCapLow = '┣';
+    private const char WhiskerCapHigh = '┫';
+    private const char BoxFill = '▒';
+    private const char BoxEdgeLow = '┫';
+    private const char BoxEdgeHigh = '┣';
+    private const char MedianMark = '┃';
+    private const char MeanMark = '◆';
+    private const char RulerLine = '─';
+    private const char RulerTick = '┬';
+    private const char RulerCornerLow = '└';
+    private const char RulerCornerHigh = '┘';
+
+    /// <summary>
+    /// Renders the supplied series. Returns an empty string when there is nothing finite to draw.
+    /// </summary>
+    /// <param name="series">Series to draw on a shared axis (1 = single box, 2 = comparison, N = group).</param>
+    /// <param name="unit">Display unit for the axis (typically <see cref="DurationFormatter.SelectUnit(System.Collections.Generic.IEnumerable{double})"/>).</param>
+    /// <param name="width">Plot width in characters (the drawable lane, excluding the label column).</param>
+    public static string Render(IReadOnlyList<BoxPlotSeries> series, DurationUnit unit, int width = DefaultWidth)
+    {
+        if (series is null) return string.Empty;
+
+        var drawable = series.Where(s => s is { IsEmpty: false }).ToList();
+        if (drawable.Count == 0) return string.Empty;
+
+        // Axis spans the cleaned min–max only (outliers are reported as a count, not plotted, so a few
+        // far-flung points can't compress the box out of view).
+        var axisValuesMs = drawable
+            .SelectMany(s => new[] { s.Min, s.Max })
+            .Where(double.IsFinite)
+            .ToList();
+        if (axisValuesMs.Count == 0) return string.Empty;
+
+        width = Math.Max(MinWidth, width);
+        var axisMinMs = axisValuesMs.Min();
+        var axisMaxMs = axisValuesMs.Max();
+        var minU = DurationFormatter.ToUnit(axisMinMs, unit);
+        var maxU = DurationFormatter.ToUnit(axisMaxMs, unit);
+        var spanU = maxU - minU;
+
+        // Column for a millisecond value. With zero span (all values equal) everything collapses to
+        // the lane centre so the single marker is visible rather than jammed against the edge.
+        int Col(double valueMs)
+        {
+            if (spanU <= 0) return width / 2;
+            var u = DurationFormatter.ToUnit(valueMs, unit);
+            var col = (int)Math.Round((u - minU) / spanU * (width - 1));
+            return Math.Clamp(col, 0, width - 1);
+        }
+
+        var labelWidth = Math.Clamp(drawable.Max(s => (s.Label ?? string.Empty).Length), 0, MaxLabelWidth);
+        var labelPad = new string(Space, labelWidth);
+        var decimals = AxisDecimals(spanU);
+
+        var sb = new StringBuilder();
+
+        // Header: unit, right-aligned over the lane.
+        var unitHeader = $"Time ({DurationFormatter.UnitLabel(unit)})";
+        sb.Append(labelPad).Append("  ").AppendLine(PadCentreOrRight(unitHeader, width));
+
+        // One lane per series.
+        foreach (var s in drawable)
+        {
+            sb.Append(TruncatePad(s.Label ?? string.Empty, labelWidth)).Append("  ");
+            sb.Append(Lane(s, width, Col));
+            sb.Append("  n=").Append(s.N);
+            if (s.OutlierCount > 0) sb.Append(" (+").Append(s.OutlierCount).Append(" outliers)");
+            sb.AppendLine();
+        }
+
+        // Shared axis ruler + tick labels.
+        sb.Append(labelPad).Append("  ").AppendLine(Ruler(width, spanU));
+        sb.Append(labelPad).Append("  ").AppendLine(TickLabels(width, axisMinMs, axisMaxMs, unit, decimals, spanU));
+
+        // Legend.
+        sb.Append("  ").Append(MedianMark).Append(" median  ")
+            .Append(MeanMark).Append(" mean  ")
+            .Append(BoxFill).Append(" IQR box  ")
+            .Append(WhiskerCapLow).Append(WhiskerLine).Append(WhiskerCapHigh).Append(" min–max");
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static string Lane(BoxPlotSeries s, int width, Func<double, int> col)
+    {
+        var buf = new char[width];
+        for (var i = 0; i < width; i++) buf[i] = Space;
+
+        if (s.HasNoSpread)
+        {
+            buf[col(s.Median)] = MeanMark;
+            return new string(buf);
+        }
+
+        var minC = col(s.Min);
+        var maxC = col(s.Max);
+        var q1C = col(s.Q1);
+        var q3C = col(s.Q3);
+
+        // Layers, painted low-to-high precedence (later overwrites earlier).
+        for (var i = minC; i <= maxC; i++)
+        {
+            if (buf[i] == Space) buf[i] = WhiskerLine;
+        }
+
+        for (var i = q1C; i <= q3C; i++) buf[i] = BoxFill;
+
+        buf[q1C] = BoxEdgeLow;
+        buf[q3C] = BoxEdgeHigh;
+
+        if (minC < q1C) buf[minC] = WhiskerCapLow;
+        if (maxC > q3C) buf[maxC] = WhiskerCapHigh;
+
+        var meanC = col(s.Mean);
+        if (meanC >= 0 && meanC < width) buf[meanC] = MeanMark;
+
+        buf[col(s.Median)] = MedianMark; // highest precedence
+
+        return new string(buf);
+    }
+
+    private static string Ruler(int width, double spanU)
+    {
+        var buf = new char[width];
+        for (var i = 0; i < width; i++) buf[i] = RulerLine;
+
+        if (spanU <= 0)
+        {
+            buf[width / 2] = RulerTick;
+            return new string(buf);
+        }
+
+        foreach (var tickCol in TickColumns(width)) buf[tickCol] = RulerTick;
+        buf[0] = RulerCornerLow;
+        buf[width - 1] = RulerCornerHigh;
+        return new string(buf);
+    }
+
+    private static string TickLabels(int width, double axisMinMs, double axisMaxMs, DurationUnit unit, int decimals, double spanU)
+    {
+        var buf = new char[width];
+        for (var i = 0; i < width; i++) buf[i] = Space;
+
+        IEnumerable<int> cols = spanU <= 0 ? new[] { width / 2 } : TickColumns(width);
+
+        var lastEnd = -2;
+        foreach (var tickCol in cols)
+        {
+            var fraction = width <= 1 ? 0 : tickCol / (double)(width - 1);
+            var valueMs = axisMinMs + fraction * (axisMaxMs - axisMinMs);
+            var text = DurationFormatter.Format(valueMs, unit, decimals);
+
+            var start = tickCol - text.Length / 2;
+            if (tickCol == 0) start = 0;
+            if (tickCol == width - 1) start = width - text.Length;
+            start = Math.Clamp(start, 0, Math.Max(0, width - text.Length));
+
+            if (start <= lastEnd + 1) continue; // keep at least one space between labels
+            for (var i = 0; i < text.Length && start + i < width; i++) buf[start + i] = text[i];
+            lastEnd = start + text.Length - 1;
+        }
+
+        return new string(buf).TrimEnd();
+    }
+
+    // Five evenly spaced ticks across the lane (0%, 25%, 50%, 75%, 100%).
+    private static IEnumerable<int> TickColumns(int width)
+    {
+        var seen = new HashSet<int>();
+        foreach (var fraction in new[] { 0.0, 0.25, 0.5, 0.75, 1.0 })
+        {
+            var col = (int)Math.Round(fraction * (width - 1));
+            if (seen.Add(col)) yield return col;
+        }
+    }
+
+    private static int AxisDecimals(double spanU)
+    {
+        if (spanU >= 100) return 0;
+        if (spanU >= 10) return 1;
+        if (spanU >= 1) return 2;
+        return 3;
+    }
+
+    private static string TruncatePad(string label, int labelWidth)
+    {
+        if (labelWidth == 0) return string.Empty;
+        if (label.Length > labelWidth)
+        {
+            return labelWidth <= 1 ? label[..labelWidth] : label[..(labelWidth - 1)] + "…";
+        }
+
+        return label.PadRight(labelWidth);
+    }
+
+    private static string PadCentreOrRight(string text, int width)
+    {
+        if (text.Length >= width) return text;
+        var leftPad = width - text.Length;
+        return new string(Space, leftPad) + text;
+    }
+}

--- a/source/Sailfish/Presentation/AsciiHistogramRenderer.cs
+++ b/source/Sailfish/Presentation/AsciiHistogramRenderer.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Renders one or more <see cref="DistributionData"/> as compact horizontal histograms ("small
+/// multiples") sharing a single, nice-rounded x-axis. Each distribution gets a block-glyph histogram
+/// row (<c>▁▂▃▄▅▆▇█</c>) positioned on the shared axis so differences in location are visible, with a
+/// thin marker line beneath it carrying the mean (<c>╵</c>) and median (<c>╿</c>) at their true x. A
+/// summary table underneath lists exact n / outliers / min / max. No markers ever sit inside the
+/// histogram blocks, avoiding the font side-bearing problems of the old inline box-plot style.
+/// </summary>
+public static class AsciiHistogramRenderer
+{
+    private const int DefaultPlotWidth = 60;
+    private const int MinPlotWidth = 20;
+    private const int Indent = 2;
+    private const int LabelGap = 2;
+    private const int MaxLabelWidth = 22;
+
+    private const string Blocks = "▁▂▃▄▅▆▇█";
+    private const char MeanMark = '╵';
+    private const char MedianMark = '╿';
+    private const char MeanMedianMark = '╽'; // mean and median land on the same column
+
+    private const char AxisLine = '─';
+    private const char AxisTick = '┬';
+    private const char AxisLeftCap = '├';
+    private const char AxisRightCap = '┤';
+
+    /// <summary>
+    /// Renders the supplied distributions. Returns an empty string when there is nothing to plot.
+    /// </summary>
+    /// <param name="distributions">Distributions to draw on a shared axis (1 = single, N = small multiples).</param>
+    /// <param name="unit">Display unit; samples (ms) are converted to it for the axis and labels.</param>
+    /// <param name="measure">Axis title prefix, e.g. "Time" → "Time (ms)".</param>
+    /// <param name="plotWidth">Width of the plot area in characters.</param>
+    public static string Render(IReadOnlyList<DistributionData> distributions, DurationUnit unit, string measure = "Time", int plotWidth = DefaultPlotWidth, int bins = 12)
+    {
+        if (distributions is null) return string.Empty;
+
+        var drawable = distributions.Where(d => d is { IsEmpty: false }).ToList();
+        if (drawable.Count == 0) return string.Empty;
+
+        var allUnitValues = drawable
+            .SelectMany(d => d.Samples)
+            .Select(ms => DurationFormatter.ToUnit(ms, unit))
+            .Where(double.IsFinite)
+            .ToList();
+        if (allUnitValues.Count == 0) return string.Empty;
+
+        var axis = NiceAxis.Compute(allUnitValues.Min(), allUnitValues.Max());
+
+        plotWidth = Math.Max(MinPlotWidth, plotWidth);
+        var leftLabel = Format(axis.Min, axis.Decimals);
+        var rightLabel = Format(axis.Max, axis.Decimals);
+
+        // The label field must hold the longest distribution name AND leave room for the right-aligned
+        // left-axis endpoint label (plus a separating space) so the histograms and axis '├' line up.
+        var labelWidth = drawable.Max(d => Fit(d.Label).Length);
+        labelWidth = Math.Max(labelWidth, leftLabel.Length + 1);
+        labelWidth = Math.Clamp(labelWidth, 1, Math.Max(MaxLabelWidth, leftLabel.Length + 1));
+        var plotLeft = Indent + labelWidth + LabelGap;
+
+        var span = axis.Max - axis.Min;
+
+        int Col(double unitValue)
+        {
+            if (span <= 0) return plotWidth / 2;
+            var c = (int)Math.Round((unitValue - axis.Min) / span * (plotWidth - 1));
+            return Math.Clamp(c, 0, plotWidth - 1);
+        }
+
+        var sb = new StringBuilder();
+        var anyCombinedMarker = false;
+
+        // Unit title, right-aligned to the plot's right edge.
+        sb.AppendLine(PadLeftTo($"{measure} ({DurationFormatter.UnitLabel(unit)})", plotLeft + plotWidth));
+        sb.AppendLine();
+
+        // Histogram + marker row per distribution.
+        foreach (var d in drawable)
+        {
+            var hist = BuildHistogramRow(d, unit, plotWidth, bins, axis.Min, span, Col);
+
+            sb.Append(new string(' ', Indent)).Append(Fit(d.Label).PadRight(labelWidth)).Append(new string(' ', LabelGap));
+            sb.Append(new string(hist).TrimEnd());
+            sb.AppendLine();
+
+            // Marker line directly beneath, scale-aligned.
+            var markers = new char[plotWidth];
+            Array.Fill(markers, ' ');
+            var meanCol = Col(DurationFormatter.ToUnit(d.Mean, unit));
+            var medianCol = Col(DurationFormatter.ToUnit(d.Median, unit));
+            if (meanCol == medianCol)
+            {
+                markers[meanCol] = MeanMedianMark;
+                anyCombinedMarker = true;
+            }
+            else
+            {
+                markers[meanCol] = MeanMark;
+                markers[medianCol] = MedianMark;
+            }
+
+            var markerLine = (new string(' ', plotLeft) + new string(markers)).TrimEnd();
+            if (markerLine.Length > 0) sb.AppendLine(markerLine);
+        }
+
+        sb.AppendLine();
+
+        // Shared axis line with rounded endpoints and interior ticks.
+        sb.AppendLine(BuildAxisLine(plotLeft, plotWidth, leftLabel, rightLabel, axis, Col));
+        sb.AppendLine(BuildTickLabelLine(plotLeft, plotWidth, axis, Col));
+        sb.AppendLine();
+
+        // Legend.
+        var legend = $"{new string(' ', Indent)}{MeanMark} mean   {MedianMark} median   {Blocks} count per bin";
+        if (anyCombinedMarker) legend += $"   {MeanMedianMark} mean≈median";
+        sb.AppendLine(legend);
+        sb.AppendLine();
+
+        // Summary table.
+        foreach (var d in drawable)
+        {
+            var min = d.Samples.Min();
+            var max = d.Samples.Max();
+            sb.Append(new string(' ', Indent)).Append(Fit(d.Label).PadRight(labelWidth));
+            sb.Append($"  n={d.Samples.Count}  outliers={d.OutlierCount}  min={Format(DurationFormatter.ToUnit(min, unit), 3)}  max={Format(DurationFormatter.ToUnit(max, unit), 3)}");
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildAxisLine(int plotLeft, int plotWidth, string leftLabel, string rightLabel, NiceAxisResult axis, Func<double, int> col)
+    {
+        var total = plotLeft + plotWidth + 1 + rightLabel.Length;
+        var buf = new char[total];
+        Array.Fill(buf, ' ');
+
+        for (var c = 0; c < plotWidth; c++) buf[plotLeft + c] = AxisLine;
+        buf[plotLeft] = AxisLeftCap;
+        buf[plotLeft + plotWidth - 1] = AxisRightCap;
+
+        // Interior ticks (skip the two endpoints, which are the caps).
+        for (var i = 1; i < axis.Ticks.Count - 1; i++)
+        {
+            var c = col(axis.Ticks[i]);
+            if (c > 0 && c < plotWidth - 1) buf[plotLeft + c] = AxisTick;
+        }
+
+        // Left endpoint label, right-aligned ending one space before the left cap.
+        PlaceText(buf, plotLeft - 1 - leftLabel.Length, leftLabel);
+        // Right endpoint label, one space after the right cap.
+        PlaceText(buf, plotLeft + plotWidth + 1, rightLabel);
+
+        return new string(buf).TrimEnd();
+    }
+
+    private static string BuildTickLabelLine(int plotLeft, int plotWidth, NiceAxisResult axis, Func<double, int> col)
+    {
+        var buf = new char[plotLeft + plotWidth + 8];
+        Array.Fill(buf, ' ');
+
+        // Only interior ticks get labels here; the endpoints are labelled on the axis line.
+        for (var i = 1; i < axis.Ticks.Count - 1; i++)
+        {
+            var text = Format(axis.Ticks[i], axis.Decimals);
+            var centre = plotLeft + col(axis.Ticks[i]);
+            PlaceText(buf, centre - text.Length / 2, text);
+        }
+
+        return new string(buf).TrimEnd();
+    }
+
+    // Bins a distribution's in-range samples into <paramref name="bins"/> bins over its own range, then
+    // paints each bin's glyph across the columns that bin spans on the SHARED axis. Coarse bins keep a
+    // sparse tail contiguous (no isolated single-column "dust") while position still reflects the shared
+    // scale, and the block width grows with the distribution's spread.
+    private static char[] BuildHistogramRow(DistributionData d, DurationUnit unit, int plotWidth, int bins, double axisMin, double span, Func<double, int> col)
+    {
+        var hist = new char[plotWidth];
+        Array.Fill(hist, ' ');
+
+        var values = d.Samples.Select(ms => DurationFormatter.ToUnit(ms, unit)).Where(double.IsFinite).ToArray();
+        if (values.Length == 0) return hist;
+
+        var dMin = values.Min();
+        var dMax = values.Max();
+        if (dMax - dMin <= 0)
+        {
+            hist[col(dMin)] = Blocks[^1]; // identical values: a single full-height spike
+            return hist;
+        }
+
+        var nBins = Math.Clamp(bins, 1, values.Length);
+        var binWidth = (dMax - dMin) / nBins;
+        var counts = new int[nBins];
+        foreach (var v in values)
+        {
+            counts[Math.Clamp((int)((v - dMin) / binWidth), 0, nBins - 1)]++;
+        }
+
+        var maxCount = counts.Max();
+        var startCol = col(dMin);
+        var endCol = col(dMax);
+        for (var c = startCol; c <= endCol; c++)
+        {
+            var valueAtCol = span <= 0 ? dMin : axisMin + span * (c / (double)(plotWidth - 1));
+            var idx = Math.Clamp((int)((valueAtCol - dMin) / binWidth), 0, nBins - 1);
+            hist[c] = Glyph(counts[idx], maxCount);
+        }
+
+        return hist;
+    }
+
+    private static char Glyph(int count, int maxCount)
+    {
+        if (count <= 0) return ' ';
+        if (maxCount <= 0) return Blocks[0];
+        var level = (int)Math.Ceiling((double)count / maxCount * Blocks.Length);
+        level = Math.Clamp(level, 1, Blocks.Length);
+        return Blocks[level - 1];
+    }
+
+    private static string Fit(string? label)
+    {
+        label ??= string.Empty;
+        if (label.Length <= MaxLabelWidth) return label;
+        return MaxLabelWidth <= 1 ? label[..MaxLabelWidth] : label[..(MaxLabelWidth - 1)] + "…";
+    }
+
+    private static string Format(double value, int decimals)
+        => value.ToString("F" + Math.Max(0, decimals), System.Globalization.CultureInfo.InvariantCulture);
+
+    private static string PadLeftTo(string text, int width)
+        => text.Length >= width ? text : new string(' ', width - text.Length) + text;
+
+    private static void PlaceText(char[] buffer, int start, string text)
+    {
+        if (start < 0) start = 0;
+        for (var i = 0; i < text.Length && start + i < buffer.Length; i++)
+        {
+            buffer[start + i] = text[i];
+        }
+    }
+}

--- a/source/Sailfish/Presentation/BoxPlotData.cs
+++ b/source/Sailfish/Presentation/BoxPlotData.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MathNet.Numerics.Statistics;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Builds <see cref="BoxPlotSeries"/> five-number summaries from raw samples. Quartiles use the same
+/// MathNet.Numerics statistics the rest of Sailfish already relies on (<c>Mean()</c>/<c>Median()</c>
+/// on <c>PerformanceRunResult</c>), so a box plot is always consistent with the scalar stats shown
+/// next to it.
+/// </summary>
+public static class BoxPlotData
+{
+    /// <summary>
+    /// Builds a series from an already-cleaned sample (outliers removed). The whiskers span the
+    /// cleaned min–max; <paramref name="removedOutliers"/> — Sailfish's own detected outliers — are
+    /// carried through to be drawn as separate markers. Non-finite values are filtered out.
+    /// </summary>
+    /// <param name="label">Row label (method / test-case / group member name).</param>
+    /// <param name="cleaned">The sample after Sailfish outlier removal, in milliseconds.</param>
+    /// <param name="mean">The mean Sailfish already computed (in ms); recomputed from
+    /// <paramref name="cleaned"/> only if this is non-finite.</param>
+    /// <param name="removedOutliers">Outliers Sailfish removed, in ms. Optional.</param>
+    public static BoxPlotSeries FromSamples(
+        string label,
+        IReadOnlyList<double> cleaned,
+        double mean,
+        IReadOnlyList<double>? removedOutliers = null)
+    {
+        var finite = (cleaned ?? Array.Empty<double>()).Where(double.IsFinite).ToArray();
+        var outliers = (removedOutliers ?? Array.Empty<double>()).Where(double.IsFinite).ToArray();
+
+        if (finite.Length == 0)
+        {
+            return new BoxPlotSeries(label, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, outliers, 0);
+        }
+
+        if (finite.Length == 1)
+        {
+            var only = finite[0];
+            return new BoxPlotSeries(label, only, only, only, only, only, double.IsFinite(mean) ? mean : only, outliers, 1);
+        }
+
+        var min = finite.Minimum();
+        var max = finite.Maximum();
+        var q1 = finite.LowerQuartile();
+        var median = finite.Median();
+        var q3 = finite.UpperQuartile();
+        var resolvedMean = double.IsFinite(mean) ? mean : finite.Mean();
+
+        return new BoxPlotSeries(label, min, q1, median, q3, max, resolvedMean, outliers, finite.Length);
+    }
+
+    /// <summary>
+    /// Convenience overload that computes the mean from <paramref name="cleaned"/>.
+    /// </summary>
+    public static BoxPlotSeries FromSamples(string label, IReadOnlyList<double> cleaned, IReadOnlyList<double>? removedOutliers = null)
+        => FromSamples(label, cleaned, double.NaN, removedOutliers);
+}

--- a/source/Sailfish/Presentation/BoxPlotSeries.cs
+++ b/source/Sailfish/Presentation/BoxPlotSeries.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Immutable five-number summary (plus mean and removed outliers) for one distribution, ready to be
+/// drawn as a box-and-whisker plot. All durations are in <b>milliseconds</b> — Sailfish stores every
+/// measurement in ms (see <c>PerformanceRunResult.ConvertFromPerfTimer</c>) and the display unit is
+/// applied only at render time, exactly like <see cref="DurationFormatter"/>.
+/// <para>
+/// <see cref="Outliers"/> are the points Sailfish's own detector already removed from the sample; the
+/// box and whiskers are computed from the <em>cleaned</em> data, so the whiskers span the cleaned
+/// min–max and the outliers are drawn as separate markers. When a surface has no separate outlier
+/// list (the SailDiff comparison arrays are already cleaned), pass an empty list.
+/// </para>
+/// </summary>
+public sealed record BoxPlotSeries(
+    string Label,
+    double Min,
+    double Q1,
+    double Median,
+    double Q3,
+    double Max,
+    double Mean,
+    IReadOnlyList<double> Outliers,
+    int N)
+{
+    /// <summary>True when there is no finite data to plot.</summary>
+    public bool IsEmpty => N == 0;
+
+    /// <summary>True when every value coincides (zero spread) — render as a single marker.</summary>
+    public bool HasNoSpread => N > 0 && Max - Min <= 0;
+
+    /// <summary>Number of outliers Sailfish removed before computing this summary.</summary>
+    public int OutlierCount => Outliers?.Count ?? 0;
+}

--- a/source/Sailfish/Presentation/BoxPlotSvgRenderer.cs
+++ b/source/Sailfish/Presentation/BoxPlotSvgRenderer.cs
@@ -36,8 +36,15 @@ public static class BoxPlotSvgRenderer
         if (axisValuesMs.Count == 0) return string.Empty;
 
         width = Math.Max(360, width);
-        var axisMinMs = axisValuesMs.Min();
-        var axisMaxMs = axisValuesMs.Max();
+
+        // Pad the axis by 1/4 of the data range each side so whiskers float in the central ~2/3 of the
+        // plot rather than always pinning to both edges (matches AsciiBoxPlotRenderer).
+        var dataMinMs = axisValuesMs.Min();
+        var dataMaxMs = axisValuesMs.Max();
+        var dataRangeMs = dataMaxMs - dataMinMs;
+        var padMs = dataRangeMs > 0 ? dataRangeMs * 0.25 : 0;
+        var axisMinMs = dataMinMs - padMs;
+        var axisMaxMs = dataMaxMs + padMs;
         var minU = DurationFormatter.ToUnit(axisMinMs, unit);
         var maxU = DurationFormatter.ToUnit(axisMaxMs, unit);
         var spanU = maxU - minU;

--- a/source/Sailfish/Presentation/BoxPlotSvgRenderer.cs
+++ b/source/Sailfish/Presentation/BoxPlotSvgRenderer.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Renders <see cref="BoxPlotSeries"/> as a self-contained inline <c>&lt;svg&gt;</c> box-and-whisker
+/// chart. Pure server-side — hand-rolled SVG rects/lines, no JavaScript or external libraries — exactly
+/// like <see cref="ScaleFishHtmlReportBuilder"/>, so the markup drops straight into an offline HTML file.
+/// As with the ASCII renderer, the axis is scaled to the cleaned min–max and removed-outlier counts are
+/// noted in the row label rather than stretching the axis.
+/// </summary>
+public static class BoxPlotSvgRenderer
+{
+    private const int LabelWidth = 160;
+    private const int PadRight = 24;
+    private const int PadTop = 30;
+    private const int RowHeight = 38;
+    private const int AxisHeight = 52;
+
+    /// <summary>
+    /// Renders the supplied series to an <c>&lt;svg&gt;</c> string. Returns an empty string when there
+    /// is nothing finite to draw.
+    /// </summary>
+    public static string RenderSvg(IReadOnlyList<BoxPlotSeries> series, DurationUnit unit, int width = 720)
+    {
+        if (series is null) return string.Empty;
+
+        var drawable = series.Where(s => s is { IsEmpty: false }).ToList();
+        if (drawable.Count == 0) return string.Empty;
+
+        var axisValuesMs = drawable.SelectMany(s => new[] { s.Min, s.Max }).Where(double.IsFinite).ToList();
+        if (axisValuesMs.Count == 0) return string.Empty;
+
+        width = Math.Max(360, width);
+        var axisMinMs = axisValuesMs.Min();
+        var axisMaxMs = axisValuesMs.Max();
+        var minU = DurationFormatter.ToUnit(axisMinMs, unit);
+        var maxU = DurationFormatter.ToUnit(axisMaxMs, unit);
+        var spanU = maxU - minU;
+
+        var plotLeft = LabelWidth;
+        var plotRight = width - PadRight;
+        var plotW = plotRight - plotLeft;
+        var height = PadTop + drawable.Count * RowHeight + AxisHeight;
+
+        double XPix(double valueMs)
+        {
+            if (spanU <= 0) return plotLeft + plotW / 2.0;
+            var u = DurationFormatter.ToUnit(valueMs, unit);
+            var x = plotLeft + plotW * (u - minU) / spanU;
+            return Math.Clamp(x, plotLeft, plotRight);
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"<svg class=\"boxplot\" width=\"{width}\" height=\"{height}\" viewBox=\"0 0 {width} {height}\" xmlns=\"http://www.w3.org/2000/svg\">");
+
+        // Unit label, top-right.
+        sb.AppendLine($"<text class=\"bp-unit\" x=\"{plotRight}\" y=\"{PadTop - 12}\" text-anchor=\"end\">Time ({Escape(DurationFormatter.UnitLabel(unit))})</text>");
+
+        for (var i = 0; i < drawable.Count; i++)
+        {
+            AppendRow(sb, drawable[i], PadTop + i * RowHeight + RowHeight / 2, XPix);
+        }
+
+        AppendAxis(sb, plotLeft, plotRight, PadTop + drawable.Count * RowHeight + 10, axisMinMs, axisMaxMs, unit, spanU);
+
+        sb.AppendLine("</svg>");
+        return sb.ToString();
+    }
+
+    private static void AppendRow(StringBuilder sb, BoxPlotSeries s, double cy, Func<double, double> xPix)
+    {
+        var label = s.Label ?? string.Empty;
+        if (s.OutlierCount > 0) label += $" (+{s.OutlierCount} out)";
+        sb.AppendLine($"<text class=\"bp-label\" x=\"8\" y=\"{F2(cy + 4)}\">{Escape(label)} · n={s.N}</text>");
+
+        if (s.HasNoSpread)
+        {
+            sb.AppendLine($"<circle class=\"bp-mean\" cx=\"{F2(xPix(s.Median))}\" cy=\"{F2(cy)}\" r=\"3.5\"/>");
+            return;
+        }
+
+        var boxHeight = RowHeight * 0.46;
+        var boxTop = cy - boxHeight / 2;
+        var minX = xPix(s.Min);
+        var maxX = xPix(s.Max);
+        var q1X = xPix(s.Q1);
+        var q3X = xPix(s.Q3);
+        var medX = xPix(s.Median);
+        var meanX = xPix(s.Mean);
+        var capTop = cy - boxHeight * 0.3;
+        var capBottom = cy + boxHeight * 0.3;
+
+        // Whisker line + end caps.
+        sb.AppendLine($"<line class=\"bp-whisker\" x1=\"{F2(minX)}\" y1=\"{F2(cy)}\" x2=\"{F2(maxX)}\" y2=\"{F2(cy)}\"/>");
+        sb.AppendLine($"<line class=\"bp-whisker\" x1=\"{F2(minX)}\" y1=\"{F2(capTop)}\" x2=\"{F2(minX)}\" y2=\"{F2(capBottom)}\"/>");
+        sb.AppendLine($"<line class=\"bp-whisker\" x1=\"{F2(maxX)}\" y1=\"{F2(capTop)}\" x2=\"{F2(maxX)}\" y2=\"{F2(capBottom)}\"/>");
+
+        // IQR box.
+        sb.AppendLine($"<rect class=\"bp-box\" x=\"{F2(q1X)}\" y=\"{F2(boxTop)}\" width=\"{F2(Math.Max(1, q3X - q1X))}\" height=\"{F2(boxHeight)}\"/>");
+
+        // Median line.
+        sb.AppendLine($"<line class=\"bp-median\" x1=\"{F2(medX)}\" y1=\"{F2(boxTop)}\" x2=\"{F2(medX)}\" y2=\"{F2(boxTop + boxHeight)}\"/>");
+
+        // Mean marker.
+        sb.AppendLine($"<circle class=\"bp-mean\" cx=\"{F2(meanX)}\" cy=\"{F2(cy)}\" r=\"3.5\"/>");
+    }
+
+    private static void AppendAxis(StringBuilder sb, double left, double right, double y, double axisMinMs, double axisMaxMs, DurationUnit unit, double spanU)
+    {
+        sb.AppendLine($"<line class=\"bp-axis\" x1=\"{F2(left)}\" y1=\"{F2(y)}\" x2=\"{F2(right)}\" y2=\"{F2(y)}\"/>");
+
+        var decimals = spanU >= 100 ? 0 : spanU >= 10 ? 1 : spanU >= 1 ? 2 : 3;
+        const int ticks = 5;
+        for (var i = 0; i < ticks; i++)
+        {
+            var fraction = i / (double)(ticks - 1);
+            var x = left + (right - left) * fraction;
+            var valueMs = axisMinMs + fraction * (axisMaxMs - axisMinMs);
+            sb.AppendLine($"<line class=\"bp-axis\" x1=\"{F2(x)}\" y1=\"{F2(y)}\" x2=\"{F2(x)}\" y2=\"{F2(y + 5)}\"/>");
+            sb.AppendLine($"<text class=\"bp-tick\" x=\"{F2(x)}\" y=\"{F2(y + 18)}\" text-anchor=\"middle\">{Escape(DurationFormatter.Format(valueMs, unit, decimals))}</text>");
+        }
+
+        // Legend.
+        sb.AppendLine($"<text class=\"bp-legend\" x=\"8\" y=\"{F2(y + 18)}\">box = IQR · line = median · ● = mean</text>");
+    }
+
+    private static string F2(double v)
+    {
+        if (double.IsNaN(v)) return "0";
+        if (double.IsInfinity(v)) return "0";
+        return v.ToString("F2", CultureInfo.InvariantCulture);
+    }
+
+    private static string Escape(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return string.Empty;
+        return s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+    }
+}

--- a/source/Sailfish/Presentation/BoxPlotSvgRenderer.cs
+++ b/source/Sailfish/Presentation/BoxPlotSvgRenderer.cs
@@ -38,7 +38,7 @@ public static class BoxPlotSvgRenderer
         width = Math.Max(360, width);
 
         // Pad the axis by 1/4 of the data range each side so whiskers float in the central ~2/3 of the
-        // plot rather than always pinning to both edges (matches AsciiBoxPlotRenderer).
+        // plot rather than always pinning to both edges.
         var dataMinMs = axisValuesMs.Min();
         var dataMaxMs = axisValuesMs.Max();
         var dataRangeMs = dataMaxMs - dataMinMs;

--- a/source/Sailfish/Presentation/DistributionData.cs
+++ b/source/Sailfish/Presentation/DistributionData.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// One distribution to plot as a histogram row: a label, the in-range (outlier-removed) samples in
+/// <b>milliseconds</b>, the mean and median (also ms), and how many outliers were removed. The
+/// renderer derives n / min / max from <see cref="Samples"/>; mean and median are supplied because
+/// Sailfish (and SailDiff) already compute them.
+/// </summary>
+public sealed record DistributionData(
+    string Label,
+    IReadOnlyList<double> Samples,
+    double Mean,
+    double Median,
+    int OutlierCount)
+{
+    public bool IsEmpty => Samples is null || Samples.Count == 0;
+
+    /// <summary>
+    /// Builds a distribution from raw samples, filtering non-finite values and recomputing mean/median
+    /// from the samples when the supplied values are not finite.
+    /// </summary>
+    public static DistributionData FromSamples(string label, IReadOnlyList<double> samples, double mean, double median, int outlierCount)
+    {
+        var finite = (samples ?? Array.Empty<double>()).Where(double.IsFinite).ToArray();
+        if (finite.Length == 0)
+        {
+            return new DistributionData(label, finite, double.NaN, double.NaN, Math.Max(0, outlierCount));
+        }
+
+        var resolvedMean = double.IsFinite(mean) ? mean : finite.Average();
+        var resolvedMedian = double.IsFinite(median) ? median : ComputeMedian(finite);
+        return new DistributionData(label, finite, resolvedMean, resolvedMedian, Math.Max(0, outlierCount));
+    }
+
+    private static double ComputeMedian(double[] values)
+    {
+        var sorted = (double[])values.Clone();
+        Array.Sort(sorted);
+        var mid = sorted.Length / 2;
+        return sorted.Length % 2 == 0 ? (sorted[mid - 1] + sorted[mid]) / 2.0 : sorted[mid];
+    }
+}

--- a/source/Sailfish/Presentation/DistributionPlotRenderer.cs
+++ b/source/Sailfish/Presentation/DistributionPlotRenderer.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Which terminal/Markdown distribution visualization to render.
+/// </summary>
+public enum DistributionPlotStyle
+{
+    /// <summary>Compact shared-axis histograms (default).</summary>
+    Histogram = 0,
+
+    /// <summary>Horizontal box-and-whisker plots.</summary>
+    BoxPlot = 1
+}
+
+/// <summary>
+/// Single entry point for rendering distribution plots, dispatching to the configured
+/// <see cref="DistributionPlotStyle"/>. Callers describe each series once (label + raw in-range samples
+/// + mean/median + removed outliers) and this builds the renderer-specific model, so the style is
+/// chosen in one place rather than branched across every output surface.
+/// </summary>
+public static class DistributionPlotRenderer
+{
+    private const int DefaultWidth = 60;
+
+    /// <summary>One distribution to render: raw in-range samples (ms) plus its statistics.</summary>
+    public readonly record struct Series(
+        string Label,
+        IReadOnlyList<double> Samples,
+        double Mean,
+        double Median,
+        IReadOnlyList<double>? Outliers);
+
+    /// <summary>
+    /// Renders the supplied series in the requested style. Returns an empty string when there is
+    /// nothing to draw.
+    /// </summary>
+    public static string Render(IReadOnlyList<Series> series, DurationUnit unit, DistributionPlotStyle style, int width = DefaultWidth)
+    {
+        if (series is null || series.Count == 0) return string.Empty;
+
+        return style == DistributionPlotStyle.BoxPlot
+            ? AsciiBoxPlotRenderer.Render(
+                series.Select(s => BoxPlotData.FromSamples(s.Label, s.Samples, s.Mean, s.Outliers)).ToList(),
+                unit,
+                width)
+            : AsciiHistogramRenderer.Render(
+                series.Select(s => DistributionData.FromSamples(s.Label, s.Samples, s.Mean, s.Median, s.Outliers?.Count ?? 0)).ToList(),
+                unit,
+                plotWidth: width);
+    }
+}

--- a/source/Sailfish/Presentation/MarkdownTableConverter.cs
+++ b/source/Sailfish/Presentation/MarkdownTableConverter.cs
@@ -267,8 +267,8 @@ public class MarkdownTableConverter : IMarkdownTableConverter
         }
     }
 
-    // Renders one box-and-whisker per method in the group, fenced so monospace alignment survives
-    // Markdown rendering. Gated by IRunSettings.EnableDistributionPlots (default on).
+    // Renders a shared-axis histogram (one row per method in the group), fenced so monospace alignment
+    // survives Markdown rendering. Gated by IRunSettings.EnableDistributionPlots (default on).
     private void AppendGroupDistributionPlot(IReadOnlyList<ICompiledTestCaseResult> groupResults, DurationUnit unit, StringBuilder stringBuilder)
     {
         if (!(_runSettings?.EnableDistributionPlots ?? true)) return;
@@ -278,15 +278,17 @@ public class MarkdownTableConverter : IMarkdownTableConverter
             .Select(r =>
             {
                 var pr = r.PerformanceRunResult!;
-                return BoxPlotData.FromSamples(
+                return new DistributionPlotRenderer.Series(
                     r.TestCaseId!.DisplayName,
                     pr.DataWithOutliersRemoved,
                     pr.Mean,
+                    pr.Median,
                     pr.UpperOutliers.Concat(pr.LowerOutliers).ToArray());
             })
             .ToList();
 
-        var plot = AsciiBoxPlotRenderer.Render(series, unit);
+        var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+        var plot = DistributionPlotRenderer.Render(series, unit, style);
         if (string.IsNullOrEmpty(plot)) return;
 
         stringBuilder.AppendLine("**Distribution**");

--- a/source/Sailfish/Presentation/MarkdownTableConverter.cs
+++ b/source/Sailfish/Presentation/MarkdownTableConverter.cs
@@ -29,6 +29,7 @@ public class MarkdownTableConverter : IMarkdownTableConverter
 {
     private readonly ISailDiffUnifiedFormatter? _unifiedFormatter;
     private readonly IReproducibilityManifestProvider? _manifestProvider;
+    private readonly IRunSettings? _runSettings;
 
 
     public MarkdownTableConverter()
@@ -36,18 +37,23 @@ public class MarkdownTableConverter : IMarkdownTableConverter
         // Default constructor for backward compatibility
         _unifiedFormatter = null;
         _manifestProvider = null;
+        _runSettings = null;
     }
 
     public MarkdownTableConverter(ISailDiffUnifiedFormatter unifiedFormatter)
     {
         _unifiedFormatter = unifiedFormatter ?? throw new ArgumentNullException(nameof(unifiedFormatter));
         _manifestProvider = null;
+        _runSettings = null;
     }
 
-    public MarkdownTableConverter(ISailDiffUnifiedFormatter unifiedFormatter, IReproducibilityManifestProvider manifestProvider)
+    // IRunSettings is optional so existing callers/tests keep working; DI injects the registered
+    // instance and uses it to gate the inline distribution plots.
+    public MarkdownTableConverter(ISailDiffUnifiedFormatter unifiedFormatter, IReproducibilityManifestProvider manifestProvider, IRunSettings? runSettings = null)
     {
         _unifiedFormatter = unifiedFormatter ?? throw new ArgumentNullException(nameof(unifiedFormatter));
         _manifestProvider = manifestProvider ?? throw new ArgumentNullException(nameof(manifestProvider));
+        _runSettings = runSettings;
     }
 
     // Decimals to show within the auto-selected time unit (e.g. "1.100 µs").
@@ -189,7 +195,7 @@ public class MarkdownTableConverter : IMarkdownTableConverter
         return stringBuilder.ToString();
     }
 
-    private static void AppendEnhancedResults(string typeName, IEnumerable<ICompiledTestCaseResult> compiledResults, StringBuilder stringBuilder)
+    private void AppendEnhancedResults(string typeName, IEnumerable<ICompiledTestCaseResult> compiledResults, StringBuilder stringBuilder)
     {
         stringBuilder.AppendLine($"## 🧪 {typeName}");
         stringBuilder.AppendLine();
@@ -242,6 +248,9 @@ public class MarkdownTableConverter : IMarkdownTableConverter
             }
             stringBuilder.AppendLine();
 
+            // Box-and-whisker plot of every method in the group on a shared axis (same unit as the table)
+            AppendGroupDistributionPlot(groupResults, unit, stringBuilder);
+
             // Append statistical validation warnings (if any)
             foreach (var r in groupResults.Where(gr => gr.PerformanceRunResult?.Validation?.HasWarnings == true))
             {
@@ -256,6 +265,36 @@ public class MarkdownTableConverter : IMarkdownTableConverter
             }
 
         }
+    }
+
+    // Renders one box-and-whisker per method in the group, fenced so monospace alignment survives
+    // Markdown rendering. Gated by IRunSettings.EnableDistributionPlots (default on).
+    private void AppendGroupDistributionPlot(IReadOnlyList<ICompiledTestCaseResult> groupResults, DurationUnit unit, StringBuilder stringBuilder)
+    {
+        if (!(_runSettings?.EnableDistributionPlots ?? true)) return;
+
+        var series = groupResults
+            .Where(r => r.PerformanceRunResult is { } pr && pr.DataWithOutliersRemoved.Length > 0)
+            .Select(r =>
+            {
+                var pr = r.PerformanceRunResult!;
+                return BoxPlotData.FromSamples(
+                    r.TestCaseId!.DisplayName,
+                    pr.DataWithOutliersRemoved,
+                    pr.Mean,
+                    pr.UpperOutliers.Concat(pr.LowerOutliers).ToArray());
+            })
+            .ToList();
+
+        var plot = AsciiBoxPlotRenderer.Render(series, unit);
+        if (string.IsNullOrEmpty(plot)) return;
+
+        stringBuilder.AppendLine("**Distribution**");
+        stringBuilder.AppendLine();
+        stringBuilder.AppendLine("```text");
+        stringBuilder.Append(plot);
+        stringBuilder.AppendLine("```");
+        stringBuilder.AppendLine();
     }
 
     private static string CreatePerformanceSummary(List<ICompiledTestCaseResult> groupResults)

--- a/source/Sailfish/Presentation/NiceAxis.cs
+++ b/source/Sailfish/Presentation/NiceAxis.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Result of a "nice number" axis computation: rounded bounds, tick step, the tick values, and the
+/// number of decimals to format labels with.
+/// </summary>
+public readonly record struct NiceAxisResult(double Min, double Max, double Step, IReadOnlyList<double> Ticks, int Decimals);
+
+/// <summary>
+/// Produces human-friendly axis bounds and tick marks (Heckbert's "nice numbers for graph labels").
+/// Given the observed data range it rounds outward to pleasant round numbers (…, 0.2, 0.5, 1, 2, 5, …)
+/// so axis labels read like <c>50.6, 50.8, 51.0</c> rather than <c>50.649, 50.811, …</c>.
+/// </summary>
+public static class NiceAxis
+{
+    /// <summary>
+    /// Computes a nice axis covering <paramref name="dataMin"/>..<paramref name="dataMax"/> with about
+    /// <paramref name="maxTicks"/> ticks (including both endpoints). Degenerate ranges (identical or
+    /// non-finite values) expand to a small sensible window centred on the value.
+    /// </summary>
+    public static NiceAxisResult Compute(double dataMin, double dataMax, int maxTicks = 5)
+    {
+        if (!double.IsFinite(dataMin) || !double.IsFinite(dataMax))
+        {
+            dataMin = 0;
+            dataMax = 1;
+        }
+
+        if (dataMax < dataMin) (dataMin, dataMax) = (dataMax, dataMin);
+
+        maxTicks = Math.Max(2, maxTicks);
+
+        // Identical / near-zero span: build a small symmetric window around the value so the spike
+        // lands in the middle of a readable axis instead of dividing by zero.
+        if (dataMax - dataMin <= 0)
+        {
+            var centre = dataMin;
+            var magnitude = Math.Abs(centre);
+            var pad = magnitude > 0 ? NiceNum(magnitude * 0.05, round: true) : 1.0;
+            if (pad <= 0) pad = 1.0;
+            dataMin = centre - pad;
+            dataMax = centre + pad;
+        }
+
+        var range = NiceNum(dataMax - dataMin, round: false);
+        var step = NiceNum(range / (maxTicks - 1), round: true);
+        if (step <= 0) step = 1.0;
+
+        var niceMin = Math.Floor(dataMin / step) * step;
+        var niceMax = Math.Ceiling(dataMax / step) * step;
+        var decimals = DecimalsForStep(step);
+
+        var ticks = new List<double>();
+        // The +0.5*step guard absorbs floating-point drift so the final tick isn't dropped.
+        for (var value = niceMin; value <= niceMax + step * 0.5; value += step)
+        {
+            ticks.Add(Math.Round(value, 10));
+        }
+
+        return new NiceAxisResult(Math.Round(niceMin, 10), Math.Round(niceMax, 10), step, ticks, decimals);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="x"/> to a "nice" number. When <paramref name="round"/> is true it rounds
+    /// to the nearest of {1,2,5}·10ⁿ; otherwise it rounds up (used for the overall range).
+    /// </summary>
+    private static double NiceNum(double x, bool round)
+    {
+        if (x <= 0) return 0;
+        var exponent = Math.Floor(Math.Log10(x));
+        var fraction = x / Math.Pow(10, exponent);
+
+        double niceFraction;
+        if (round)
+            niceFraction = fraction < 1.5 ? 1 : fraction < 3 ? 2 : fraction < 7 ? 5 : 10;
+        else
+            niceFraction = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10;
+
+        return niceFraction * Math.Pow(10, exponent);
+    }
+
+    private static int DecimalsForStep(double step)
+    {
+        if (step >= 1) return 0;
+        // e.g. step 0.2 -> 1 decimal, 0.05 -> 2. The tiny epsilon keeps clean powers of ten honest.
+        var decimals = (int)Math.Ceiling(-Math.Log10(step) - 1e-9);
+        return Math.Clamp(decimals, 0, 6);
+    }
+}

--- a/source/Sailfish/Presentation/PerformanceDistributionHtmlReportBuilder.cs
+++ b/source/Sailfish/Presentation/PerformanceDistributionHtmlReportBuilder.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+
+namespace Sailfish.Presentation;
+
+/// <summary>
+/// Renders a standalone HTML report of box-and-whisker distribution plots for a run — one chart per
+/// comparison group (or per class when there are no groups). Pure server-side inline SVG + CSS with no
+/// external dependencies, mirroring <see cref="ScaleFishHtmlReportBuilder"/>, so the file opens offline
+/// and embeds cleanly in a PR.
+/// </summary>
+public static class PerformanceDistributionHtmlReportBuilder
+{
+    private const int SvgWidth = 760;
+
+    /// <summary>
+    /// Builds the HTML document. Returns an empty string when there is nothing plottable, so callers can
+    /// skip writing a file.
+    /// </summary>
+    public static string Build(IReadOnlyList<IClassExecutionSummary> summaries)
+    {
+        if (summaries is null || summaries.Count == 0) return string.Empty;
+
+        var body = new System.Text.StringBuilder();
+        var anyChart = false;
+
+        foreach (var summary in summaries)
+        {
+            var className = summary.TestClass?.Name ?? "(unknown)";
+            var classResults = summary.CompiledTestCaseResults
+                .Where(r => r.PerformanceRunResult is { } pr && pr.DataWithOutliersRemoved.Length > 0)
+                .ToList();
+            if (classResults.Count == 0) continue;
+
+            var classBody = new System.Text.StringBuilder();
+            foreach (var group in classResults.GroupBy(r => r.GroupingId))
+            {
+                var series = group
+                    .Select(r =>
+                    {
+                        var pr = r.PerformanceRunResult!;
+                        return BoxPlotData.FromSamples(
+                            r.TestCaseId!.DisplayName,
+                            pr.DataWithOutliersRemoved,
+                            pr.Mean,
+                            pr.UpperOutliers.Concat(pr.LowerOutliers).ToArray());
+                    })
+                    .Where(s => !s.IsEmpty)
+                    .ToList();
+                if (series.Count == 0) continue;
+
+                var unit = DurationFormatter.SelectUnit(series.SelectMany(s => new[] { s.Min, s.Max }));
+                var svg = BoxPlotSvgRenderer.RenderSvg(series, unit, SvgWidth);
+                if (string.IsNullOrEmpty(svg)) continue;
+
+                if (!string.IsNullOrEmpty(group.Key))
+                {
+                    classBody.AppendLine($"<h3>{Escape(group.Key!)}</h3>");
+                }
+
+                classBody.AppendLine("<div class=\"chart\">");
+                classBody.AppendLine(svg);
+                classBody.AppendLine("</div>");
+                anyChart = true;
+            }
+
+            if (classBody.Length > 0)
+            {
+                body.AppendLine($"<h2>{Escape(className)}</h2>");
+                body.Append(classBody);
+            }
+        }
+
+        if (!anyChart) return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("<!doctype html>");
+        sb.AppendLine("<html lang=\"en\"><head>");
+        sb.AppendLine("<meta charset=\"utf-8\">");
+        sb.AppendLine("<title>Sailfish Distribution Report</title>");
+        AppendStyles(sb);
+        sb.AppendLine("</head><body>");
+        sb.AppendLine("<h1>Sailfish distribution report</h1>");
+        sb.AppendLine($"<p class=\"meta\">Generated {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC</p>");
+        sb.Append(body);
+        sb.AppendLine("</body></html>");
+        return sb.ToString();
+    }
+
+    private static void AppendStyles(System.Text.StringBuilder sb)
+    {
+        sb.AppendLine("<style>");
+        sb.AppendLine("body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 980px; margin: 2em auto; color: #1a1a1a; padding: 0 1em; }");
+        sb.AppendLine("h1 { border-bottom: 2px solid #333; padding-bottom: .3em; }");
+        sb.AppendLine("h2 { color: #2a4d8f; margin-top: 1.4em; }");
+        sb.AppendLine("h3 { color: #444; }");
+        sb.AppendLine(".meta { color: #777; font-size: .9em; }");
+        sb.AppendLine(".chart { border: 1px solid #e0e0e0; border-radius: 6px; padding: .5em; margin: 1em 0; background: #fafafa; }");
+        sb.AppendLine("svg.boxplot { background: white; }");
+        sb.AppendLine(".bp-label { font-size: 12px; fill: #333; font-family: ui-monospace, monospace; }");
+        sb.AppendLine(".bp-unit { font-size: 11px; fill: #777; }");
+        sb.AppendLine(".bp-tick { font-size: 10px; fill: #555; }");
+        sb.AppendLine(".bp-legend { font-size: 10px; fill: #777; }");
+        sb.AppendLine(".bp-whisker { stroke: #555; stroke-width: 1.5; }");
+        sb.AppendLine(".bp-box { fill: #cfe0f7; stroke: #2a4d8f; stroke-width: 1.5; }");
+        sb.AppendLine(".bp-median { stroke: #1a1a1a; stroke-width: 2; }");
+        sb.AppendLine(".bp-mean { fill: #c0392b; }");
+        sb.AppendLine(".bp-axis { stroke: #999; stroke-width: 1; }");
+        sb.AppendLine("</style>");
+    }
+
+    private static string Escape(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return string.Empty;
+        return s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+    }
+}

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -95,6 +95,7 @@ internal static class SailfishModuleRegistrations
         services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IImpactSummaryFormatter, Sailfish.Analysis.SailDiff.Formatting.ImpactSummaryFormatter>();
         services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IDetailedTableFormatter, Sailfish.Analysis.SailDiff.Formatting.DetailedTableFormatter>();
         services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IOutputContextAdapter, Sailfish.Analysis.SailDiff.Formatting.OutputContextAdapter>();
+        services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.IDistributionPlotFormatter, Sailfish.Analysis.SailDiff.Formatting.DistributionPlotFormatter>();
         services.AddTransient<Sailfish.Analysis.SailDiff.Formatting.ISailDiffUnifiedFormatter, Sailfish.Analysis.SailDiff.Formatting.SailDiffUnifiedFormatter>();
 
         services.AddTransient<ISailDiffResultMarkdownConverter, SailDiffResultMarkdownConverter>();

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -47,7 +47,8 @@ internal class RunSettings : IRunSettings
         int? seed = null,
         ScaleFishSettings? scaleFishSettings = null,
         bool enableDistributionPlots = true,
-        bool emitDistributionHtmlReport = false)
+        bool emitDistributionHtmlReport = false,
+        DistributionPlotStyle distributionPlotStyle = DistributionPlotStyle.Histogram)
     {
         TestNames = testNames;
         LocalOutputDirectory = localOutputDirectory;
@@ -82,6 +83,7 @@ internal class RunSettings : IRunSettings
         TimerCalibration = timerCalibration;
         EnableDistributionPlots = enableDistributionPlots;
         EmitDistributionHtmlReport = emitDistributionHtmlReport;
+        DistributionPlotStyle = distributionPlotStyle;
         MinimumLogLevel = minimumLogLevel;
     }
 
@@ -120,6 +122,7 @@ internal class RunSettings : IRunSettings
     public bool TimerCalibration { get; }
     public bool EnableDistributionPlots { get; }
     public bool EmitDistributionHtmlReport { get; }
+    public DistributionPlotStyle DistributionPlotStyle { get; }
 
     public LogLevel MinimumLogLevel { get; }
 

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -45,7 +45,9 @@ internal class RunSettings : IRunSettings
         bool enableEnvironmentHealthCheck = true,
         bool timerCalibration = true,
         int? seed = null,
-        ScaleFishSettings? scaleFishSettings = null)
+        ScaleFishSettings? scaleFishSettings = null,
+        bool enableDistributionPlots = true,
+        bool emitDistributionHtmlReport = false)
     {
         TestNames = testNames;
         LocalOutputDirectory = localOutputDirectory;
@@ -78,6 +80,8 @@ internal class RunSettings : IRunSettings
         CustomLogger = customLogger;
         EnableEnvironmentHealthCheck = enableEnvironmentHealthCheck;
         TimerCalibration = timerCalibration;
+        EnableDistributionPlots = enableDistributionPlots;
+        EmitDistributionHtmlReport = emitDistributionHtmlReport;
         MinimumLogLevel = minimumLogLevel;
     }
 
@@ -114,6 +118,8 @@ internal class RunSettings : IRunSettings
     public ILogger? CustomLogger { get; }
     public bool EnableEnvironmentHealthCheck { get; }
     public bool TimerCalibration { get; }
+    public bool EnableDistributionPlots { get; }
+    public bool EmitDistributionHtmlReport { get; }
 
     public LogLevel MinimumLogLevel { get; }
 

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -39,6 +39,9 @@ public class RunSettingsBuilder
     private bool _enableEnvironmentHealthCheck = true;
     private bool _timerCalibration = true;
 
+    private bool _enableDistributionPlots = true;
+    private bool _emitDistributionHtmlReport;
+
 
     // Optional deterministic randomization seed for reproducible ordering
     private int? _seed;
@@ -112,6 +115,26 @@ public class RunSettingsBuilder
     public RunSettingsBuilder WithTimerCalibration(bool enable = true)
     {
         _timerCalibration = enable;
+        return this;
+    }
+
+    /// <summary>
+    ///     Enables or disables the inline Unicode box-and-whisker distribution plots that accompany the
+    ///     IDE/Markdown readouts (default: true).
+    /// </summary>
+    public RunSettingsBuilder WithDistributionPlots(bool enable = true)
+    {
+        _enableDistributionPlots = enable;
+        return this;
+    }
+
+    /// <summary>
+    ///     Enables emitting a standalone SVG distribution HTML report into the output directory
+    ///     (default: false), mirroring <see cref="WithScaleFish()"/>'s HTML report.
+    /// </summary>
+    public RunSettingsBuilder WithDistributionHtmlReport(bool emit = true)
+    {
+        _emitDistributionHtmlReport = emit;
         return this;
     }
 
@@ -358,7 +381,9 @@ public class RunSettingsBuilder
             _enableEnvironmentHealthCheck,
             _timerCalibration,
             seed: _seed,
-            scaleFishSettings: _sfSettings);
+            scaleFishSettings: _sfSettings,
+            enableDistributionPlots: _enableDistributionPlots,
+            emitDistributionHtmlReport: _emitDistributionHtmlReport);
     }
 
     private void ApplyPreset(SailfishPreset preset)

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -41,6 +41,7 @@ public class RunSettingsBuilder
 
     private bool _enableDistributionPlots = true;
     private bool _emitDistributionHtmlReport;
+    private DistributionPlotStyle _distributionPlotStyle = DistributionPlotStyle.Histogram;
 
 
     // Optional deterministic randomization seed for reproducible ordering
@@ -135,6 +136,16 @@ public class RunSettingsBuilder
     public RunSettingsBuilder WithDistributionHtmlReport(bool emit = true)
     {
         _emitDistributionHtmlReport = emit;
+        return this;
+    }
+
+    /// <summary>
+    ///     Selects the inline distribution plot style — <see cref="DistributionPlotStyle.Histogram"/>
+    ///     (default) or <see cref="DistributionPlotStyle.BoxPlot"/>.
+    /// </summary>
+    public RunSettingsBuilder WithDistributionPlotStyle(DistributionPlotStyle style)
+    {
+        _distributionPlotStyle = style;
         return this;
     }
 
@@ -383,7 +394,8 @@ public class RunSettingsBuilder
             seed: _seed,
             scaleFishSettings: _sfSettings,
             enableDistributionPlots: _enableDistributionPlots,
-            emitDistributionHtmlReport: _emitDistributionHtmlReport);
+            emitDistributionHtmlReport: _emitDistributionHtmlReport,
+            distributionPlotStyle: _distributionPlotStyle);
     }
 
     private void ApplyPreset(SailfishPreset preset)

--- a/source/Tests.Library/Analysis/SailDiff/Formatting/DistributionPlotFormatterTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Formatting/DistributionPlotFormatterTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using Sailfish.Analysis.SailDiff.Formatting;
+using Sailfish.Contracts.Public.Models;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff.Formatting;
+
+public class DistributionPlotFormatterTests
+{
+    private readonly DistributionPlotFormatter _formatter = new();
+
+    private static SailDiffComparisonData CreateComparison(
+        string primary = "Primary",
+        string compared = "Compared",
+        bool includePlot = true)
+    {
+        return new SailDiffComparisonData
+        {
+            GroupName = "Grp",
+            PrimaryMethodName = primary,
+            ComparedMethodName = compared,
+            Statistics = new StatisticalTestResult(
+                meanBefore: 2.0, meanAfter: 4.0,
+                medianBefore: 2.0, medianAfter: 4.0,
+                testStatistic: 3.0, pValue: 0.001,
+                changeDescription: "Regressed",
+                sampleSizeBefore: 20, sampleSizeAfter: 20,
+                rawDataBefore: Enumerable.Range(0, 20).Select(i => 1.0 + i * 0.1).ToArray(),
+                rawDataAfter: Enumerable.Range(0, 20).Select(i => 3.0 + i * 0.2).ToArray(),
+                additionalResults: new Dictionary<string, object>()),
+            Metadata = new ComparisonMetadata { SampleSize = 20, AlphaLevel = 0.05, IncludeDistributionPlot = includePlot },
+            IsPerspectiveBased = false
+        };
+    }
+
+    [Fact]
+    public void CreatePlot_Ide_IncludesPlotHeaderBoxesAndBothMethods()
+    {
+        var output = _formatter.CreatePlot(CreateComparison(), OutputContext.Ide);
+
+        output.ShouldContain("📊 DISTRIBUTION");
+        output.ShouldContain("┃");        // median marker
+        output.ShouldContain("Primary");
+        output.ShouldContain("Compared");
+    }
+
+    [Fact]
+    public void CreatePlot_Markdown_WrapsInFencedCodeBlock()
+    {
+        var output = _formatter.CreatePlot(CreateComparison(), OutputContext.Markdown);
+
+        output.ShouldContain("**Distribution**");
+        output.ShouldContain("```text");
+        output.TrimEnd().ShouldEndWith("```");
+    }
+
+    [Fact]
+    public void CreatePlot_Csv_ReturnsEmpty()
+    {
+        _formatter.CreatePlot(CreateComparison(), OutputContext.Csv).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreatePlot_WhenMetadataDisablesPlot_ReturnsEmpty()
+    {
+        _formatter.CreatePlot(CreateComparison(includePlot: false), OutputContext.Ide).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreatePlot_WhenRunSettingsDisablePlots_ReturnsEmpty()
+    {
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.EnableDistributionPlots.Returns(false);
+        var formatter = new DistributionPlotFormatter(runSettings);
+
+        formatter.CreatePlot(CreateComparison(), OutputContext.Ide).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreatePlot_WhenStatisticsFailed_ReturnsEmpty()
+    {
+        var data = CreateComparison();
+        data.Statistics.Failed = true;
+
+        _formatter.CreatePlot(data, OutputContext.Ide).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreatePlot_MultipleComparisons_DrawsEachDistinctMethodOnce()
+    {
+        // Two comparisons sharing the same primary ("Tracked") => Tracked appears once, plus two others.
+        var comparisons = new[]
+        {
+            CreateComparison("Tracked", "NoTracking"),
+            CreateComparison("Tracked", "Projected")
+        };
+
+        var output = _formatter.CreatePlot(comparisons, OutputContext.Ide);
+
+        output.ShouldContain("Tracked");
+        output.ShouldContain("NoTracking");
+        output.ShouldContain("Projected");
+        // "Tracked" is rendered as a single lane (its label starts a line exactly once).
+        output.Split('\n').Count(l => l.TrimStart().StartsWith("Tracked ")).ShouldBe(1);
+    }
+
+    [Fact]
+    public void UnifiedFormatter_Format_EmbedsDistributionPlotInFullOutput()
+    {
+        var unified = SailDiffUnifiedFormatterFactory.Create();
+
+        var result = unified.Format(CreateComparison(), OutputContext.Ide);
+
+        result.DistributionPlot.ShouldContain("📊 DISTRIBUTION");
+        result.FullOutput.ShouldContain("📊 DISTRIBUTION");
+        result.FullOutput.ShouldContain("📊 PERFORMANCE COMPARISON"); // still has the existing block
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/Formatting/DistributionPlotFormatterTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Formatting/DistributionPlotFormatterTests.cs
@@ -37,12 +37,13 @@ public class DistributionPlotFormatterTests
     }
 
     [Fact]
-    public void CreatePlot_Ide_IncludesPlotHeaderBoxesAndBothMethods()
+    public void CreatePlot_Ide_IncludesPlotHeaderHistogramAndBothMethods()
     {
         var output = _formatter.CreatePlot(CreateComparison(), OutputContext.Ide);
 
         output.ShouldContain("📊 DISTRIBUTION");
-        output.ShouldContain("┃");        // median marker
+        output.ShouldContain("█");                 // histogram block glyph
+        output.ShouldContain("count per bin");      // legend
         output.ShouldContain("Primary");
         output.ShouldContain("Compared");
     }
@@ -103,8 +104,8 @@ public class DistributionPlotFormatterTests
         output.ShouldContain("Tracked");
         output.ShouldContain("NoTracking");
         output.ShouldContain("Projected");
-        // "Tracked" is rendered as a single lane (its label starts a line exactly once).
-        output.Split('\n').Count(l => l.TrimStart().StartsWith("Tracked ")).ShouldBe(1);
+        // "Tracked" is shared across both comparisons but de-duplicated to a single summary row.
+        output.Split('\n').Count(l => l.Contains("Tracked") && l.Contains("n=")).ShouldBe(1);
     }
 
     [Fact]

--- a/source/Tests.Library/Presentation/AsciiHistogramRendererTests.cs
+++ b/source/Tests.Library/Presentation/AsciiHistogramRendererTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Presentation;
+
+public class AsciiHistogramRendererTests
+{
+    private static DistributionData Dist(string label, IReadOnlyList<double> samples, int outliers = 0)
+        => DistributionData.FromSamples(label, samples, double.NaN, double.NaN, outliers);
+
+    // A unimodal-ish sample centred near `centre`.
+    private static double[] Cluster(double centre, double spread, int n)
+        => Enumerable.Range(0, n).Select(i => centre + spread * Math.Sin(i * 2.3)).ToArray();
+
+    [Fact]
+    public void Render_SingleDistribution_UsesHistogramGlyphsAndDropsOldBoxStyle()
+    {
+        var output = AsciiHistogramRenderer.Render(new[] { Dist("current", Cluster(51.0, 0.3, 200), 83) }, DurationUnit.Milliseconds);
+
+        output.IndexOfAny("▁▂▃▄▅▆▇█".ToCharArray()).ShouldBeGreaterThanOrEqualTo(0); // histogram glyphs present
+        output.ShouldContain("count per bin");
+        // Old inline box-plot glyphs must be gone.
+        output.ShouldNotContain("◆");
+        output.ShouldNotContain("┃");
+        output.ShouldNotContain("▓");
+    }
+
+    [Fact]
+    public void Render_TwoDistributions_ShareOneAxis()
+    {
+        var fast = Dist("fast run", Cluster(50.7, 0.15, 200));
+        var slow = Dist("slow run", Cluster(51.2, 0.15, 200));
+
+        var output = AsciiHistogramRenderer.Render(new[] { fast, slow }, DurationUnit.Milliseconds);
+
+        output.ShouldContain("fast run");
+        output.ShouldContain("slow run");
+        // Exactly one shared axis line (the line carrying the left cap).
+        output.Split('\n').Count(l => l.Contains('├')).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Render_FourDistributions_AlignHistogramRegion()
+    {
+        var dists = new[]
+        {
+            Dist("cold start", Cluster(50.85, 0.12, 200), 83),
+            Dist("warm start", Cluster(50.95, 0.10, 200), 22),
+            Dist("cached", Cluster(50.92, 0.08, 200), 10),
+            Dist("loaded system", Cluster(51.15, 0.10, 200), 91),
+        };
+
+        var output = AsciiHistogramRenderer.Render(dists, DurationUnit.Milliseconds);
+        var summaryLines = output.Split('\n').Where(l => l.Contains("n=")).ToList();
+
+        summaryLines.Count.ShouldBe(4);
+        // Labels are padded to a common width, so "n=" starts in the same column on every summary row.
+        summaryLines.Select(l => l.IndexOf("n=", StringComparison.Ordinal)).Distinct().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public void Render_SummaryReportsExactMinMaxAndOutlierCount()
+    {
+        var samples = new[] { 50.649, 50.8, 51.0, 51.2, 51.310 };
+        var output = AsciiHistogramRenderer.Render(new[] { Dist("m", samples, 83) }, DurationUnit.Milliseconds);
+
+        output.ShouldContain("outliers=83");
+        output.ShouldContain("min=50.649");
+        output.ShouldContain("max=51.310");
+    }
+
+    [Fact]
+    public void Render_UsesRoundedAxisTicks_NotRawValues()
+    {
+        var samples = new[] { 50.649, 50.811, 50.973, 51.148, 51.310 };
+        var output = AsciiHistogramRenderer.Render(new[] { Dist("m", samples) }, DurationUnit.Milliseconds);
+
+        output.ShouldContain("51.0");      // a rounded interior tick
+        output.ShouldContain("50.6");      // rounded endpoint
+        // raw values appear only in the summary line, never as an axis tick label
+        var axisAndTickLines = output.Split('\n').Where(l => l.Contains('├') || (l.Contains('.') && !l.Contains("n="))).ToList();
+        axisAndTickLines.Any(l => l.Contains("50.973")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Render_RightSkewed_ShowsSeparateMeanAndMedianMarkers()
+    {
+        // Many low values + a few high ones => mean noticeably greater than median.
+        var samples = Enumerable.Repeat(1.0, 80).Concat(Enumerable.Repeat(9.0, 20)).ToArray();
+        var output = AsciiHistogramRenderer.Render(new[] { Dist("skew", samples) }, DurationUnit.Milliseconds);
+
+        output.ShouldContain("╵"); // mean
+        output.ShouldContain("╿"); // median
+    }
+
+    [Fact]
+    public void Render_EmptyInput_ReturnsEmpty()
+    {
+        AsciiHistogramRenderer.Render(Array.Empty<DistributionData>(), DurationUnit.Milliseconds).ShouldBeEmpty();
+        AsciiHistogramRenderer.Render(new[] { Dist("x", Array.Empty<double>()) }, DurationUnit.Milliseconds).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_IdenticalValues_ProducesCentredSpikeWithoutCrashing()
+    {
+        var output = AsciiHistogramRenderer.Render(new[] { Dist("flat", Enumerable.Repeat(51.0, 50).ToArray()) }, DurationUnit.Milliseconds);
+
+        output.ShouldNotBeNullOrEmpty();
+        output.ShouldContain("█");          // a full-height spike
+        output.ShouldContain("min=51.000");
+        output.ShouldContain("max=51.000");
+    }
+
+    [Fact]
+    public void Render_SubMillisecondData_AutoScalesAxisUnit()
+    {
+        var samples = Enumerable.Range(0, 60).Select(i => 0.0010 + i * 0.00001).ToArray();
+        var unit = DurationFormatter.SelectUnit(samples);
+        var output = AsciiHistogramRenderer.Render(new[] { Dist("fast", samples) }, unit);
+
+        unit.ShouldBe(DurationUnit.Microseconds);
+        output.ShouldContain("Time (µs)");
+    }
+
+    [Fact]
+    public void Render_LongLabel_IsTruncatedAndAlignmentHolds()
+    {
+        var dists = new[]
+        {
+            Dist("a", Cluster(51.0, 0.2, 100)),
+            Dist("a-really-long-distribution-name-that-overflows", Cluster(51.1, 0.2, 100)),
+        };
+
+        var output = AsciiHistogramRenderer.Render(dists, DurationUnit.Milliseconds);
+        var summaryLines = output.Split('\n').Where(l => l.Contains("n=")).ToList();
+
+        summaryLines.Count.ShouldBe(2);
+        summaryLines.Select(l => l.IndexOf("n=", StringComparison.Ordinal)).Distinct().Count().ShouldBe(1);
+    }
+}

--- a/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
+++ b/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
@@ -141,6 +141,20 @@ public class BoxPlotRendererTests
     }
 
     [Fact]
+    public void Render_PadsAxisSoWhiskersDoNotPinToEdges()
+    {
+        var series = BoxPlotData.FromSamples("M", Ramp(40), mean: 20.5);
+        var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds, width: 60);
+
+        var rulerLine = output.Split('\n').First(l => l.Contains('└'));
+        var laneLine = output.Split('\n').First(l => l.Contains('├'));
+
+        // The axis ruler (└────┘) spans the full width; the data whiskers (├──┤) must sit inside it.
+        laneLine.IndexOf('├').ShouldBeGreaterThan(rulerLine.IndexOf('└'));
+        laneLine.IndexOf('┤').ShouldBeLessThan(rulerLine.IndexOf('┘'));
+    }
+
+    [Fact]
     public void Render_RespectsRequestedWidth()
     {
         var series = BoxPlotData.FromSamples("x", Ramp(20), mean: 10.5);

--- a/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
+++ b/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
@@ -73,7 +73,7 @@ public class BoxPlotRendererTests
 
         output.ShouldContain("┃");   // median
         output.ShouldContain("◆");   // mean
-        output.ShouldContain("▒");   // IQR box
+        output.ShouldContain("▓");   // IQR box
         output.ShouldContain("Time (ms)");
         output.ShouldContain("median"); // legend
         output.ShouldContain("n=20");
@@ -148,7 +148,7 @@ public class BoxPlotRendererTests
 
         var laneLine = output.Split('\n').First(l => l.Contains("n=20"));
         // label("x"=>1) + 2 spaces + 30 lane + "  n=20"
-        laneLine.ShouldContain(new string('▒', 1)); // some box drawn
+        laneLine.ShouldContain(new string('▓', 1)); // some box drawn
         laneLine.Length.ShouldBeGreaterThan(30);
     }
 

--- a/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
+++ b/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Linq;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Presentation;
+
+public class BoxPlotRendererTests
+{
+    private static double[] Ramp(int n, double start = 1.0, double step = 1.0)
+        => Enumerable.Range(0, n).Select(i => start + i * step).ToArray();
+
+    #region BoxPlotData
+
+    [Fact]
+    public void FromSamples_ComputesFiveNumberSummary()
+    {
+        var data = Ramp(9); // 1..9, median 5, quartiles 3 and 7
+        var series = BoxPlotData.FromSamples("x", data, mean: 5.0);
+
+        series.N.ShouldBe(9);
+        series.Min.ShouldBe(1.0);
+        series.Max.ShouldBe(9.0);
+        series.Median.ShouldBe(5.0);
+        series.Q1.ShouldBeLessThan(series.Median);
+        series.Q3.ShouldBeGreaterThan(series.Median);
+    }
+
+    [Fact]
+    public void FromSamples_FiltersNonFiniteValues()
+    {
+        var data = new[] { 1.0, double.NaN, 2.0, double.PositiveInfinity, 3.0 };
+        var series = BoxPlotData.FromSamples("x", data, mean: 2.0);
+
+        series.N.ShouldBe(3);
+        series.Min.ShouldBe(1.0);
+        series.Max.ShouldBe(3.0);
+    }
+
+    [Fact]
+    public void FromSamples_EmptyInput_ProducesEmptySeries()
+    {
+        var series = BoxPlotData.FromSamples("x", Array.Empty<double>(), mean: double.NaN);
+        series.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FromSamples_SingleValue_HasNoSpread()
+    {
+        var series = BoxPlotData.FromSamples("x", new[] { 4.2 }, mean: 4.2);
+        series.N.ShouldBe(1);
+        series.HasNoSpread.ShouldBeTrue();
+        series.Median.ShouldBe(4.2);
+    }
+
+    [Fact]
+    public void FromSamples_RecomputesMeanWhenNonFinite()
+    {
+        var series = BoxPlotData.FromSamples("x", new[] { 2.0, 4.0 }, mean: double.NaN);
+        series.Mean.ShouldBe(3.0);
+    }
+
+    #endregion
+
+    #region AsciiBoxPlotRenderer
+
+    [Fact]
+    public void Render_SingleSeries_DrawsBoxMedianMeanAndLegend()
+    {
+        var series = BoxPlotData.FromSamples("Method", Ramp(20), mean: 10.5);
+        var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds);
+
+        output.ShouldContain("┃");   // median
+        output.ShouldContain("◆");   // mean
+        output.ShouldContain("▒");   // IQR box
+        output.ShouldContain("Time (ms)");
+        output.ShouldContain("median"); // legend
+        output.ShouldContain("n=20");
+    }
+
+    [Fact]
+    public void Render_TwoSeries_ShareAxisAndAlignLanes()
+    {
+        var primary = BoxPlotData.FromSamples("Tracked", Ramp(30, 1.0, 0.1), mean: 2.5);
+        var compared = BoxPlotData.FromSamples("Projected", Ramp(30, 5.0, 0.3), mean: 9.0);
+
+        var output = AsciiBoxPlotRenderer.Render(new[] { primary, compared }, DurationUnit.Milliseconds);
+
+        var laneLines = output
+            .Split('\n')
+            .Where(l => l.Contains("n=")) // series lanes are suffixed with the sample count
+            .ToList();
+
+        laneLines.Count.ShouldBe(2);
+        // Lanes share the same total width (labels are padded to equal length).
+        laneLines.Select(l => l.Length).Distinct().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public void Render_AnnotatesRemovedOutlierCountWithoutStretchingAxis()
+    {
+        var series = BoxPlotData.FromSamples("x", Ramp(20), mean: 10.5, removedOutliers: new[] { 40.0, 50.0 });
+        var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds);
+
+        output.ShouldContain("(+2 outliers)");
+        // The far outliers (40, 50) must not appear on the axis — it stays scaled to the cleaned 1..20.
+        output.ShouldNotContain("50.0");
+    }
+
+    [Fact]
+    public void Render_AllEqualValues_RendersSingleMarkerWithoutCrashing()
+    {
+        var series = BoxPlotData.FromSamples("flat", new[] { 3.0, 3.0, 3.0, 3.0 }, mean: 3.0);
+        var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds);
+
+        output.ShouldNotBeNullOrEmpty();
+        output.ShouldContain("◆");
+    }
+
+    [Fact]
+    public void Render_EmptySeries_ReturnsEmptyString()
+    {
+        var empty = BoxPlotData.FromSamples("x", Array.Empty<double>(), mean: double.NaN);
+        AsciiBoxPlotRenderer.Render(new[] { empty }, DurationUnit.Milliseconds).ShouldBeEmpty();
+        AsciiBoxPlotRenderer.Render(Array.Empty<BoxPlotSeries>(), DurationUnit.Milliseconds).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_SubMillisecondData_AutoScalesAxisUnit()
+    {
+        // ~1–3 µs values (0.001–0.003 ms); the axis must render in microseconds, not "0.000 ms".
+        var samples = Enumerable.Range(0, 30).Select(i => 0.001 + i * 0.00005).ToArray();
+        var unit = DurationFormatter.SelectUnit(samples);
+        var series = BoxPlotData.FromSamples("fast", samples, mean: 0.0017);
+
+        var output = AsciiBoxPlotRenderer.Render(new[] { series }, unit);
+
+        unit.ShouldBe(DurationUnit.Microseconds);
+        output.ShouldContain("Time (µs)");
+    }
+
+    [Fact]
+    public void Render_RespectsRequestedWidth()
+    {
+        var series = BoxPlotData.FromSamples("x", Ramp(20), mean: 10.5);
+        var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds, width: 30);
+
+        var laneLine = output.Split('\n').First(l => l.Contains("n=20"));
+        // label("x"=>1) + 2 spaces + 30 lane + "  n=20"
+        laneLine.ShouldContain(new string('▒', 1)); // some box drawn
+        laneLine.Length.ShouldBeGreaterThan(30);
+    }
+
+    #endregion
+}

--- a/source/Tests.Library/Presentation/BoxPlotSvgTests.cs
+++ b/source/Tests.Library/Presentation/BoxPlotSvgTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Presentation;
+
+public class BoxPlotSvgTests
+{
+    private static double[] Ramp(int n, double start = 1.0, double step = 1.0)
+        => Enumerable.Range(0, n).Select(i => start + i * step).ToArray();
+
+    #region BoxPlotSvgRenderer
+
+    [Fact]
+    public void RenderSvg_SingleSeries_EmitsSvgWithBoxMedianAndMean()
+    {
+        var series = BoxPlotData.FromSamples("Method", Ramp(20), mean: 10.5);
+        var svg = BoxPlotSvgRenderer.RenderSvg(new[] { series }, DurationUnit.Milliseconds);
+
+        svg.ShouldStartWith("<svg");
+        svg.ShouldContain("class=\"bp-box\"");
+        svg.ShouldContain("class=\"bp-median\"");
+        svg.ShouldContain("class=\"bp-mean\"");
+        svg.ShouldContain("</svg>");
+    }
+
+    [Fact]
+    public void RenderSvg_TwoSeries_EmitsOneBoxPerSeries()
+    {
+        var series = new[]
+        {
+            BoxPlotData.FromSamples("A", Ramp(20, 1.0, 0.1), mean: 2.0),
+            BoxPlotData.FromSamples("B", Ramp(20, 5.0, 0.2), mean: 7.0)
+        };
+
+        var svg = BoxPlotSvgRenderer.RenderSvg(series, DurationUnit.Milliseconds);
+
+        CountOccurrences(svg, "class=\"bp-box\"").ShouldBe(2);
+    }
+
+    [Fact]
+    public void RenderSvg_EscapesLabels()
+    {
+        var series = BoxPlotData.FromSamples("Evil<&>\"Name", Ramp(10), mean: 5.0);
+        var svg = BoxPlotSvgRenderer.RenderSvg(new[] { series }, DurationUnit.Milliseconds);
+
+        svg.ShouldContain("Evil&lt;&amp;&gt;&quot;Name");
+        svg.ShouldNotContain("Evil<&>");
+    }
+
+    [Fact]
+    public void RenderSvg_EmptySeries_ReturnsEmpty()
+    {
+        var empty = BoxPlotData.FromSamples("x", Array.Empty<double>(), mean: double.NaN);
+        BoxPlotSvgRenderer.RenderSvg(new[] { empty }, DurationUnit.Milliseconds).ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region PerformanceDistributionHtmlReportBuilder
+
+    [Fact]
+    public void Build_WithResults_ProducesHtmlDocumentWithSvgAndNames()
+    {
+        var summary = CreateSummary("MyBenchmarks",
+            ("LoadUserById", "GroupA", Ramp(20, 1.0, 0.1)),
+            ("LoadUserByEmail", "GroupA", Ramp(20, 2.0, 0.2)));
+
+        var html = PerformanceDistributionHtmlReportBuilder.Build(new[] { summary });
+
+        html.ShouldContain("<!doctype html>");
+        html.ShouldContain("<svg");
+        html.ShouldContain("MyBenchmarks");
+        html.ShouldContain("GroupA");
+        html.ShouldContain("LoadUserById");
+        html.ShouldContain("LoadUserByEmail");
+    }
+
+    [Fact]
+    public void Build_WithNoSummaries_ReturnsEmpty()
+    {
+        PerformanceDistributionHtmlReportBuilder.Build(Array.Empty<IClassExecutionSummary>()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Build_WithNoPlottableData_ReturnsEmpty()
+    {
+        var summary = CreateSummary("Empty", ("M", "G", Array.Empty<double>()));
+        PerformanceDistributionHtmlReportBuilder.Build(new[] { summary }).ShouldBeEmpty();
+    }
+
+    #endregion
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static IClassExecutionSummary CreateSummary(string className, params (string Display, string Group, double[] Data)[] cases)
+    {
+        var summary = Substitute.For<IClassExecutionSummary>();
+        var testClass = Substitute.For<Type>();
+        testClass.Name.Returns(className);
+        summary.TestClass.Returns(testClass);
+
+        var results = cases.Select(c =>
+        {
+            var perf = new PerformanceRunResult(
+                c.Display, c.Data.Length > 0 ? c.Data.Average() : 0, 1.0, 1.0,
+                c.Data.Length > 0 ? c.Data.Average() : 0,
+                c.Data, c.Data.Length, 0, c.Data,
+                Array.Empty<double>(), Array.Empty<double>(), 0);
+
+            var compiled = Substitute.For<ICompiledTestCaseResult>();
+            compiled.GroupingId.Returns(c.Group);
+            compiled.TestCaseId.Returns(new TestCaseId(c.Display));
+            compiled.PerformanceRunResult.Returns(perf);
+            compiled.Exception.Returns((Exception?)null);
+            return compiled;
+        }).ToList();
+
+        summary.CompiledTestCaseResults.Returns(results);
+        return summary;
+    }
+}

--- a/source/Tests.Library/Presentation/DistributionPlotRendererTests.cs
+++ b/source/Tests.Library/Presentation/DistributionPlotRendererTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Presentation;
+
+public class DistributionPlotRendererTests
+{
+    private static DistributionPlotRenderer.Series Series()
+    {
+        var samples = Enumerable.Range(0, 200).Select(i => 51.0 + 0.2 * Math.Sin(i * 2.1)).ToArray();
+        return new DistributionPlotRenderer.Series("method", samples, double.NaN, double.NaN, new[] { 60.0, 61.0 });
+    }
+
+    [Fact]
+    public void Render_HistogramStyle_UsesHistogramGlyphs()
+    {
+        var output = DistributionPlotRenderer.Render(new[] { Series() }, DurationUnit.Milliseconds, DistributionPlotStyle.Histogram);
+
+        output.ShouldContain("count per bin");                              // histogram legend
+        output.IndexOfAny("▁▂▃▄▅▆▇█".ToCharArray()).ShouldBeGreaterThanOrEqualTo(0);
+        output.ShouldNotContain("IQR box");                                 // not the box-plot legend
+    }
+
+    [Fact]
+    public void Render_BoxPlotStyle_UsesBoxPlotGlyphs()
+    {
+        var output = DistributionPlotRenderer.Render(new[] { Series() }, DurationUnit.Milliseconds, DistributionPlotStyle.BoxPlot);
+
+        output.ShouldContain("IQR box");          // box-plot legend
+        output.ShouldContain("▓");                 // IQR box fill
+        output.ShouldNotContain("count per bin");  // not the histogram legend
+    }
+
+    [Fact]
+    public void Render_BoxPlotStyle_PassesOutlierCountThrough()
+    {
+        var output = DistributionPlotRenderer.Render(new[] { Series() }, DurationUnit.Milliseconds, DistributionPlotStyle.BoxPlot);
+        output.ShouldContain("(+2 outliers)");
+    }
+
+    [Fact]
+    public void Render_EmptyInput_ReturnsEmpty()
+    {
+        DistributionPlotRenderer.Render(Array.Empty<DistributionPlotRenderer.Series>(), DurationUnit.Milliseconds, DistributionPlotStyle.Histogram).ShouldBeEmpty();
+    }
+}

--- a/source/Tests.Library/Presentation/MarkdownTableConverterTests.cs
+++ b/source/Tests.Library/Presentation/MarkdownTableConverterTests.cs
@@ -524,6 +524,44 @@ public class MarkdownTableConverterTests
         }
 
         [Fact]
+        public void ConvertToEnhancedMarkdownTableString_IncludesFencedDistributionPlotForGroup()
+        {
+            // Arrange — two methods in one group
+            var a = CreateCompiledResult("GroupX", "AlphaMethod", mean: 100.0, median: 100.0, stdDev: 1.0, variance: 1.0, sampleSize: 10);
+            var b = CreateCompiledResult("GroupX", "BetaMethod", mean: 200.0, median: 200.0, stdDev: 2.0, variance: 4.0, sampleSize: 10);
+            var summary = CreateExecutionSummaryFromResults("TestClass1", a, b);
+
+            // Act
+            var result = _markdownTableConverter.ConvertToEnhancedMarkdownTableString(new List<IClassExecutionSummary> { summary });
+
+            // Assert — fenced box plot with both methods present
+            result.ShouldContain("**Distribution**");
+            result.ShouldContain("```text");
+            result.ShouldContain("┃"); // median marker
+            result.ShouldContain("AlphaMethod");
+            result.ShouldContain("BetaMethod");
+        }
+
+        [Fact]
+        public void ConvertToEnhancedMarkdownTableString_WhenDistributionPlotsDisabled_OmitsPlot()
+        {
+            // Arrange — converter with plots disabled via run settings
+            var runSettings = Substitute.For<IRunSettings>();
+            runSettings.EnableDistributionPlots.Returns(false);
+            var converter = new MarkdownTableConverter(_mockUnifiedFormatter, new TestManifestProvider(), runSettings);
+
+            var a = CreateCompiledResult("GroupX", "AlphaMethod", mean: 100.0, median: 100.0, stdDev: 1.0, variance: 1.0, sampleSize: 10);
+            var summary = CreateExecutionSummaryFromResults("TestClass1", a);
+
+            // Act
+            var result = converter.ConvertToEnhancedMarkdownTableString(new List<IClassExecutionSummary> { summary });
+
+            // Assert — the table still renders, but no plot block
+            result.ShouldContain("StdDev (ms");
+            result.ShouldNotContain("**Distribution**");
+        }
+
+        [Fact]
         public void ConvertToEnhancedMarkdownTableString_TableShouldIncludeSampleSizeInStdDevHeader()
         {
             // Arrange

--- a/source/Tests.Library/Presentation/MarkdownTableConverterTests.cs
+++ b/source/Tests.Library/Presentation/MarkdownTableConverterTests.cs
@@ -534,10 +534,10 @@ public class MarkdownTableConverterTests
             // Act
             var result = _markdownTableConverter.ConvertToEnhancedMarkdownTableString(new List<IClassExecutionSummary> { summary });
 
-            // Assert — fenced box plot with both methods present
+            // Assert — fenced histogram with both methods present
             result.ShouldContain("**Distribution**");
             result.ShouldContain("```text");
-            result.ShouldContain("┃"); // median marker
+            result.ShouldContain("█"); // histogram block glyph
             result.ShouldContain("AlphaMethod");
             result.ShouldContain("BetaMethod");
         }

--- a/source/Tests.Library/Presentation/NiceAxisTests.cs
+++ b/source/Tests.Library/Presentation/NiceAxisTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Sailfish.Presentation;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Presentation;
+
+public class NiceAxisTests
+{
+    [Fact]
+    public void Compute_RoundsObservedRangeOutToNiceBounds()
+    {
+        var axis = NiceAxis.Compute(50.649, 51.310);
+
+        axis.Min.ShouldBe(50.6, 1e-9);
+        axis.Max.ShouldBe(51.4, 1e-9);
+        axis.Step.ShouldBe(0.2, 1e-9);
+        axis.Decimals.ShouldBe(1);
+        axis.Ticks.ShouldContain(t => System.Math.Abs(t - 50.8) < 1e-9);
+        axis.Ticks.ShouldContain(t => System.Math.Abs(t - 51.0) < 1e-9);
+        axis.Ticks.ShouldContain(t => System.Math.Abs(t - 51.2) < 1e-9);
+    }
+
+    [Fact]
+    public void Compute_ProducesRoundLabelsNotRawValues()
+    {
+        var axis = NiceAxis.Compute(50.649, 51.310);
+        var labels = axis.Ticks.Select(t => t.ToString("F" + axis.Decimals, System.Globalization.CultureInfo.InvariantCulture)).ToList();
+
+        labels.ShouldContain("50.6");
+        labels.ShouldContain("51.4");
+        labels.ShouldNotContain("50.649");
+    }
+
+    [Fact]
+    public void Compute_IdenticalValues_ProducesWindowAroundValue()
+    {
+        var axis = NiceAxis.Compute(51.0, 51.0);
+
+        axis.Min.ShouldBeLessThan(51.0);
+        axis.Max.ShouldBeGreaterThan(51.0);
+        axis.Ticks.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public void Compute_WiderRange_UsesCoarserStepAndZeroDecimals()
+    {
+        var axis = NiceAxis.Compute(1.0, 12.0);
+
+        axis.Step.ShouldBeGreaterThanOrEqualTo(1.0);
+        axis.Decimals.ShouldBe(0);
+        axis.Min.ShouldBeLessThanOrEqualTo(1.0);
+        axis.Max.ShouldBeGreaterThanOrEqualTo(12.0);
+    }
+}

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Sailfish.Presentation;
 using Sailfish.TestAdapter.Execution;
 using Shouldly;
 using Xunit;
@@ -38,6 +39,44 @@ public class AdapterRunSettingsLoaderTests
 
             var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
             runSettings.EnableEnvironmentHealthCheck.ShouldBeFalse();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            try { Directory.Delete(root, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Theory]
+    [InlineData("\"GlobalSettings\": { \"DistributionPlotStyle\": \"BoxPlot\" }, \"SailDiffSettings\": {}")]
+    [InlineData("\"GlobalSettings\": {}, \"SailDiffSettings\": { \"DistributionPlotStyle\": \"BoxPlot\" }")] // convenience fallback
+    public void DistributionPlotStyle_BoxPlot_IsParsed_FromEitherSection(string sections)
+    {
+        var json = "{ " + sections + ", \"SailfishSettings\": {}, \"ScaleFishSettings\": {} }";
+        LoadFromConfig(json).DistributionPlotStyle.ShouldBe(DistributionPlotStyle.BoxPlot);
+    }
+
+    [Fact]
+    public void DistributionPlotStyle_DefaultsToHistogram_WhenUnset()
+    {
+        var json = "{ \"GlobalSettings\": {}, \"SailDiffSettings\": {}, \"SailfishSettings\": {}, \"ScaleFishSettings\": {} }";
+        LoadFromConfig(json).DistributionPlotStyle.ShouldBe(DistributionPlotStyle.Histogram);
+    }
+
+    // Writes the config in a parent dir and runs from a nested dir, because the loader recurses
+    // UPWARDS to find .sailfish.json (it doesn't match a file sitting in the current directory).
+    private static Sailfish.Contracts.Public.Models.IRunSettings LoadFromConfig(string json)
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var root = Path.Combine(Path.GetTempPath(), "sf_adapter_settings_" + Guid.NewGuid().ToString("N"));
+        var nested = Path.Combine(root, "a", "b");
+        Directory.CreateDirectory(nested);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, ".sailfish.json"), json);
+            Directory.SetCurrentDirectory(nested);
+            return AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
         }
         finally
         {

--- a/source/Tests.TestAdapter/SailfishConsoleWindowFormatterTests.cs
+++ b/source/Tests.TestAdapter/SailfishConsoleWindowFormatterTests.cs
@@ -141,6 +141,45 @@ public class SailfishConsoleWindowFormatterTests
     }
 
     [Fact]
+    public void FormConsoleWindowMessageForSailfish_IncludesDistributionPlotByDefault()
+    {
+        // Arrange
+        var performanceResult = CreatePerformanceRunResult();
+        var compiledResult = CreateCompiledResultWithPerformance(performanceResult);
+        var executionSummary = CreateExecutionSummaryWithCompiledResult(compiledResult);
+        var results = new List<IClassExecutionSummary> { executionSummary };
+
+        // Act
+        var output = _formatter.FormConsoleWindowMessageForSailfish(results);
+
+        // Assert — plots default on; a box (median bar) and the legend are present.
+        output.ShouldContain("Distribution Plot");
+        output.ShouldContain("┃"); // median marker
+        output.ShouldContain("median"); // legend
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailfish_WhenDistributionPlotsDisabled_OmitsPlot()
+    {
+        // Arrange
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.EnableDistributionPlots.Returns(false);
+        var formatter = new SailfishConsoleWindowFormatter(_logger, runSettings);
+
+        var performanceResult = CreatePerformanceRunResult();
+        var compiledResult = CreateCompiledResultWithPerformance(performanceResult);
+        var executionSummary = CreateExecutionSummaryWithCompiledResult(compiledResult);
+        var results = new List<IClassExecutionSummary> { executionSummary };
+
+        // Act
+        var output = formatter.FormConsoleWindowMessageForSailfish(results);
+
+        // Assert — the statistics still render, but the plot section is gone.
+        output.ShouldContain("Descriptive Statistics");
+        output.ShouldNotContain("Distribution Plot");
+    }
+
+    [Fact]
     public void FormConsoleWindowMessageForSailfish_WithSubMicrosecondTimings_RendersMicrosecondsNotZeroMilliseconds()
     {
         // Arrange — values are in milliseconds (canonical). ~1.1 µs mean with a ~15 ns CI margin:

--- a/source/Tests.TestAdapter/SailfishConsoleWindowFormatterTests.cs
+++ b/source/Tests.TestAdapter/SailfishConsoleWindowFormatterTests.cs
@@ -152,10 +152,31 @@ public class SailfishConsoleWindowFormatterTests
         // Act
         var output = _formatter.FormConsoleWindowMessageForSailfish(results);
 
-        // Assert — plots default on; a box (median bar) and the legend are present.
+        // Assert — plots default on; a histogram and the legend are present.
         output.ShouldContain("Distribution Plot");
-        output.ShouldContain("┃"); // median marker
-        output.ShouldContain("median"); // legend
+        output.ShouldContain("█"); // histogram block glyph
+        output.ShouldContain("count per bin"); // legend
+    }
+
+    [Fact]
+    public void FormConsoleWindowMessageForSailfish_PlotAppearsUnderDescriptiveStatsBeforeRawData()
+    {
+        var performanceResult = CreatePerformanceRunResult();
+        var compiledResult = CreateCompiledResultWithPerformance(performanceResult);
+        var executionSummary = CreateExecutionSummaryWithCompiledResult(compiledResult);
+        var results = new List<IClassExecutionSummary> { executionSummary };
+
+        var output = _formatter.FormConsoleWindowMessageForSailfish(results);
+
+        var stats = output.IndexOf("Descriptive Statistics", StringComparison.Ordinal);
+        var plot = output.IndexOf("Distribution Plot", StringComparison.Ordinal);
+        var outliers = output.IndexOf("Outliers Removed", StringComparison.Ordinal);
+        var rawDist = output.IndexOf("Distribution (", StringComparison.Ordinal);
+
+        stats.ShouldBeGreaterThanOrEqualTo(0);
+        plot.ShouldBeGreaterThan(stats);      // plot sits under Descriptive Statistics
+        outliers.ShouldBeGreaterThan(plot);   // raw outlier dump moved below the plot
+        rawDist.ShouldBeGreaterThan(plot);    // raw distribution dump moved below the plot
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds **distribution visualizations** to Sailfish readouts so you can *see* spread, skew, and how methods compare — not just read scalar stats. Two styles, selectable via a setting:

- **Histogram (default)** — compact shared-axis "small multiples"; one row per method:

```text
Distribution Plot
-----------------
                                                  Time (ms)

  Tracked()      ▄▄▆▇▇▅▆▆█▆▅
                      ╽
  Projected()                              ▄▄███▄▆▇▅███▄▄
                                                ╽

   0 ├───────────┬───────────┬──────────┬───────────┬───────────┤ 10
                 2           4          6           8

  ╵ mean   ╿ median   ▁▂▃▄▅▆▇█ count per bin   ╽ mean≈median

  Tracked()    n=138  outliers=0  min=1.402  max=3.050
  Projected()  n=138  outliers=0  min=7.701  max=9.779
```

- **Box plot (opt-in)** — the horizontal box-and-whisker style, selected with `DistributionPlotStyle = BoxPlot`.

## How

- **`AsciiHistogramRenderer`** — stacked histogram rows on one shared, nice-rounded x-axis; per-row normalized `▁▂▃▄▅▆▇█`; a scale-aligned `╵` mean / `╿` median marker line under each row (`╽` when they coincide); aligned `n=`/`outliers=`/`min=`/`max=` summary. Markers never sit inside the histogram blocks (avoids the font side-bearing problems of inline `◆`/`┃`).
- **`NiceAxis`** — Heckbert "nice numbers" axis: rounds the observed range out to readable ticks (`50.649…51.310` → `50.6 … 51.4`, ticks `50.8/51.0/51.2`).
- **`DistributionPlotRenderer`** — one facade that dispatches to the configured `DistributionPlotStyle` (`Histogram` | `BoxPlot`) from a single per-series description, so the four output surfaces don't each branch.
- **Setting**: `IRunSettings.DistributionPlotStyle` (default `Histogram`) + `RunSettingsBuilder.WithDistributionPlotStyle` + TestAdapter `.sailfish.json` `"DistributionPlotStyle"`. Existing `EnableDistributionPlots` (default on) / `EmitDistributionHtmlReport` (default off) unchanged.
- **Layout**: the per-case IDE plot now sits directly under **Descriptive Statistics**, with the raw "Outliers Removed" / "Distribution (ms)" dumps moved below it.
- Wired into all four surfaces: per-case IDE output, the SailDiff comparison pipeline, grouped enhanced Markdown, and the session comparison report. The box-plot renderer also still backs the optional SVG HTML report.

## Design notes

- Histogram bins each distribution into ~12 bins over its own range and paints contiguous column spans on the shared axis — keeps a sparse tail readable instead of single-column "dust", while position/width still reflect the shared scale.
- Box-plot axis is padded 25%/side; outliers are reported as a count, not plotted (both styles).
- **Known limitation**: a linear shared axis compresses fast methods when a group spans orders of magnitude. A log-scale axis option is a natural follow-on.

## Tests

- New: `NiceAxisTests`, `AsciiHistogramRendererTests`, `DistributionPlotRendererTests` (style dispatch); existing box-plot, comparison, grouped-Markdown, and per-case tests updated/retained.
- Full `Tests.Library` (1537) + `Tests.TestAdapter` (559) green on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added distribution plot visualizations (histogram and box-plot styles) for performance comparison results in IDE, Markdown, and console outputs
  - Optional standalone HTML distribution report generation
  - New configuration settings to enable/disable distribution plots and select visualization style

* **Chores**
  - Updated performance test sample size from 3 to 300 for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->