### PR TITLE
Skipper Phase 1: environment snapshot + effect-size grounding

### DIFF
--- a/source/Sailfish/Analysis/Ai/EnvironmentSnapshot.cs
+++ b/source/Sailfish/Analysis/Ai/EnvironmentSnapshot.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     A concise, reliability-focused snapshot of the machine and runtime the benchmark ran on, projected from
+///     Sailfish's reproducibility manifest and environment health check. Lets Skipper describe the environment
+///     and — crucially — temper its verdict when the host is noisy or misconfigured (the dominant failure mode of
+///     microbenchmarking). Volatile fields (timestamp, session id) are deliberately excluded so the context hash —
+///     and therefore the cached narrative — stays stable across runs on the same machine and commit.
+/// </summary>
+public sealed record EnvironmentSnapshot(
+    string DotNetRuntime,
+    string Os,
+    string OsArchitecture,
+    string ProcessArchitecture,
+    string? CpuModel,
+    string GcMode,
+    string Jit,
+    string CpuAffinity,
+    string Timer,
+    int HealthScore,
+    string? HealthLabel,
+    string? CiSystem,
+    string? CommitSha,
+    IReadOnlyList<EnvironmentConcern> Concerns);
+
+/// <summary>A single environment health concern (a Warn or Fail entry) the agent should weigh when judging reliability.</summary>
+public sealed record EnvironmentConcern(
+    string Name,
+    string Status,
+    string Details,
+    string? Recommendation);

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContext.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContext.cs
@@ -9,7 +9,8 @@ namespace Sailfish.Analysis.Ai;
 /// </summary>
 public sealed record PerformanceNarrativeContext(
     IReadOnlyList<SailDiffCaseContext> Comparisons,
-    string SailDiffMarkdown);
+    string SailDiffMarkdown,
+    EnvironmentSnapshot? Environment);
 
 /// <summary>Grounded before / after figures for one test case, lifted directly from a SailDiff result.</summary>
 public sealed record SailDiffCaseContext(
@@ -25,4 +26,7 @@ public sealed record SailDiffCaseContext(
     string ChangeDescription,
     int SampleSizeBefore,
     int SampleSizeAfter,
-    bool Failed);
+    bool Failed,
+    string? EffectSizeName = null,
+    double? EffectSizeValue = null,
+    double? MinimumDetectableEffectPercent = null);

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Results;
 
 namespace Sailfish.Analysis.Ai;
 
@@ -17,13 +19,57 @@ internal interface IPerformanceNarrativeContextBuilder
 /// </summary>
 internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrativeContextBuilder
 {
+    private readonly IEnvironmentHealthReportProvider healthProvider;
+    private readonly IReproducibilityManifestProvider manifestProvider;
+
+    public PerformanceNarrativeContextBuilder(
+        IReproducibilityManifestProvider manifestProvider,
+        IEnvironmentHealthReportProvider healthProvider)
+    {
+        this.manifestProvider = manifestProvider;
+        this.healthProvider = healthProvider;
+    }
+
     public PerformanceNarrativeContext Build(SailDiffAnalysisCompleteNotification notification, double alpha)
     {
         var comparisons = notification.TestCaseResults
             .Select(result => ToCaseContext(result, alpha))
             .ToList();
 
-        return new PerformanceNarrativeContext(comparisons, notification.ResultsAsMarkdown ?? string.Empty);
+        return new PerformanceNarrativeContext(comparisons, notification.ResultsAsMarkdown ?? string.Empty, BuildEnvironment());
+    }
+
+    /// <summary>
+    ///     Projects the reproducibility manifest and environment health report (if captured) into a concise
+    ///     snapshot. Returns null when neither is available — the narrative simply proceeds without environment
+    ///     context. Both are read defensively so timing of capture never breaks the analysis.
+    /// </summary>
+    private EnvironmentSnapshot? BuildEnvironment()
+    {
+        var manifest = manifestProvider.Current;
+        var health = healthProvider.Current;
+        if (manifest is null && health is null) return null;
+
+        var concerns = health?.Entries
+            .Where(entry => entry.Status is HealthStatus.Warn or HealthStatus.Fail)
+            .Select(entry => new EnvironmentConcern(entry.Name, entry.Status.ToString(), entry.Details, entry.Recommendation))
+            .ToList() ?? new List<EnvironmentConcern>();
+
+        return new EnvironmentSnapshot(
+            manifest?.DotNetRuntime ?? string.Empty,
+            manifest?.Os ?? string.Empty,
+            manifest?.OsArchitecture ?? string.Empty,
+            manifest?.ProcessArchitecture ?? string.Empty,
+            manifest?.CpuModel,
+            manifest?.GcMode ?? string.Empty,
+            manifest?.Jit ?? string.Empty,
+            manifest?.CpuAffinity ?? string.Empty,
+            manifest?.Timer ?? string.Empty,
+            manifest?.EnvironmentHealthScore ?? health?.Score ?? 0,
+            manifest?.EnvironmentHealthLabel ?? health?.SummaryLabel,
+            manifest?.CiSystem,
+            manifest?.CommitSha,
+            concerns);
     }
 
     private static SailDiffCaseContext ToCaseContext(SailDiffResult result, double alpha)
@@ -57,7 +103,10 @@ internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrative
             stats.ChangeDescription,
             stats.SampleSizeBefore,
             stats.SampleSizeAfter,
-            Failed: false);
+            Failed: false,
+            EffectSizeName: stats.EffectSize?.Name,
+            EffectSizeValue: stats.EffectSize?.Value,
+            MinimumDetectableEffectPercent: stats.MinimumDetectableEffectPercent);
     }
 
     private static SkipperVerdict DeriveVerdict(StatisticalTestResult stats, double alpha)

