### PR TITLE
Skipper AI analysis layer — Phase 0: contracts + wiring

### DIFF
--- a/source/Sailfish/Analysis/Ai/AiAnalysisSettings.cs
+++ b/source/Sailfish/Analysis/Ai/AiAnalysisSettings.cs
@@ -1,0 +1,33 @@
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     Settings for the Skipper AI analysis layer. Mirrors the shape of <c>SailDiffSettings</c> /
+///     <c>ScaleFishSettings</c>; supply a configured instance via
+///     <c>RunSettingsBuilder.WithAiAnalysis(AiAnalysisSettings)</c>.
+/// </summary>
+public sealed class AiAnalysisSettings
+{
+    public AiAnalysisSettings(
+        SkipperRole role = SkipperRole.Explain,
+        bool writeReviewArtifact = true,
+        bool emitConsoleSummary = true,
+        bool useResponseCache = true)
+    {
+        Role = role;
+        WriteReviewArtifact = writeReviewArtifact;
+        EmitConsoleSummary = emitConsoleSummary;
+        UseResponseCache = useResponseCache;
+    }
+
+    /// <summary>The authority the agent runs under. Phase 0 supports <see cref="SkipperRole.Explain" />.</summary>
+    public SkipperRole Role { get; }
+
+    /// <summary>When true, the <see cref="SkipperReview" /> is serialized to <c>skipper-review_*.json</c> beside the run output.</summary>
+    public bool WriteReviewArtifact { get; }
+
+    /// <summary>When true, the review's short narrative is printed to the console beneath the SailDiff table.</summary>
+    public bool EmitConsoleSummary { get; }
+
+    /// <summary>When true, identical context packets reuse a cached review (no re-spend, and stable output).</summary>
+    public bool UseResponseCache { get; }
+}

--- a/source/Sailfish/Analysis/Ai/Capabilities.cs
+++ b/source/Sailfish/Analysis/Ai/Capabilities.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     Marker for a capability an agent may be granted for a session. Capabilities are the mechanism by which
+///     Skipper escalates from "explain" (read-only) to "act" (open PRs, file tickets, query telemetry) without
+///     changing the <see cref="ISailfishAgent" /> contract — the host simply grants more of them.
+/// </summary>
+public interface ISkipperCapability
+{
+}
+
+/// <summary>Grants read-only access to the repository under <see cref="RepositoryRoot" />. Shipped, and granted locally.</summary>
+public interface ICodeReadCapability : ISkipperCapability
+{
+    string RepositoryRoot { get; }
+}
+
+/// <summary>Reserved (not yet wired): query a telemetry backend such as Azure Log Analytics or Databricks.</summary>
+public interface ITelemetryQueryCapability : ISkipperCapability
+{
+}
+
+/// <summary>Reserved (not yet wired): open or update a pull request.</summary>
+public interface IVersionControlCapability : ISkipperCapability
+{
+}
+
+/// <summary>Reserved (not yet wired): file or update a work-tracking ticket.</summary>
+public interface ITicketCapability : ISkipperCapability
+{
+}
+
+/// <summary>Reserved (not yet wired): synthesize and run a benchmark targeting a diff.</summary>
+public interface IBenchmarkSynthesisCapability : ISkipperCapability
+{
+}
+
+/// <summary>The set of capabilities granted to an agent for a session.</summary>
+public interface ICapabilityRegistry
+{
+    /// <summary>All granted capabilities.</summary>
+    IReadOnlyCollection<ISkipperCapability> Granted { get; }
+
+    /// <summary>True when a capability assignable to <typeparamref name="TCapability" /> has been granted.</summary>
+    bool Has<TCapability>() where TCapability : class, ISkipperCapability;
+
+    /// <summary>The granted capability assignable to <typeparamref name="TCapability" />, or <c>null</c>.</summary>
+    TCapability? Get<TCapability>() where TCapability : class, ISkipperCapability;
+}
+
+internal sealed class CapabilityRegistry : ICapabilityRegistry
+{
+    private readonly IReadOnlyCollection<ISkipperCapability> capabilities;
+
+    public CapabilityRegistry(IEnumerable<ISkipperCapability> capabilities)
+    {
+        this.capabilities = capabilities.ToArray();
+    }
+
+    public IReadOnlyCollection<ISkipperCapability> Granted => capabilities;
+
+    public bool Has<TCapability>() where TCapability : class, ISkipperCapability => Get<TCapability>() is not null;
+
+    public TCapability? Get<TCapability>() where TCapability : class, ISkipperCapability =>
+        capabilities.OfType<TCapability>().FirstOrDefault();
+}
+
+/// <summary>Default read-only code-access capability granted for the local Explain flow.</summary>
+internal sealed record CodeReadCapability(string RepositoryRoot) : ICodeReadCapability;

