### PR TITLE
Skipper Phase 2: inline console formatter (verdict chips)

### DIFF
--- a/source/Sailfish/Analysis/Ai/SkipperConsoleFormatter.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperConsoleFormatter.cs
@@ -1,0 +1,59 @@
+using System.Text;
+
+namespace Sailfish.Analysis.Ai;
+
+internal interface ISkipperConsoleFormatter
+{
+    string Format(SkipperReview review);
+}
+
+/// <summary>
+///     Renders a <see cref="SkipperReview" /> into the inline console block shown beneath the SailDiff table.
+///     Owning the formatting here (rather than trusting the agent's prose) keeps the verdict vocabulary and the
+///     🔴/🟢/⚪/🟡 chips consistent no matter which model produced the review.
+/// </summary>
+internal sealed class SkipperConsoleFormatter : ISkipperConsoleFormatter
+{
+    public string Format(SkipperReview review)
+    {
+        var sb = new StringBuilder();
+        sb.Append("🧭 Skipper  ").Append(Chip(review.OverallVerdict)).Append(' ').Append(Label(review.OverallVerdict));
+
+        if (!string.IsNullOrWhiteSpace(review.ConsoleSummary))
+        {
+            sb.AppendLine();
+            sb.Append(review.ConsoleSummary.Trim());
+        }
+
+        foreach (var finding in review.Findings)
+        {
+            sb.AppendLine();
+            sb.Append("  • ").Append(Chip(finding.Verdict)).Append(' ')
+                .Append(finding.TestCaseDisplayName).Append(" — ").Append(finding.Summary.Trim());
+
+            if (finding.CitedSourceLocations is { Count: > 0 })
+            {
+                sb.AppendLine();
+                sb.Append("       ↳ ").Append(string.Join(", ", finding.CitedSourceLocations));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Chip(SkipperVerdict verdict) => verdict switch
+    {
+        SkipperVerdict.Regressed => "🔴",
+        SkipperVerdict.Improved => "🟢",
+        SkipperVerdict.NotSignificant => "⚪",
+        _ => "🟡"
+    };
+
+    private static string Label(SkipperVerdict verdict) => verdict switch
+    {
+        SkipperVerdict.Regressed => "REGRESSED",
+        SkipperVerdict.Improved => "IMPROVED",
+        SkipperVerdict.NotSignificant => "NOT SIGNIFICANT",
+        _ => "INCONCLUSIVE"
+    };
+}

--- a/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
@@ -24,6 +24,7 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
 {
     private readonly ISailfishAgent agent;
     private readonly IConsoleWriter consoleWriter;
+    private readonly ISkipperConsoleFormatter consoleFormatter;
     private readonly IPerformanceNarrativeContextBuilder contextBuilder;
     private readonly ILogger logger;
     private readonly ISkipperResponseCache responseCache;
@@ -37,6 +38,7 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
         ISkipperReviewWriter reviewWriter,
         ISkipperResponseCache responseCache,
         IConsoleWriter consoleWriter,
+        ISkipperConsoleFormatter consoleFormatter,
         ILogger logger)
     {
         this.runSettings = runSettings;
@@ -45,6 +47,7 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
         this.reviewWriter = reviewWriter;
         this.responseCache = responseCache;
         this.consoleWriter = consoleWriter;
+        this.consoleFormatter = consoleFormatter;
         this.logger = logger;
     }
 
@@ -66,8 +69,8 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
             if (settings.WriteReviewArtifact)
                 await reviewWriter.WriteAsync(review, cancellationToken).ConfigureAwait(false);
 
-            if (settings.EmitConsoleSummary && !string.IsNullOrWhiteSpace(review.ConsoleSummary))
-                consoleWriter.WriteString(review.ConsoleSummary);
+            if (settings.EmitConsoleSummary)
+                consoleWriter.WriteString(consoleFormatter.Format(review));
         }
         catch (Exception ex)
         {

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -141,6 +141,7 @@ internal static class SailfishModuleRegistrations
         services.AddTransient<IPerformanceNarrativeContextBuilder, PerformanceNarrativeContextBuilder>();
         services.AddTransient<ISkipperReviewWriter, SkipperReviewWriter>();
         services.AddTransient<ISkipperResponseCache, FileSkipperResponseCache>();
+        services.AddTransient<ISkipperConsoleFormatter, SkipperConsoleFormatter>();
 
         return services;
     }

--- a/source/Tests.Library/Analysis/Ai/SkipperConsoleFormatterTests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperConsoleFormatterTests.cs
@@ -1,0 +1,64 @@
+using System;
+using Sailfish.Analysis.Ai;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.Ai;
+
+public class SkipperConsoleFormatterTests
+{
+    private readonly SkipperConsoleFormatter formatter = new();
+
+    [Fact]
+    public void Format_RendersOverallVerdictChipAndLabel()
+    {
+        var review = new SkipperReview(
+            SkipperVerdict.Regressed,
+            Array.Empty<Finding>(),
+            Array.Empty<ProposedAction>(),
+            "ParseHeaders got slower.",
+            string.Empty);
+
+        var output = formatter.Format(review);
+
+        output.ShouldContain("🧭 Skipper");
+        output.ShouldContain("🔴");
+        output.ShouldContain("REGRESSED");
+        output.ShouldContain("ParseHeaders got slower.");
+    }
+
+    [Fact]
+    public void Format_RendersFindingsWithChipsAndCitations()
+    {
+        var review = new SkipperReview(
+            SkipperVerdict.Regressed,
+            new[]
+            {
+                new Finding("Bench.ParseHeaders", SkipperVerdict.Regressed, "regex allocated in loop",
+                    new[] { "Parser.cs:88" }, 0.9)
+            },
+            Array.Empty<ProposedAction>(),
+            string.Empty,
+            string.Empty);
+
+        var output = formatter.Format(review);
+
+        output.ShouldContain("Bench.ParseHeaders");
+        output.ShouldContain("regex allocated in loop");
+        output.ShouldContain("Parser.cs:88");
+    }
+
+    [Theory]
+    [InlineData(SkipperVerdict.Improved, "🟢", "IMPROVED")]
+    [InlineData(SkipperVerdict.NotSignificant, "⚪", "NOT SIGNIFICANT")]
+    [InlineData(SkipperVerdict.Inconclusive, "🟡", "INCONCLUSIVE")]
+    public void Format_MapsVerdictToChipAndLabel(SkipperVerdict verdict, string chip, string label)
+    {
+        var review = new SkipperReview(verdict, Array.Empty<Finding>(), Array.Empty<ProposedAction>(), "narrative", string.Empty);
+
+        var output = formatter.Format(review);
+
+        output.ShouldContain(chip);
+        output.ShouldContain(label);
+    }
+}


### PR DESCRIPTION
> **Stacked on #267 (Phase 1), which is stacked on #266 (Phase 0).** Merge in order; this retargets to `main` after its parents land.

## What this adds

The formatter that turns a structured `SkipperReview` into the inline block shown beneath the SailDiff table. The key design point: **Sailfish owns the formatting, not the agent.** The agent returns structured `Findings` + a short summary; Sailfish renders the chips and verdict labels — so the vocabulary stays consistent no matter which model produced the review.

- **`SkipperConsoleFormatter`**: header + overall verdict chip/label, the narrative, then one bullet per `Finding` with its own chip and the `file:line` locations it cited. Verdict labels match SailDiff's vocabulary (`NOT SIGNIFICANT`, never "no change").
- Chips: 🔴 regressed · 🟢 improved · ⚪ not significant · 🟡 inconclusive.
- The handler now formats the whole review via `ISkipperConsoleFormatter` instead of echoing the raw `ConsoleSummary`.

Example of what a registered agent will produce beneath the table:

```
🧭 Skipper  🔴 REGRESSED
ParseHeaders is 18% slower than baseline and it's a real change (p<0.001, CV 2.1%).
  • 🔴 Bench.ParseHeaders — regex compiled inside the per-row loop
       ↳ Parser.cs:88
```

## Still invisible by default

With only the no-op agent registered, the handler short-circuits and nothing renders — the formatter is exercised by unit tests today and lights up automatically when a real `ISailfishAgent` arrives in Phase 3.

## Test plan

- 5 new tests (23 total): chip/label mapping for every verdict, finding rendering with citations, and narrative inclusion.
- Builds clean on **net9.0** and **net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)