--- a/source/Tests.Library/Analysis/Ai/SkipperEnvironmentTests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperEnvironmentTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using Sailfish.Analysis.Ai;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Results;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.Ai;
+
+public class SkipperEnvironmentTests
+{
+    [Fact]
+    public void Environment_IsNull_WhenNeitherManifestNorHealthCaptured()
+    {
+        var context = MakeBuilder(manifest: null, health: null).Build(Notification(), 0.05);
+
+        context.Environment.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Environment_ProjectsManifestFields_AndFiltersConcernsToWarnAndFail()
+    {
+        var manifest = new ReproducibilityManifest
+        {
+            DotNetRuntime = ".NET 10.0",
+            Os = "macOS 15",
+            CpuModel = "Apple M3",
+            GcMode = "Workstation",
+            CiSystem = "GitHub Actions",
+            CommitSha = "abc123",
+            EnvironmentHealthScore = 72,
+            EnvironmentHealthLabel = "Good"
+        };
+        var health = new EnvironmentHealthReport(new[]
+        {
+            new HealthCheckEntry("Power Plan", HealthStatus.Warn, "Balanced", "Switch to High Performance"),
+            new HealthCheckEntry("Tiered PGO", HealthStatus.Pass, "disabled"),
+            new HealthCheckEntry("Debugger", HealthStatus.Fail, "attached", "Detach the debugger")
+        });
+
+        var context = MakeBuilder(manifest, health).Build(Notification(), 0.05);
+
+        context.Environment.ShouldNotBeNull();
+        var env = context.Environment!;
+        env.DotNetRuntime.ShouldBe(".NET 10.0");
+        env.CpuModel.ShouldBe("Apple M3");
+        env.CiSystem.ShouldBe("GitHub Actions");
+        env.CommitSha.ShouldBe("abc123");
+        env.HealthScore.ShouldBe(72);
+        env.HealthLabel.ShouldBe("Good");
+
+        // Only Warn/Fail entries are surfaced as concerns — Pass is noise for reliability judgement.
+        env.Concerns.Select(c => c.Name).ShouldBe(new[] { "Power Plan", "Debugger" }, ignoreOrder: true);
+        env.Concerns.Single(c => c.Name == "Power Plan").Recommendation.ShouldBe("Switch to High Performance");
+    }
+
+    [Fact]
+    public void Environment_UsesHealthReportScore_WhenManifestAbsent()
+    {
+        var health = new EnvironmentHealthReport(new[]
+        {
+            new HealthCheckEntry("Timer", HealthStatus.Pass, "high-resolution")
+        });
+
+        var context = MakeBuilder(manifest: null, health: health).Build(Notification(), 0.05);
+
+        context.Environment.ShouldNotBeNull();
+        context.Environment!.HealthScore.ShouldBe(health.Score);
+        context.Environment.Concerns.ShouldBeEmpty();
+    }
+
+    private static PerformanceNarrativeContextBuilder MakeBuilder(ReproducibilityManifest? manifest, EnvironmentHealthReport? health)
+    {
+        var manifestProvider = Substitute.For<IReproducibilityManifestProvider>();
+        manifestProvider.Current.Returns(manifest);
+        var healthProvider = Substitute.For<IEnvironmentHealthReportProvider>();
+        healthProvider.Current.Returns(health);
+        return new PerformanceNarrativeContextBuilder(manifestProvider, healthProvider);
+    }
+
+    private static SailDiffAnalysisCompleteNotification Notification()
+    {
+        var stats = new StatisticalTestResult(
+            10, 11, 10, 11, 0, 0.01, "desc", 5, 5,
+            Array.Empty<double>(), Array.Empty<double>(), new Dictionary<string, object>());
+        var result = new SailDiffResult(new TestCaseId("X"), new TestResultWithOutlierAnalysis(stats, null, null));
+        return new SailDiffAnalysisCompleteNotification(new[] { result }, "## md");
+    }
+}

--- a/source/Tests.Library/Analysis/Ai/SkipperPhase0Tests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperPhase0Tests.cs
@@ -7,6 +7,9 @@ using Sailfish.Analysis.Ai;
 using Sailfish.Analysis.SailDiff.Statistics.Tests;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Results;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -74,7 +77,7 @@ public class NoOpSailfishAgentTests
         var agent = new NoOpSailfishAgent();
         var session = new SkipperSession(
             SkipperRole.Explain,
-            new PerformanceNarrativeContext(Array.Empty<SailDiffCaseContext>(), string.Empty),
+            new PerformanceNarrativeContext(Array.Empty<SailDiffCaseContext>(), string.Empty, null),
             new CapabilityRegistry(Array.Empty<ISkipperCapability>()),
             "/tmp");
 
@@ -87,7 +90,9 @@ public class NoOpSailfishAgentTests
 public class PerformanceNarrativeContextBuilderTests
 {
     private const double Alpha = 0.05;
-    private readonly PerformanceNarrativeContextBuilder builder = new();
+    private readonly PerformanceNarrativeContextBuilder builder = new(
+        Substitute.For<IReproducibilityManifestProvider>(),
+        Substitute.For<IEnvironmentHealthReportProvider>());
 
     [Fact]
     public void SignificantSlowdown_IsRegressed_WithCorrectPercentChange()
@@ -130,6 +135,19 @@ public class PerformanceNarrativeContextBuilderTests
         c.Failed.ShouldBeTrue();
     }
 
+    [Fact]
+    public void EffectSizeAndMde_FlowIntoContext()
+    {
+        var context = Build(MakeResult("A", meanBefore: 100, meanAfter: 118, pValue: 0.001,
+            effectSize: new EffectSizeReport("Cliff's delta", 0.8, 0.5, 0.95),
+            minimumDetectableEffectPercent: 3.2));
+
+        var c = context.Comparisons.Single();
+        c.EffectSizeName.ShouldBe("Cliff's delta");
+        c.EffectSizeValue!.Value.ShouldBe(0.8, 1e-9);
+        c.MinimumDetectableEffectPercent!.Value.ShouldBe(3.2, 1e-9);
+    }
+
     private PerformanceNarrativeContext Build(params SailDiffResult[] results) =>
         builder.Build(new SailDiffAnalysisCompleteNotification(results, "## markdown"), Alpha);
 
@@ -139,7 +157,9 @@ public class PerformanceNarrativeContextBuilderTests
         double meanAfter = 0,
         double pValue = 1.0,
         double? qValue = null,
-        bool failed = false)
+        bool failed = false,
+        EffectSizeReport? effectSize = null,
+        double? minimumDetectableEffectPercent = null)
     {
         StatisticalTestResult stats;
         if (failed)
@@ -158,7 +178,9 @@ public class PerformanceNarrativeContextBuilderTests
                 rawDataBefore: Array.Empty<double>(), rawDataAfter: Array.Empty<double>(),
                 additionalResults: new Dictionary<string, object>())
             {
-                QValue = qValue
+                QValue = qValue,
+                EffectSize = effectSize,
+                MinimumDetectableEffectPercent = minimumDetectableEffectPercent
             };
         }
 