--- a/source/Sailfish/Analysis/Ai/IActionExecutor.cs
+++ b/source/Sailfish/Analysis/Ai/IActionExecutor.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     Host-supplied executor for <see cref="ProposedAction" />s. This is the propose / execute safety boundary:
+///     Skipper only ever <i>proposes</i> actions; whether any of them run — and behind what approval policy — is
+///     entirely the host's decision. No executor is registered locally, so proposed actions are display-only.
+///     Reserved for the action-taking automation future.
+/// </summary>
+public interface IActionExecutor
+{
+    Task ExecuteAsync(ProposedAction action, CancellationToken cancellationToken);
+}

--- a/source/Sailfish/Analysis/Ai/ISailfishAgent.cs
+++ b/source/Sailfish/Analysis/Ai/ISailfishAgent.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     The single seam a consumer implements to give Sailfish an AI "Skipper" — the crewmate that reads
+///     the instruments (SailDiff / ScaleFish) and explains what changed and why.
+///     <para>
+///         Implementations are pure <b>transport</b>. Sailfish assembles a fully-grounded
+///         <see cref="SkipperSession" /> (authoritative numbers + the capabilities the agent is allowed to
+///         use) and hands it over. The implementation forwards it to a model however it likes — a one-shot
+///         completion, a local model, or a full agentic loop (e.g. the Claude Agent SDK / <c>claude</c> CLI)
+///         that uses the read-only code access granted by <see cref="ICodeReadCapability" /> to investigate
+///         the code under test.
+///     </para>
+///     <para>
+///         Register a custom implementation from an <c>IRegisterSailfishServices</c> provider:
+///         <c>services.AddSingleton&lt;ISailfishAgent, MyAgent&gt;()</c>. When none is registered a no-op
+///         default is used and AI analysis is silently skipped — the feature is strictly additive.
+///     </para>
+/// </summary>
+public interface ISailfishAgent
+{
+    /// <summary>
+    ///     Analyze a completed comparison and return a <see cref="SkipperReview" />.
+    ///     <para>
+    ///         Implementations must not compute or invent measurements: reason only over the grounded figures
+    ///         in <see cref="SkipperSession.Context" />, and for any claim about code cite a real
+    ///         <c>file:line</c> that was actually read.
+    ///     </para>
+    /// </summary>
+    Task<SkipperReview> RunAsync(SkipperSession session, CancellationToken cancellationToken);
+}

--- a/source/Sailfish/Analysis/Ai/NoOpSailfishAgent.cs
+++ b/source/Sailfish/Analysis/Ai/NoOpSailfishAgent.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     Default <see cref="ISailfishAgent" />, registered when the consumer has not supplied one. Returns an
+///     empty review so the AI analysis layer stays completely invisible until a real agent is registered via
+///     <c>IRegisterSailfishServices</c>.
+/// </summary>
+internal sealed class NoOpSailfishAgent : ISailfishAgent
+{
+    public Task<SkipperReview> RunAsync(SkipperSession session, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(SkipperReview.Empty);
+    }
+}

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContext.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContext.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     The grounded, authoritative packet handed to an <see cref="ISailfishAgent" />. Every number here is
+///     computed by Sailfish / SailDiff — the agent must reason over these figures and never recompute or invent
+///     them. Enriched in later phases with an environment snapshot and ScaleFish scaling projections.
+/// </summary>
+public sealed record PerformanceNarrativeContext(
+    IReadOnlyList<SailDiffCaseContext> Comparisons,
+    string SailDiffMarkdown);
+
+/// <summary>Grounded before / after figures for one test case, lifted directly from a SailDiff result.</summary>
+public sealed record SailDiffCaseContext(
+    string DisplayName,
+    SkipperVerdict Verdict,
+    double MeanBefore,
+    double MeanAfter,
+    double MedianBefore,
+    double MedianAfter,
+    double PercentChangeMean,
+    double PValue,
+    double? AdjustedPValue,
+    string ChangeDescription,
+    int SampleSizeBefore,
+    int SampleSizeAfter,
+    bool Failed);

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+
+namespace Sailfish.Analysis.Ai;
+
+internal interface IPerformanceNarrativeContextBuilder
+{
+    PerformanceNarrativeContext Build(SailDiffAnalysisCompleteNotification notification, double alpha);
+}
+
+/// <summary>
+///     Lifts the authoritative SailDiff figures into the grounded packet the agent reasons over. The verdict is
+///     derived here (deterministically, from the p-value and the direction of the mean shift) so the agent never
+///     has to — and so the same vocabulary is used everywhere.
+/// </summary>
+internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrativeContextBuilder
+{
+    public PerformanceNarrativeContext Build(SailDiffAnalysisCompleteNotification notification, double alpha)
+    {
+        var comparisons = notification.TestCaseResults
+            .Select(result => ToCaseContext(result, alpha))
+            .ToList();
+
+        return new PerformanceNarrativeContext(comparisons, notification.ResultsAsMarkdown ?? string.Empty);
+    }
+
+    private static SailDiffCaseContext ToCaseContext(SailDiffResult result, double alpha)
+    {
+        var displayName = result.TestCaseId.DisplayName;
+        var stats = result.TestResultsWithOutlierAnalysis.StatisticalTestResult;
+
+        if (stats.Failed)
+        {
+            return new SailDiffCaseContext(
+                displayName, SkipperVerdict.Inconclusive,
+                MeanBefore: 0, MeanAfter: 0, MedianBefore: 0, MedianAfter: 0,
+                PercentChangeMean: 0, PValue: double.NaN, AdjustedPValue: null,
+                ChangeDescription: stats.ChangeDescription, SampleSizeBefore: 0, SampleSizeAfter: 0, Failed: true);
+        }
+
+        var percentChangeMean = stats.MeanBefore != 0
+            ? (stats.MeanAfter - stats.MeanBefore) / stats.MeanBefore * 100.0
+            : 0.0;
+
+        return new SailDiffCaseContext(
+            displayName,
+            DeriveVerdict(stats, alpha),
+            stats.MeanBefore,
+            stats.MeanAfter,
+            stats.MedianBefore,
+            stats.MedianAfter,
+            percentChangeMean,
+            stats.PValue,
+            stats.QValue,
+            stats.ChangeDescription,
+            stats.SampleSizeBefore,
+            stats.SampleSizeAfter,
+            Failed: false);
+    }
+
+    private static SkipperVerdict DeriveVerdict(StatisticalTestResult stats, double alpha)
+    {
+        // Prefer the BH-FDR adjusted q-value when present (it controls the family-wise error rate across the
+        // pairs in an N×N method comparison); otherwise fall back to the raw p-value.
+        var p = stats.QValue ?? stats.PValue;
+        if (double.IsNaN(p) || p >= alpha) return SkipperVerdict.NotSignificant;
+
+        return stats.MeanAfter > stats.MeanBefore ? SkipperVerdict.Regressed : SkipperVerdict.Improved;
+    }
+}

