### PR TITLE
Skipper Phase 3: agentic claude-CLI reference provider + markdown report

### DIFF
--- a/source/ConsoleAppDemo/AppRegistrationProvider.cs
+++ b/source/ConsoleAppDemo/AppRegistrationProvider.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using PerformanceTestingUserInvokedConsoleApp.CustomHandlerOverrideExamples;
+using Sailfish.Analysis.Ai;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Registration;
 
@@ -15,6 +16,11 @@ public class AppRegistrationProvider : IRegisterSailfishServices
         services.AddTransient<WebApplicationFactory<DemoApp>>();
         services.AddTransient<INotificationHandler<TestRunCompletedNotification>, TestRunCompletedNotificationHandler>();
         services.AddTransient<ICloudWriter, CloudWriter>();
+
+        // Reference agentic Skipper: drives the `claude` CLI to read the code under test and explain regressions.
+        // Registering an ISailfishAgent is the only step needed to light up the AI analysis layer.
+        services.AddSingleton<ISailfishAgent, ClaudeAgentModelProvider>();
+
         await Task.Yield();
     }
 }

--- a/source/ConsoleAppDemo/CustomHandlerOverrideExamples/ClaudeAgentModelProvider.cs
+++ b/source/ConsoleAppDemo/CustomHandlerOverrideExamples/ClaudeAgentModelProvider.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sailfish.Analysis.Ai;
+
+namespace PerformanceTestingUserInvokedConsoleApp.CustomHandlerOverrideExamples;
+
+/// <summary>
+///     Reference <see cref="ISailfishAgent" /> that drives the <c>claude</c> CLI as an agentic, code-aware
+///     analyst. This is the "one seam, two power levels" payoff: the same interface that accepts a dumb one-shot
+///     completion also accepts a full agent that <em>reads the code under test</em> and cites <c>file:line</c>.
+///     <para>
+///         It hands Skipper's grounded context to <c>claude -p</c> with read-only tools (Read/Grep/Glob) scoped to
+///         the repository root, then parses the returned JSON into a <see cref="SkipperReview" />. Everything
+///         degrades gracefully — if the CLI is absent or errors, a short note is returned and the benchmark run is
+///         unaffected. Copy this into your own project and adapt the transport (Anthropic SDK, Bedrock, a local
+///         model) to taste; the CLI flags below may need tweaking for your installed version.
+///     </para>
+/// </summary>
+internal sealed class ClaudeAgentModelProvider : ISailfishAgent
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public async Task<SkipperReview> RunAsync(SkipperSession session, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var raw = await InvokeClaudeAsync(BuildPrompt(session), session.RepositoryRoot, cancellationToken);
+            return ParseReview(raw);
+        }
+        catch (Exception ex)
+        {
+            // The CLI may be missing, unauthenticated, or offline. Skipper is strictly additive — never throw.
+            return SkipperReview.Empty with { ConsoleSummary = $"(Skipper unavailable: {ex.Message})" };
+        }
+    }
+
+    private static string BuildPrompt(SkipperSession session)
+    {
+        var contextJson = JsonSerializer.Serialize(session.Context, JsonOptions);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("You are Skipper, a performance analyst embedded in the Sailfish benchmarking library.");
+        sb.AppendLine("A SailDiff comparison just completed. Explain WHAT changed and, by reading the code under test, WHY.");
+        sb.AppendLine();
+        sb.AppendLine("Rules:");
+        sb.AppendLine("- Use ONLY the numbers in the context below. Never invent or recompute a measurement.");
+        sb.AppendLine("- You MAY read files under the repository root to find the cause. Cite each as path:line.");
+        sb.AppendLine("- If the environment shows concerns, or a change is not statistically significant, say so and temper the verdict.");
+        sb.AppendLine("- Respond with ONLY a JSON object (no prose, no code fences) matching this schema:");
+        sb.AppendLine("""
+                      {
+                        "overallVerdict": "Improved|Regressed|NotSignificant|Inconclusive",
+                        "consoleSummary": "<=3 sentence plain-text summary",
+                        "markdownReport": "a fuller markdown explanation that cites file:line",
+                        "findings": [
+                          {"testCaseDisplayName":"...","verdict":"Improved|Regressed|NotSignificant|Inconclusive","summary":"...","citedSourceLocations":["path:line"],"confidence":0.0}
+                        ]
+                      }
+                      """);
+        sb.AppendLine();
+        sb.AppendLine("Context:");
+        sb.AppendLine(contextJson);
+        return sb.ToString();
+    }
+
+    private static async Task<string> InvokeClaudeAsync(string prompt, string repositoryRoot, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "claude",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Directory.Exists(repositoryRoot) ? repositoryRoot : Directory.GetCurrentDirectory()
+        };
+        startInfo.ArgumentList.Add("-p");                 // headless "print" mode; prompt arrives on stdin
+        startInfo.ArgumentList.Add("--output-format");
+        startInfo.ArgumentList.Add("text");
+        startInfo.ArgumentList.Add("--allowedTools");     // read-only investigation only
+        startInfo.ArgumentList.Add("Read");
+        startInfo.ArgumentList.Add("Grep");
+        startInfo.ArgumentList.Add("Glob");
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        await process.StandardInput.WriteAsync(prompt);
+        process.StandardInput.Close();
+
+        var stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"claude exited with code {process.ExitCode}: {stderr}");
+
+        return stdout;
+    }
+
+    private static SkipperReview ParseReview(string raw)
+    {
+        var json = ExtractJsonObject(raw);
+        if (json is null)
+            return SkipperReview.Empty with { ConsoleSummary = raw.Trim(), MarkdownReport = raw.Trim() };
+
+        try
+        {
+            var dto = JsonSerializer.Deserialize<ReviewDto>(json, JsonOptions);
+            if (dto is null) return SkipperReview.Empty;
+
+            var findings = (dto.Findings ?? new List<FindingDto>())
+                .Select(f => new Finding(
+                    f.TestCaseDisplayName ?? string.Empty,
+                    f.Verdict,
+                    f.Summary ?? string.Empty,
+                    f.CitedSourceLocations ?? new List<string>(),
+                    f.Confidence))
+                .ToList();
+
+            return new SkipperReview(
+                dto.OverallVerdict,
+                findings,
+                Array.Empty<ProposedAction>(),
+                dto.ConsoleSummary ?? string.Empty,
+                dto.MarkdownReport ?? string.Empty);
+        }
+        catch
+        {
+            return SkipperReview.Empty with { ConsoleSummary = raw.Trim() };
+        }
+    }
+
+    private static string? ExtractJsonObject(string raw)
+    {
+        var start = raw.IndexOf('{');
+        var end = raw.LastIndexOf('}');
+        return start >= 0 && end > start ? raw[start..(end + 1)] : null;
+    }
+
+    private sealed class ReviewDto
+    {
+        public SkipperVerdict OverallVerdict { get; set; }
+        public string? ConsoleSummary { get; set; }
+        public string? MarkdownReport { get; set; }
+        public List<FindingDto>? Findings { get; set; }
+    }
+
+    private sealed class FindingDto
+    {
+        public string? TestCaseDisplayName { get; set; }
+        public SkipperVerdict Verdict { get; set; }
+        public string? Summary { get; set; }
+        public List<string>? CitedSourceLocations { get; set; }
+        public double Confidence { get; set; }
+    }
+}