### PR DESCRIPTION
> **Stacked on #266 (Phase 0).** Review/merge that first; this PR targets the Phase 0 branch and will retarget to `main` once it lands.

## What this adds

Phase 0 shipped the contracts. Phase 1 makes the grounded context packet genuinely *informative* — the foundation for reliability-aware narratives. Still no model calls and no rendering; this is pure context enrichment.

- **`EnvironmentSnapshot`** — a concise projection of Sailfish's existing `ReproducibilityManifest` (runtime, OS, CPU, GC mode, JIT, CPU affinity, timer, CI system, commit SHA) plus the environment health score/label. Volatile fields (timestamp, session id) are deliberately excluded so the cache key stays stable per machine + commit.
- **`EnvironmentConcern`** — `Warn`/`Fail` health-check entries (with their recommendations) are surfaced so Skipper can *temper a verdict on a noisy or misconfigured host* — the dominant failure mode of microbenchmarking. `Pass` entries are dropped as noise.
- **Richer `SailDiffCaseContext`** — adds `EffectSizeName` / `EffectSizeValue` and `MinimumDetectableEffectPercent`, lifted from `StatisticalTestResult`: magnitude and statistical power alongside the binary significance verdict.
- **`PerformanceNarrativeContextBuilder`** now reads `IReproducibilityManifestProvider` and `IEnvironmentHealthReportProvider` **defensively** — returns `null` environment when neither has been captured yet, so the timing of capture can never break the analysis.

## Why it's grounded

The environment data comes straight from the manifest Sailfish already computes; the effect size and MDE come straight from SailDiff. Nothing here is invented — the agent (arriving in Phase 3) reasons over these figures, it doesn't produce them.

## Test plan

- 4 new tests (18 total across the Skipper suite) covering effect-size/MDE flow-through, manifest projection, Warn/Fail concern filtering, and the health-only (no-manifest) fallback.
- Core + full solution build clean on **net9.0** and **net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)