--- a/source/Sailfish/Analysis/Ai/SkipperResponseCache.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperResponseCache.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Analysis.Ai;
+
+internal interface ISkipperResponseCache
+{
+    /// <summary>A stable key for a context packet under a given role. Identical inputs produce identical keys.</summary>
+    string ComputeKey(PerformanceNarrativeContext context, SkipperRole role);
+
+    Task<SkipperReview?> TryGetAsync(string key, CancellationToken cancellationToken);
+
+    Task SetAsync(string key, SkipperReview review, CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     File-backed cache keyed on a hash of the grounded context packet. Guarantees that the same numbers yield
+///     the same narrative across runs — no re-spend on the model, and stable, reproducible output. A corrupt or
+///     unreadable entry is treated as a miss and never breaks a run.
+/// </summary>
+internal sealed class FileSkipperResponseCache : ISkipperResponseCache
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly IRunSettings runSettings;
+
+    public FileSkipperResponseCache(IRunSettings runSettings)
+    {
+        this.runSettings = runSettings;
+    }
+
+    public string ComputeKey(PerformanceNarrativeContext context, SkipperRole role)
+    {
+        var payload = role + "|" + JsonSerializer.Serialize(context, SerializerOptions);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash);
+    }
+
+    public async Task<SkipperReview?> TryGetAsync(string key, CancellationToken cancellationToken)
+    {
+        var path = PathFor(key);
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<SkipperReview>(json, SerializerOptions);
+        }
+        catch
+        {
+            return null; // a corrupt cache entry must never break a run
+        }
+    }
+
+    public async Task SetAsync(string key, SkipperReview review, CancellationToken cancellationToken)
+    {
+        var path = PathFor(key);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var json = JsonSerializer.Serialize(review, SerializerOptions);
+        await File.WriteAllTextAsync(path, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private string PathFor(string key) => Path.Join(runSettings.LocalOutputDirectory, "skipper_cache", key + ".json");
+}

--- a/source/Sailfish/Analysis/Ai/SkipperReview.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperReview.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     How Skipper classifies a comparison. Mirrors SailDiff's vocabulary: a comparison is "not significant"
+///     (never "no change"), a regression is <em>slower</em>, and an improvement is <em>faster</em>.
+/// </summary>
+public enum SkipperVerdict
+{
+    Improved,
+    Regressed,
+    NotSignificant,
+    Inconclusive
+}
+
+/// <summary>A single diagnosis Skipper produced for a test case, together with the code it actually cited.</summary>
+public sealed record Finding(
+    string TestCaseDisplayName,
+    SkipperVerdict Verdict,
+    string Summary,
+    IReadOnlyList<string> CitedSourceLocations,
+    double Confidence);
+
+/// <summary>
+///     The kind of action Skipper proposes. The local Explain path never emits any; these are reserved for the
+///     action-taking future, where a host-supplied <see cref="IActionExecutor" /> decides what (if anything) runs.
+/// </summary>
+public enum ProposedActionKind
+{
+    FileTicket,
+    OpenPullRequest,
+    RunTelemetryQuery,
+    CreateBenchmark,
+    Custom
+}
+
+/// <summary>An action Skipper <b>proposes</b>. Skipper never executes actions itself — see <see cref="IActionExecutor" />.</summary>
+public sealed record ProposedAction(
+    ProposedActionKind Kind,
+    string Title,
+    string Detail,
+    IReadOnlyDictionary<string, string> Parameters);
+
+/// <summary>
+///     The structured result of an analysis. <see cref="Findings" /> are diagnoses (the local Explain path stops
+///     here); <see cref="Actions" /> are proposals only. Serialized to <c>skipper-review_*.json</c> so a decoupled
+///     orchestrator can consume it and act under its own approval policy.
+/// </summary>
+public sealed record SkipperReview(
+    SkipperVerdict OverallVerdict,
+    IReadOnlyList<Finding> Findings,
+    IReadOnlyList<ProposedAction> Actions,
+    string ConsoleSummary,
+    string MarkdownReport)
+{
+    /// <summary>
+    ///     An empty review. The no-op default agent returns this, and any agent may return it to signal
+    ///     "nothing worth saying" — in which case nothing is rendered or persisted.
+    /// </summary>
+    public static SkipperReview Empty { get; } = new(
+        SkipperVerdict.Inconclusive,
+        Array.Empty<Finding>(),
+        Array.Empty<ProposedAction>(),
+        string.Empty,
+        string.Empty);
+
+    /// <summary>True when the review carries anything worth rendering or persisting.</summary>
+    public bool HasContent =>
+        Findings is { Count: > 0 } ||
+        Actions is { Count: > 0 } ||
+        !string.IsNullOrWhiteSpace(ConsoleSummary) ||
+        !string.IsNullOrWhiteSpace(MarkdownReport);
+}

--- a/source/Sailfish/Analysis/Ai/SkipperReviewWriter.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperReviewWriter.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Presentation;
+
+namespace Sailfish.Analysis.Ai;
+
+internal interface ISkipperReviewWriter
+{
+    Task WriteAsync(SkipperReview review, CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Persists a <see cref="SkipperReview" /> as <c>skipper-review_*.json</c> beside the run output. This is the
+///     artifact a decoupled orchestrator consumes in the action-taking future (the "act via artifacts" half of the
+///     hybrid topology).
+/// </summary>
+internal sealed class SkipperReviewWriter : ISkipperReviewWriter
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly IRunSettings runSettings;
+
+    public SkipperReviewWriter(IRunSettings runSettings)
+    {
+        this.runSettings = runSettings;
+    }
+
+    public async Task WriteAsync(SkipperReview review, CancellationToken cancellationToken)
+    {
+        var directory = runSettings.LocalOutputDirectory;
+        Directory.CreateDirectory(directory);
+
+        var fileName = DefaultFileSettings.AppendTagsToFilename(
+            $"skipper-review_{runSettings.TimeStamp:yyyyMMdd_HHmmss}.json",
+            runSettings.Tags);
+        var filePath = Path.Join(directory, fileName);
+
+        var json = JsonSerializer.Serialize(review, SerializerOptions);
+        await File.WriteAllTextAsync(filePath, json, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/source/Sailfish/Analysis/Ai/SkipperSession.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperSession.cs
@@ -1,0 +1,32 @@
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     The authority an <see cref="ISailfishAgent" /> operates under for a single session. Phase 0 only ever
+///     issues <see cref="Explain" />; the remaining roles reserve the same pipeline for future automation
+///     (CI review, remediation via PR / ticket, and benchmark authoring) without a contract change.
+/// </summary>
+public enum SkipperRole
+{
+    /// <summary>Read-only: explain what changed and why. The only role used locally today.</summary>
+    Explain,
+
+    /// <summary>Produce a pass / warn / fail verdict suitable for gating a pipeline (future).</summary>
+    Review,
+
+    /// <summary>Propose remediations such as opening a PR or filing a ticket (future).</summary>
+    Remediate,
+
+    /// <summary>Synthesize a targeted benchmark for a diff and run it before / after (future).</summary>
+    Author
+}
+
+/// <summary>
+///     Everything an <see cref="ISailfishAgent" /> needs for one analysis: the role (authority), the grounded
+///     <see cref="PerformanceNarrativeContext" />, the set of granted <see cref="Capabilities" />, and the
+///     repository root the agent may read from when granted <see cref="ICodeReadCapability" />.
+/// </summary>
+public sealed record SkipperSession(
+    SkipperRole Role,
+    PerformanceNarrativeContext Context,
+    ICapabilityRegistry Capabilities,
+    string RepositoryRoot);

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis;
 using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.Ai;
 
 using Sailfish.Extensions.Types;
 using Sailfish.Logging;
@@ -15,9 +16,11 @@ public interface IRunSettings
     string LocalOutputDirectory { get; }
     bool RunSailDiff { get; }
     bool RunScaleFish { get; }
+    bool RunAiAnalysis { get; }
     bool CreateTrackingFiles { get; }
     SailDiffSettings SailDiffSettings { get; }
     ScaleFishSettings ScaleFishSettings { get; }
+    AiAnalysisSettings AiAnalysisSettings { get; }
     IEnumerable<Type> TestLocationAnchors { get; }
     IEnumerable<Type> RegistrationProviderAnchors { get; }
     OrderedDictionary Tags { get; }

--- a/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Sailfish.Analysis.Ai;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Logging;
+using Sailfish.Presentation.Console;
+
+namespace Sailfish.DefaultHandlers.Ai;
+
+/// <summary>
+///     Bridges a completed SailDiff comparison to the AI "Skipper" layer: builds a grounded context packet, runs
+///     the registered <see cref="ISailfishAgent" />, then persists and renders the result.
+///     <para>
+///         The whole path is opt-in (<see cref="IRunSettings.RunAiAnalysis" />), strictly additive, and must never
+///         throw into the run. If no real agent is registered, or anything fails, the benchmark output is entirely
+///         unaffected.
+///     </para>
+/// </summary>
+internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<SailDiffAnalysisCompleteNotification>
+{
+    private readonly ISailfishAgent agent;
+    private readonly IConsoleWriter consoleWriter;
+    private readonly IPerformanceNarrativeContextBuilder contextBuilder;
+    private readonly ILogger logger;
+    private readonly ISkipperResponseCache responseCache;
+    private readonly ISkipperReviewWriter reviewWriter;
+    private readonly IRunSettings runSettings;
+
+    public SkipperSailDiffAnalysisHandler(
+        IRunSettings runSettings,
+        ISailfishAgent agent,
+        IPerformanceNarrativeContextBuilder contextBuilder,
+        ISkipperReviewWriter reviewWriter,
+        ISkipperResponseCache responseCache,
+        IConsoleWriter consoleWriter,
+        ILogger logger)
+    {
+        this.runSettings = runSettings;
+        this.agent = agent;
+        this.contextBuilder = contextBuilder;
+        this.reviewWriter = reviewWriter;
+        this.responseCache = responseCache;
+        this.consoleWriter = consoleWriter;
+        this.logger = logger;
+    }
+
+    public async Task Handle(SailDiffAnalysisCompleteNotification notification, CancellationToken cancellationToken)
+    {
+        if (!runSettings.RunAiAnalysis) return;     // opt-in
+        if (agent is NoOpSailfishAgent) return;     // no real agent registered — stay invisible
+
+        try
+        {
+            var settings = runSettings.AiAnalysisSettings;
+
+            var context = contextBuilder.Build(notification, runSettings.SailDiffSettings.Alpha);
+            if (context.Comparisons.Count == 0) return;
+
+            var review = await ResolveReviewAsync(context, settings, cancellationToken).ConfigureAwait(false);
+            if (!review.HasContent) return;
+
+            if (settings.WriteReviewArtifact)
+                await reviewWriter.WriteAsync(review, cancellationToken).ConfigureAwait(false);
+
+            if (settings.EmitConsoleSummary && !string.IsNullOrWhiteSpace(review.ConsoleSummary))
+                consoleWriter.WriteString(review.ConsoleSummary);
+        }
+        catch (Exception ex)
+        {
+            // Strictly additive: AI analysis must never break or alter a benchmark run.
+            logger.Log(LogLevel.Warning, ex, "Skipper AI analysis failed; continuing without it.");
+        }
+    }
+
+    private async Task<SkipperReview> ResolveReviewAsync(
+        PerformanceNarrativeContext context,
+        AiAnalysisSettings settings,
+        CancellationToken cancellationToken)
+    {
+        string? cacheKey = null;
+        if (settings.UseResponseCache)
+        {
+            cacheKey = responseCache.ComputeKey(context, settings.Role);
+            var cached = await responseCache.TryGetAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            if (cached is not null) return cached;
+        }
+
+        var repositoryRoot = ResolveRepositoryRoot();
+        var capabilities = new CapabilityRegistry(new ISkipperCapability[] { new CodeReadCapability(repositoryRoot) });
+        var session = new SkipperSession(settings.Role, context, capabilities, repositoryRoot);
+
+        var review = await agent.RunAsync(session, cancellationToken).ConfigureAwait(false);
+
+        if (cacheKey is not null && review.HasContent)
+            await responseCache.SetAsync(cacheKey, review, cancellationToken).ConfigureAwait(false);
+
+        return review;
+    }
+
+    /// <summary>Walks up from the working directory to the nearest Git root; falls back to the working directory.</summary>
+    private static string ResolveRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git"))) return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+}

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -1,6 +1,8 @@
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Sailfish.Analysis;
+using Sailfish.Analysis.Ai;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Statistics;
 using Sailfish.Analysis.SailDiff.Statistics.Tests;
@@ -132,6 +134,13 @@ internal static class SailfishModuleRegistrations
         services.AddTransient<IPermutationTest, PermutationTest>();
         services.AddTransient<IScalefishObservationCompiler, ScalefishObservationCompiler>();
         services.AddTransient<ISailDiffConsoleWindowMessageFormatter, SailDiffConsoleWindowMessageFormatter>();
+
+        // Skipper AI analysis layer. The agent is the only seam a consumer overrides; TryAdd means a
+        // user-registered ISailfishAgent (from IRegisterSailfishServices) wins regardless of registration order.
+        services.TryAddSingleton<ISailfishAgent, NoOpSailfishAgent>();
+        services.AddTransient<IPerformanceNarrativeContextBuilder, PerformanceNarrativeContextBuilder>();
+        services.AddTransient<ISkipperReviewWriter, SkipperReviewWriter>();
+        services.AddTransient<ISkipperResponseCache, FileSkipperResponseCache>();
 
         return services;
     }

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis;
 using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.Ai;
 
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Extensions.Types;
@@ -45,7 +46,9 @@ internal class RunSettings : IRunSettings
         bool enableEnvironmentHealthCheck = true,
         bool timerCalibration = true,
         int? seed = null,
-        ScaleFishSettings? scaleFishSettings = null)
+        ScaleFishSettings? scaleFishSettings = null,
+        bool useAiAnalysis = false,
+        AiAnalysisSettings? aiAnalysisSettings = null)
     {
         TestNames = testNames;
         LocalOutputDirectory = localOutputDirectory;
@@ -54,6 +57,8 @@ internal class RunSettings : IRunSettings
         RunScaleFish = useScaleFish;
         SailDiffSettings = sailDiffSettings;
         ScaleFishSettings = scaleFishSettings ?? new ScaleFishSettings();
+        RunAiAnalysis = useAiAnalysis;
+        AiAnalysisSettings = aiAnalysisSettings ?? new AiAnalysisSettings();
         TestLocationAnchors = testLocationAnchors;
         RegistrationProviderAnchors = registrationProviderAnchors;
         Tags = tags;
@@ -86,8 +91,10 @@ internal class RunSettings : IRunSettings
     public bool CreateTrackingFiles { get; }
     public bool RunSailDiff { get; }
     public bool RunScaleFish { get; }
+    public bool RunAiAnalysis { get; }
     public SailDiffSettings SailDiffSettings { get; }
     public ScaleFishSettings ScaleFishSettings { get; }
+    public AiAnalysisSettings AiAnalysisSettings { get; }
     public IEnumerable<Type> TestLocationAnchors { get; }
     public IEnumerable<Type> RegistrationProviderAnchors { get; }
     public OrderedDictionary Tags { get; }

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis;
 using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.Ai;
 
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Extensions.Types;
@@ -32,6 +33,8 @@ public class RunSettingsBuilder
     private bool _scaleFish;
     private SailDiffSettings? _sdSettings;
     private ScaleFishSettings? _sfSettings;
+    private bool _aiAnalysis;
+    private AiAnalysisSettings? _aiSettings;
     private bool _setDebug;
     private bool _streamTrackingUpdates = true;
     private DateTime? _timeStamp;
@@ -186,6 +189,26 @@ public class RunSettingsBuilder
     {
         _scaleFish = true;
         _sfSettings = settings;
+        return this;
+    }
+
+    /// <summary>
+    ///     Enables the Skipper AI analysis layer for the current run. Requires an <c>ISailfishAgent</c> to be
+    ///     registered via <c>IRegisterSailfishServices</c>; otherwise the run proceeds completely unchanged.
+    /// </summary>
+    public RunSettingsBuilder WithAiAnalysis()
+    {
+        _aiAnalysis = true;
+        return this;
+    }
+
+    /// <summary>
+    ///     Enables the Skipper AI analysis layer with a custom <see cref="AiAnalysisSettings" /> object.
+    /// </summary>
+    public RunSettingsBuilder WithAiAnalysis(AiAnalysisSettings settings)
+    {
+        _aiAnalysis = true;
+        _aiSettings = settings;
         return this;
     }
 
@@ -358,7 +381,9 @@ public class RunSettingsBuilder
             _enableEnvironmentHealthCheck,
             _timerCalibration,
             seed: _seed,
-            scaleFishSettings: _sfSettings);
+            scaleFishSettings: _sfSettings,
+            useAiAnalysis: _aiAnalysis,
+            aiAnalysisSettings: _aiSettings);
     }
 
     private void ApplyPreset(SailfishPreset preset)

--- a/source/Tests.Library/Analysis/Ai/SkipperPhase0Tests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperPhase0Tests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Analysis.Ai;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.Ai;
+
+public class SkipperReviewTests
+{
+    [Fact]
+    public void Empty_HasNoContent()
+    {
+        SkipperReview.Empty.HasContent.ShouldBeFalse();
+        SkipperReview.Empty.OverallVerdict.ShouldBe(SkipperVerdict.Inconclusive);
+    }
+
+    [Fact]
+    public void HasContent_TrueWhenConsoleSummaryPresent()
+    {
+        var review = SkipperReview.Empty with { ConsoleSummary = "Skipper says hi" };
+        review.HasContent.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasContent_TrueWhenFindingsPresent()
+    {
+        var review = new SkipperReview(
+            SkipperVerdict.Regressed,
+            new[] { new Finding("Bench.Method", SkipperVerdict.Regressed, "slower", Array.Empty<string>(), 0.9) },
+            Array.Empty<ProposedAction>(),
+            string.Empty,
+            string.Empty);
+
+        review.HasContent.ShouldBeTrue();
+    }
+}
+
+public class CapabilityRegistryTests
+{
+    [Fact]
+    public void GrantedCapability_IsDiscoverable()
+    {
+        const string repoRoot = "/tmp/repo";
+        var registry = new CapabilityRegistry(new ISkipperCapability[] { new CodeReadCapability(repoRoot) });
+
+        registry.Has<ICodeReadCapability>().ShouldBeTrue();
+        registry.Get<ICodeReadCapability>().ShouldNotBeNull();
+        registry.Get<ICodeReadCapability>()!.RepositoryRoot.ShouldBe(repoRoot);
+        registry.Granted.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UngrantedCapability_IsAbsent()
+    {
+        var registry = new CapabilityRegistry(new ISkipperCapability[] { new CodeReadCapability("/tmp/repo") });
+
+        registry.Has<ITelemetryQueryCapability>().ShouldBeFalse();
+        registry.Get<ITelemetryQueryCapability>().ShouldBeNull();
+    }
+}
+
+public class NoOpSailfishAgentTests
+{
+    [Fact]
+    public async Task ReturnsEmptyReview()
+    {
+        var agent = new NoOpSailfishAgent();
+        var session = new SkipperSession(
+            SkipperRole.Explain,
+            new PerformanceNarrativeContext(Array.Empty<SailDiffCaseContext>(), string.Empty),
+            new CapabilityRegistry(Array.Empty<ISkipperCapability>()),
+            "/tmp");
+
+        var review = await agent.RunAsync(session, CancellationToken.None);
+
+        review.HasContent.ShouldBeFalse();
+    }
+}
+
+public class PerformanceNarrativeContextBuilderTests
+{
+    private const double Alpha = 0.05;
+    private readonly PerformanceNarrativeContextBuilder builder = new();
+
+    [Fact]
+    public void SignificantSlowdown_IsRegressed_WithCorrectPercentChange()
+    {
+        var context = Build(MakeResult("A", meanBefore: 100, meanAfter: 118, pValue: 0.001));
+
+        var c = context.Comparisons.Single();
+        c.Verdict.ShouldBe(SkipperVerdict.Regressed);
+        c.PercentChangeMean.ShouldBe(18.0, 1e-9);
+    }
+
+    [Fact]
+    public void SignificantSpeedup_IsImproved()
+    {
+        var context = Build(MakeResult("A", meanBefore: 100, meanAfter: 80, pValue: 0.001));
+        context.Comparisons.Single().Verdict.ShouldBe(SkipperVerdict.Improved);
+    }
+
+    [Fact]
+    public void NonSignificant_IsNotSignificant_RegardlessOfDirection()
+    {
+        var context = Build(MakeResult("A", meanBefore: 100, meanAfter: 130, pValue: 0.42));
+        context.Comparisons.Single().Verdict.ShouldBe(SkipperVerdict.NotSignificant);
+    }
+
+    [Fact]
+    public void AdjustedQValue_IsPreferredOverRawPValue()
+    {
+        // Raw p is significant, but the BH-FDR q-value is not → the family-wise verdict wins.
+        var context = Build(MakeResult("A", meanBefore: 100, meanAfter: 130, pValue: 0.001, qValue: 0.20));
+        context.Comparisons.Single().Verdict.ShouldBe(SkipperVerdict.NotSignificant);
+    }
+
+    [Fact]
+    public void FailedResult_IsInconclusive()
+    {
+        var context = Build(MakeResult("A", failed: true));
+        var c = context.Comparisons.Single();
+        c.Verdict.ShouldBe(SkipperVerdict.Inconclusive);
+        c.Failed.ShouldBeTrue();
+    }
+
+    private PerformanceNarrativeContext Build(params SailDiffResult[] results) =>
+        builder.Build(new SailDiffAnalysisCompleteNotification(results, "## markdown"), Alpha);
+
+    private static SailDiffResult MakeResult(
+        string name,
+        double meanBefore = 0,
+        double meanAfter = 0,
+        double pValue = 1.0,
+        double? qValue = null,
+        bool failed = false)
+    {
+        StatisticalTestResult stats;
+        if (failed)
+        {
+            stats = new StatisticalTestResult(new Exception("boom"));
+        }
+        else
+        {
+            stats = new StatisticalTestResult(
+                meanBefore, meanAfter,
+                medianBefore: meanBefore, medianAfter: meanAfter,
+                testStatistic: 0,
+                pValue: pValue,
+                changeDescription: "desc",
+                sampleSizeBefore: 10, sampleSizeAfter: 10,
+                rawDataBefore: Array.Empty<double>(), rawDataAfter: Array.Empty<double>(),
+                additionalResults: new Dictionary<string, object>())
+            {
+                QValue = qValue
+            };
+        }
+
+        return new SailDiffResult(new TestCaseId(name), new TestResultWithOutlierAnalysis(stats, null, null));
+    }
+}

--- a/source/Tests.Library/RunSettingsBuilder_AiAnalysisTests.cs
+++ b/source/Tests.Library/RunSettingsBuilder_AiAnalysisTests.cs
@@ -1,0 +1,44 @@
+using Sailfish;
+using Sailfish.Analysis.Ai;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library;
+
+public class RunSettingsBuilder_AiAnalysisTests
+{
+    [Fact]
+    public void AiAnalysis_IsOptIn_DefaultsOff()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder().Build();
+
+        settings.RunAiAnalysis.ShouldBeFalse();
+        settings.AiAnalysisSettings.ShouldNotBeNull();
+        settings.AiAnalysisSettings.Role.ShouldBe(SkipperRole.Explain);
+    }
+
+    [Fact]
+    public void WithAiAnalysis_EnablesIt_ReturnsThis()
+    {
+        var builder = RunSettingsBuilder.CreateBuilder();
+
+        var result = builder.WithAiAnalysis();
+
+        result.ShouldBeSameAs(builder);
+        builder.Build().RunAiAnalysis.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WithAiAnalysis_WithCustomSettings_FlowsThrough()
+    {
+        var custom = new AiAnalysisSettings(emitConsoleSummary: false, writeReviewArtifact: false, useResponseCache: false);
+
+        var settings = RunSettingsBuilder.CreateBuilder().WithAiAnalysis(custom).Build();
+
+        settings.RunAiAnalysis.ShouldBeTrue();
+        settings.AiAnalysisSettings.ShouldBeSameAs(custom);
+        settings.AiAnalysisSettings.EmitConsoleSummary.ShouldBeFalse();
+        settings.AiAnalysisSettings.WriteReviewArtifact.ShouldBeFalse();
+        settings.AiAnalysisSettings.UseResponseCache.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## What this is

Phase 0 of **Skipper** — an opt-in AI layer (sibling to SailDiff and ScaleFish) that explains *what changed and why* in a performance comparison. This PR lands the **load-bearing skeleton only**: the contracts and wiring. It is invisible at runtime until a consumer registers a real `ISailfishAgent`.

The design principle: **split transport from intelligence.** The one thing a consumer implements is `ISailfishAgent` (pure transport — forward a request to a model). Sailfish owns everything else: assembling a *grounded* context packet from the authoritative SailDiff numbers, caching, and rendering. The model reasons over the provided figures and **never recomputes them**.

## What's included (all the forward-compatible primitives, Explain implemented)

- **`ISailfishAgent`** + `SkipperSession` + `SkipperRole` (`Explain` | `Review` | `Remediate` | `Author` — only `Explain` is used today)
- **Capability model**: `ICapabilityRegistry` / `ISkipperCapability`, with `ICodeReadCapability` shipped and granted locally. Telemetry / version-control / ticket / benchmark-synthesis capabilities are reserved as markers so future automation slots in via DI without a contract change.
- **`SkipperReview`** (`Findings` + `ProposedAction`s) with the **propose-vs-execute boundary**: `IActionExecutor` is host-supplied and *absent locally*, so proposed actions are display-only.
- **`PerformanceNarrativeContext`** — grounded before/after figures lifted from `SailDiffResult`. Verdict is derived deterministically (BH-FDR q-value preferred over the raw p-value; vocabulary matches SailDiff — "not significant", never "no change").
- **`.WithAiAnalysis()`** on `RunSettingsBuilder`; `RunAiAnalysis` / `AiAnalysisSettings` on `IRunSettings`.
- **`SkipperSailDiffAnalysisHandler`** bridges `SailDiffAnalysisCompleteNotification` → agent, with a file-backed **response cache** (stable output, no re-spend) and a **`skipper-review_*.json`** artifact (the "act via artifacts" half of the planned hybrid topology).

## Why it's safe to merge now

Strictly additive and invisible by default:
- The no-op default agent is registered via `TryAddSingleton`, so a user-registered `ISailfishAgent` (from `IRegisterSailfishServices`) wins under any registration order.
- The whole path is gated on `RunAiAnalysis` (opt-in) and short-circuits when only the no-op agent is present.
- The handler never throws into a run — any failure is logged and the benchmark output is unaffected.

## Not in this PR (coming next, stacked)

- **Phase 1**: enrich the context packet (environment snapshot, ScaleFish scaling projections).
- **Phase 2**: inline console rendering (verdict chip + narrative beneath the SailDiff table).
- **Phase 3**: the agentic reference provider (`claude` CLI / Agent SDK, reads code under test, cites `file:line`) + the markdown Skipper Report.

## Test plan

- `dotnet build source/Sailfish.sln` → clean (0 errors).
- 14 new unit tests pass on **net9.0** and **net10.0**, covering: opt-in builder semantics, capability registry discovery, the no-op agent, `SkipperReview.HasContent`, and verdict derivation (regressed / improved / not-significant / q-value-preferred / failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)