--- a/source/ConsoleAppDemo/Program.cs
+++ b/source/ConsoleAppDemo/Program.cs
@@ -12,6 +12,7 @@ var settings = RunSettingsBuilder
     .WithTestNames(typeof(ReadmeExample).FullName!)
     .WithSailDiff()
     .WithScaleFish()
+    .WithAiAnalysis() // Skipper: explains SailDiff results via the registered ISailfishAgent (see AppRegistrationProvider)
     // .WithGlobalSampleSize(30)
     .WithMinimumLogLevel(LogLevel.Information)
     // .WithCustomLogger(new CustomLogger(new LoggerConfiguration().WriteTo.Console().CreateLogger()))

--- a/source/Sailfish/Analysis/Ai/SkipperReportWriter.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperReportWriter.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Presentation;
+
+namespace Sailfish.Analysis.Ai;
+
+internal interface ISkipperReportWriter
+{
+    Task WriteAsync(SkipperReview review, CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Persists the agent's full causal write-up as a human-readable <c>skipper-report_*.md</c> beside the run
+///     output. This is the deep artifact (call paths, cited code, suggested fixes) that complements the terse
+///     console block; <c>review.json</c> remains the machine-readable sibling.
+/// </summary>
+internal sealed class SkipperReportWriter : ISkipperReportWriter
+{
+    private readonly IRunSettings runSettings;
+
+    public SkipperReportWriter(IRunSettings runSettings)
+    {
+        this.runSettings = runSettings;
+    }
+
+    public async Task WriteAsync(SkipperReview review, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(review.MarkdownReport)) return;
+
+        var directory = runSettings.LocalOutputDirectory;
+        Directory.CreateDirectory(directory);
+
+        var fileName = DefaultFileSettings.AppendTagsToFilename(
+            $"skipper-report_{runSettings.TimeStamp:yyyyMMdd_HHmmss}.md",
+            runSettings.Tags);
+        var filePath = Path.Join(directory, fileName);
+
+        await File.WriteAllTextAsync(filePath, review.MarkdownReport, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
@@ -29,6 +29,7 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
     private readonly ILogger logger;
     private readonly ISkipperResponseCache responseCache;
     private readonly ISkipperReviewWriter reviewWriter;
+    private readonly ISkipperReportWriter reportWriter;
     private readonly IRunSettings runSettings;
 
     public SkipperSailDiffAnalysisHandler(
@@ -36,6 +37,7 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
         ISailfishAgent agent,
         IPerformanceNarrativeContextBuilder contextBuilder,
         ISkipperReviewWriter reviewWriter,
+        ISkipperReportWriter reportWriter,
         ISkipperResponseCache responseCache,
         IConsoleWriter consoleWriter,
         ISkipperConsoleFormatter consoleFormatter,
@@ -45,6 +47,7 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
         this.agent = agent;
         this.contextBuilder = contextBuilder;
         this.reviewWriter = reviewWriter;
+        this.reportWriter = reportWriter;
         this.responseCache = responseCache;
         this.consoleWriter = consoleWriter;
         this.consoleFormatter = consoleFormatter;
@@ -67,7 +70,10 @@ internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<Sail
             if (!review.HasContent) return;
 
             if (settings.WriteReviewArtifact)
+            {
                 await reviewWriter.WriteAsync(review, cancellationToken).ConfigureAwait(false);
+                await reportWriter.WriteAsync(review, cancellationToken).ConfigureAwait(false);
+            }
 
             if (settings.EmitConsoleSummary)
                 consoleWriter.WriteString(consoleFormatter.Format(review));

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -140,6 +140,7 @@ internal static class SailfishModuleRegistrations
         services.TryAddSingleton<ISailfishAgent, NoOpSailfishAgent>();
         services.AddTransient<IPerformanceNarrativeContextBuilder, PerformanceNarrativeContextBuilder>();
         services.AddTransient<ISkipperReviewWriter, SkipperReviewWriter>();
+        services.AddTransient<ISkipperReportWriter, SkipperReportWriter>();
         services.AddTransient<ISkipperResponseCache, FileSkipperResponseCache>();
         services.AddTransient<ISkipperConsoleFormatter, SkipperConsoleFormatter>();
 

--- a/source/Tests.Library/Analysis/Ai/SkipperReportWriterTests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperReportWriterTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish;
+using Sailfish.Analysis.Ai;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.Ai;
+
+public class SkipperReportWriterTests
+{
+    [Fact]
+    public async Task WritesMarkdownReport_WhenPresent()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var settings = RunSettingsBuilder.CreateBuilder().WithLocalOutputDirectory(dir).Build();
+            var writer = new SkipperReportWriter(settings);
+            var review = new SkipperReview(
+                SkipperVerdict.Regressed,
+                Array.Empty<Finding>(),
+                Array.Empty<ProposedAction>(),
+                "summary",
+                "# Skipper Report\n\nParseHeaders regressed — regex compiled in loop (Parser.cs:88).");
+
+            await writer.WriteAsync(review, CancellationToken.None);
+
+            var file = Directory.GetFiles(dir, "skipper-report_*.md").ShouldHaveSingleItem();
+            (await File.ReadAllTextAsync(file)).ShouldContain("Parser.cs:88");
+        }
+        finally
+        {
+            Cleanup(dir);
+        }
+    }
+
+    [Fact]
+    public async Task WritesNothing_WhenMarkdownReportEmpty()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var settings = RunSettingsBuilder.CreateBuilder().WithLocalOutputDirectory(dir).Build();
+            var writer = new SkipperReportWriter(settings);
+            var review = SkipperReview.Empty with { ConsoleSummary = "summary only" };
+
+            await writer.WriteAsync(review, CancellationToken.None);
+
+            Directory.GetFiles(dir, "skipper-report_*.md").ShouldBeEmpty();
+        }
+        finally
+        {
+            Cleanup(dir);
+        }
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "skipper-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+        catch
+        {
+            /* best effort */
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #268 (Phase 2) → #267 (Phase 1) → #266 (Phase 0).** Merge in order; retargets to `main` after parents land.

## What this adds — the payoff

A real, **code-aware** `ISailfishAgent` plus the deep human-readable artifact. This is where Skipper stops describing numbers and starts *diagnosing* them.

### Core (`Sailfish`)
- **`SkipperReportWriter`** persists `review.MarkdownReport` as **`skipper-report_*.md`** beside the run output — the deep artifact (call paths, cited code, suggested fixes) that complements the terse console block and the machine-readable `review.json`. Wired into the handler under `WriteReviewArtifact`; registered in DI.

### Reference implementation (`ConsoleAppDemo`)
- **`ClaudeAgentModelProvider : ISailfishAgent`** drives the `claude` CLI (`claude -p`) with **read-only tools** (`Read`/`Grep`/`Glob`) scoped to the repository root. It:
  - hands the model Skipper's grounded context packet,
  - instructs it to **cite `file:line` and never invent numbers**,
  - parses the JSON response into a `SkipperReview`,
  - **degrades gracefully** if the CLI is absent/offline/unauthenticated — the benchmark run is never affected.
- This is the **"one seam, two power levels"** demonstration: the same `ISailfishAgent` interface that accepts a dumb one-shot completion also accepts a full agent that reads the code under test. Copy it into your own project and swap the transport (Anthropic SDK, Bedrock, a local model) as needed.
- Registered via `AppRegistrationProvider`; the demo run opts in with `.WithAiAnalysis()`.

## End-to-end, this is what a local run now produces

Beneath the SailDiff table: the inline verdict block (Phase 2). On disk: `skipper-report_*.md` (this PR) + `review.json` (Phase 0) + the response cache. All grounded in the Phase 1 context packet (SailDiff numbers + environment snapshot).

## Notes for the reviewer

- The `claude` CLI flags (`--allowedTools`, `--output-format`) may need adjusting for your installed version; the provider is a *reference* and fails safe, so a flag mismatch just yields a graceful "Skipper unavailable" note rather than a broken run.
- Nothing in core depends on any model SDK — the agent seam stays neutral.

## Test plan

- 2 new tests (25 total across the Skipper suite): markdown report is written when present, and skipped when empty.
- Core + full solution build clean; the demo project builds with **0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)