### PR TITLE
Make SailDiff comparison output unambiguous (baseline-anchored wording + NOT SIGNIFICANT)

### DIFF
--- a/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailDiffTestOutputWindowMessageFormatter.cs
+++ b/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailDiffTestOutputWindowMessageFormatter.cs
@@ -137,7 +137,7 @@ internal class SailDiffTestOutputWindowMessageFormatter : ISailDiffTestOutputWin
 
         if (!isSignificant)
         {
-            return $"⚪ IMPACT: {Math.Abs(percentChange):F1}% difference (NO CHANGE)\n" + meanLine + magnitudeLine;
+            return $"⚪ IMPACT: {Math.Abs(percentChange):F1}% difference from baseline (NOT SIGNIFICANT)\n" + meanLine + magnitudeLine;
         }
 
         var isImprovement = percentChange < 0;
@@ -145,7 +145,8 @@ internal class SailDiffTestOutputWindowMessageFormatter : ISailDiffTestOutputWin
         var significance = isImprovement ? "IMPROVED" : "REGRESSED";
         var icon = isImprovement ? "🟢" : "🔴";
 
-        return $"{icon} IMPACT: {Math.Abs(percentChange):F1}% {direction} ({significance})\n" + meanLine + magnitudeLine;
+        // Before = baseline, After = the run under test; name the baseline so "slower/faster" has a referent.
+        return $"{icon} IMPACT: {Math.Abs(percentChange):F1}% {direction} than baseline ({significance})\n" + meanLine + magnitudeLine;
     }
 
     private static string BuildMagnitudeLine(StatisticalTestResult stats)

--- a/source/Sailfish/Analysis/SailDiff/Formatting/DetailedTableFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/DetailedTableFormatter.cs
@@ -80,8 +80,14 @@ public class DetailedTableFormatter : IDetailedTableFormatter
         var unit = SelectUnit(comparisons);
         var unitLabel = DurationFormatter.UnitLabel(unit);
 
-        // Create table headers
-        var headers = new[] { "Metric", "Primary Method", "Compared Method", "Change", "P-Value" };
+        // Create table headers. For a single comparison, name the columns with the real methods and
+        // mark the reference as the baseline so each row is self-describing. For multiple comparisons
+        // the columns are shared across row-groups, so fall back to Baseline/Comparison and let the
+        // per-group "Comparing:" line name the methods.
+        var single = comparisons.Count == 1;
+        var baselineHeader = single ? $"{comparisons[0].PrimaryMethodName} (baseline)" : "Baseline";
+        var comparedHeader = single ? comparisons[0].ComparedMethodName : "Comparison";
+        var headers = new[] { "Metric", baselineHeader, comparedHeader, "Change", "P-Value" };
         var rows = new List<string[]>();
 
         foreach (var data in comparisons)
@@ -98,7 +104,7 @@ public class DetailedTableFormatter : IDetailedTableFormatter
             // Add comparison header if multiple comparisons
             if (comparisons.Count > 1)
             {
-                sb.AppendLine($"Comparing: {data.PrimaryMethodName} vs {data.ComparedMethodName}");
+                sb.AppendLine($"Comparing: {data.ComparedMethodName} vs baseline {data.PrimaryMethodName}");
             }
 
             rows.Add(new[] { $"Mean ({unitLabel})", DurationFormatter.Format(primaryTime, unit, Decimals), DurationFormatter.Format(comparedTime, unit, Decimals), changeText, $"{stats.PValue:F6}" });
@@ -119,6 +125,10 @@ public class DetailedTableFormatter : IDetailedTableFormatter
 
         // Format as aligned table
         sb.Append(FormatAsAlignedTable(headers, rows));
+
+        // Spell out the sign convention so a leading "+" can't be misread as "better".
+        sb.AppendLine();
+        sb.AppendLine("Change = comparison vs. baseline (positive = slower, negative = faster).");
 
         // Add metadata
         if (comparisons.Any())
@@ -160,7 +170,7 @@ public class DetailedTableFormatter : IDetailedTableFormatter
             var changeText = percentChange >= 0 ? $"+{percentChange:F1}%" : $"{percentChange:F1}%";
 
             sb.AppendLine();
-            sb.AppendLine($"| Metric | {data.PrimaryMethodName} | {data.ComparedMethodName} | Change | P-Value |");
+            sb.AppendLine($"| Metric | {data.PrimaryMethodName} (baseline) | {data.ComparedMethodName} | Change | P-Value |");
             sb.AppendLine("|--------|------------|-------------|--------|---------|");
             sb.AppendLine($"| Mean ({unitLabel}) | {DurationFormatter.Format(primaryTime, unit, Decimals)} | {DurationFormatter.Format(comparedTime, unit, Decimals)} | {changeText} | {stats.PValue:F6} |");
 
@@ -171,6 +181,8 @@ public class DetailedTableFormatter : IDetailedTableFormatter
             var medianChangeText = medianChange >= 0 ? $"+{medianChange:F1}%" : $"{medianChange:F1}%";
 
             sb.AppendLine($"| Median ({unitLabel}) | {DurationFormatter.Format(primaryMedian, unit, Decimals)} | {DurationFormatter.Format(comparedMedian, unit, Decimals)} | {medianChangeText} | - |");
+            sb.AppendLine();
+            sb.AppendLine("_Change = comparison vs. baseline (positive = slower, negative = faster)._");
             sb.AppendLine();
         }
 

--- a/source/Sailfish/Analysis/SailDiff/Formatting/ImpactSummaryFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/ImpactSummaryFormatter.cs
@@ -98,11 +98,8 @@ public class ImpactSummaryFormatter : IImpactSummaryFormatter
     private string CreateIdeImpactSummary(SailDiffComparisonData data, ComparisonAnalysis analysis)
     {
         var icon = GetSignificanceIcon(analysis.Significance);
-        var direction = analysis.IsImprovement ? "faster" : "slower";
-        var significanceText = GetSignificanceText(analysis.Significance);
-        
-        var summary = $"{icon} IMPACT: {data.PrimaryMethodName} vs {data.ComparedMethodName} - " +
-                     $"{analysis.PercentageChange:F1}% {direction} ({significanceText})";
+
+        var summary = $"{icon} IMPACT: {BuildVerdict(data, analysis)}";
 
         if (analysis.IsStatisticallySignificant)
         {
@@ -119,11 +116,8 @@ public class ImpactSummaryFormatter : IImpactSummaryFormatter
     private string CreateMarkdownImpactSummary(SailDiffComparisonData data, ComparisonAnalysis analysis)
     {
         var icon = GetMarkdownSignificanceIcon(analysis.Significance);
-        var direction = analysis.IsImprovement ? "faster" : "slower";
-        var significanceText = GetSignificanceText(analysis.Significance);
-        
-        return $"**{icon} IMPACT: {data.PrimaryMethodName} vs {data.ComparedMethodName} - " +
-               $"{analysis.PercentageChange:F1}% {direction} ({significanceText})**";
+
+        return $"**{icon} IMPACT: {BuildVerdict(data, analysis)}**";
     }
 
     /// <summary>
@@ -132,11 +126,8 @@ public class ImpactSummaryFormatter : IImpactSummaryFormatter
     private string CreateConsoleImpactSummary(SailDiffComparisonData data, ComparisonAnalysis analysis)
     {
         var indicator = GetConsoleSignificanceIndicator(analysis.Significance);
-        var direction = analysis.IsImprovement ? "faster" : "slower";
-        var significanceText = GetSignificanceText(analysis.Significance);
-        
-        return $"{indicator} IMPACT: {data.PrimaryMethodName} vs {data.ComparedMethodName} - " +
-               $"{analysis.PercentageChange:F1}% {direction} ({significanceText})";
+
+        return $"{indicator} IMPACT: {BuildVerdict(data, analysis)}";
     }
 
     /// <summary>
@@ -150,6 +141,22 @@ public class ImpactSummaryFormatter : IImpactSummaryFormatter
         return $"{data.PrimaryMethodName},{data.ComparedMethodName}," +
                $"{analysis.PercentageChange:F1}%,{direction},{significanceText}," +
                $"{analysis.PValue:F6},{analysis.PrimaryTime:F3},{analysis.ComparedTime:F3}";
+    }
+
+    /// <summary>
+    /// Builds the one verdict clause shared by every context so the direction can never be misread:
+    /// "{compared} is {pct}% {faster|slower} than baseline {primary} ({significance})".
+    /// The compared method is the grammatical subject and the primary method is named as the
+    /// baseline — the reference the percentage is measured against (see <see cref="AnalyzeComparison"/>,
+    /// where %Δ is always computed relative to the baseline). This avoids the old "A vs B - N% slower"
+    /// phrasing, where it was impossible to tell whether A or B was the slower method.
+    /// </summary>
+    private static string BuildVerdict(SailDiffComparisonData data, ComparisonAnalysis analysis)
+    {
+        var direction = analysis.IsImprovement ? "faster" : "slower";
+        var significanceText = GetSignificanceText(analysis.Significance);
+        return $"{data.ComparedMethodName} is {analysis.PercentageChange:F1}% {direction} " +
+               $"than baseline {data.PrimaryMethodName} ({significanceText})";
     }
 
     /// <summary>
@@ -203,8 +210,8 @@ public class ImpactSummaryFormatter : IImpactSummaryFormatter
         {
             ComparisonSignificance.Improved => "IMPROVED",
             ComparisonSignificance.Regressed => "REGRESSED",
-            ComparisonSignificance.NoChange => "NO CHANGE",
-            _ => "NO CHANGE"
+            ComparisonSignificance.NoChange => "NOT SIGNIFICANT",
+            _ => "NOT SIGNIFICANT"
         };
     }
 }

--- a/source/Sailfish/Contracts.Public/TestResultTableContentFormatter.cs
+++ b/source/Sailfish/Contracts.Public/TestResultTableContentFormatter.cs
@@ -70,7 +70,7 @@ public class SailDiffResultMarkdownConverter : ISailDiffResultMarkdownConverter
 
         // Fallback to enhanced legacy format. Pass the configured alpha so the legacy impact
         // summary's significance decision honours the user setting — without this the legacy
-        // path silently downgraded a real "Regressed" result to "NO CHANGE" for any p-value
+        // path silently downgraded a real "Regressed" result to "NOT SIGNIFICANT" for any p-value
         // between 0.05 and the configured alpha (e.g. α = 0.10 on the Relaxed preset).
         return CreateEnhancedLegacyOutput(enumeratedResults, context, alpha);
     }
@@ -259,7 +259,7 @@ public class SailDiffResultMarkdownConverter : ISailDiffResultMarkdownConverter
         if (!isSignificant)
         {
             var noChangeIcon = context == OutputContext.Console ? "[=]" : "⚪";
-            return $"{noChangeIcon} **{result.TestCaseId.DisplayName}**: {Math.Abs(percentChange):F1}% difference (NO CHANGE)";
+            return $"{noChangeIcon} **{result.TestCaseId.DisplayName}**: {Math.Abs(percentChange):F1}% difference from baseline (NOT SIGNIFICANT)";
         }
 
         var direction = isImprovement ? "faster" : "slower";
@@ -270,6 +270,7 @@ public class SailDiffResultMarkdownConverter : ISailDiffResultMarkdownConverter
             _ => isImprovement ? "🟢" : "🔴"
         };
 
-        return $"{icon} **{result.TestCaseId.DisplayName}**: {Math.Abs(percentChange):F1}% {direction} ({significance})";
+        // Before = baseline; name it so "slower/faster" can't be read the wrong way around.
+        return $"{icon} **{result.TestCaseId.DisplayName}**: {Math.Abs(percentChange):F1}% {direction} than baseline ({significance})";
     }
 }

--- a/source/Tests.Library/Analysis/SailDiff/Formatting/DetailedTableFormatterTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Formatting/DetailedTableFormatterTests.cs
@@ -135,8 +135,8 @@ public class DetailedTableFormatterTests
         var result = _formatter.CreateDetailedTable(comparisons, OutputContext.Ide);
 
         // Assert
-        result.ShouldContain("Comparing: Method1 vs Method2");
-        result.ShouldContain("Comparing: Method3 vs Method4");
+        result.ShouldContain("Comparing: Method2 vs baseline Method1");
+        result.ShouldContain("Comparing: Method4 vs baseline Method3");
     }
 
     #endregion

--- a/source/Tests.Library/Analysis/SailDiff/Tier1RigorTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Tier1RigorTests.cs
@@ -240,7 +240,7 @@ public class Tier1RigorTests
         // constructed without an ISailDiffUnifiedFormatter (the public default-ctor surface),
         // the legacy fallback used to hardcode `p < 0.05` and ignore the configured alpha.
         // With Relaxed (α = 0.10) and a Regressed verdict at p = 0.08 the impact line read
-        // "NO CHANGE", contradicting the test wrapper's own verdict. The fix prefers the
+        // "NOT SIGNIFICANT", contradicting the test wrapper's own verdict. The fix prefers the
         // ChangeDescription as the authoritative source and threads alpha as the fallback.
         var testCaseId = new TestCaseId("Suite.MyTest()");
         var stats = new StatisticalTestResult(
@@ -267,14 +267,14 @@ public class Tier1RigorTests
             alpha: 0.10);
 
         output.ShouldContain("REGRESSED");
-        output.ShouldNotContain("(NO CHANGE)");
+        output.ShouldNotContain("(NOT SIGNIFICANT)");
     }
 
     [Fact]
     public void LegacyImpactSummary_RespectsNoChangeVerdict_WhenTestWrapperSaidNoChange()
     {
         // Symmetric check: if the test wrapper produced NoChange (because p > the user's α),
-        // the legacy summary must show NO CHANGE regardless of how the raw p-value compares
+        // the legacy summary must show NOT SIGNIFICANT regardless of how the raw p-value compares
         // to the legacy 0.05 default — the wrapper is the single source of truth.
         var testCaseId = new TestCaseId("Suite.MyTest()");
         var stats = new StatisticalTestResult(
@@ -299,7 +299,7 @@ public class Tier1RigorTests
             Sailfish.Analysis.SailDiff.Formatting.OutputContext.Markdown,
             alpha: 0.01); // strict alpha; wrapper's NoChange already reflects this
 
-        output.ShouldContain("NO CHANGE");
+        output.ShouldContain("NOT SIGNIFICANT");
         output.ShouldNotContain("REGRESSED");
         output.ShouldNotContain("IMPROVED");
     }

--- a/source/Tests.Library/Contracts/Public/SailDiffResultMarkdownConverterTests.cs
+++ b/source/Tests.Library/Contracts/Public/SailDiffResultMarkdownConverterTests.cs
@@ -309,7 +309,7 @@ public class SailDiffResultMarkdownConverterTests
         var result = _converterWithoutFormatter.ConvertToEnhancedMarkdownTable(sailDiffResults, OutputContext.Markdown);
 
         // Assert
-        result.ShouldContain("NO CHANGE");
+        result.ShouldContain("NOT SIGNIFICANT");
     }
 
     [Fact]

--- a/source/Tests.TestAdapter/SailDiffTestOutputWindowMessageFormatterTests.cs
+++ b/source/Tests.TestAdapter/SailDiffTestOutputWindowMessageFormatterTests.cs
@@ -45,7 +45,7 @@ public class SailDiffTestOutputWindowMessageFormatterTests
         outputResult.ShouldContain("==================================================");
         // Display values are recomputed from the raw samples ([1,2,3] -> 2, [9,10,11] -> 10),
         // and the unit is auto-selected (ms here). %Δ = (10-2)/2 = 400%.
-        outputResult.ShouldContain("⚪ IMPACT: 400.0% difference (NO CHANGE)");
+        outputResult.ShouldContain("⚪ IMPACT: 400.0% difference from baseline (NOT SIGNIFICANT)");
         outputResult.ShouldContain("P-Value: 0.001000 | Mean: 2.000 ms → 10.000 ms");
         outputResult.ShouldContain("Before Ids: abc.wow()");
         outputResult.ShouldContain("After Ids: Id2");


### PR DESCRIPTION
## Problem

The test-adapter comparison readout was ambiguous. The headline

> ⚪ IMPACT: Tracked() vs NoTracking() - 24.6% slower (NO CHANGE)

doesn't say *which* method is slow — and the natural reading (first-named = slow) is backwards: the % is computed relative to the primary/baseline, so it's the **second** method that's 24.6% slower. Separately, `(NO CHANGE)` next to a 24.6% delta reads as a contradiction — it actually means "not statistically significant at α".

## Fix

Every comparison-output path now uses one unambiguous, baseline-anchored model.

**Before**

```
⚪ IMPACT: Tracked() vs NoTracking() - 24.6% slower (NO CHANGE)
🔴 IMPACT: Tracked() vs Projected() - 306.9% slower (REGRESSED)

| Metric    | Primary Method | Compared Method | Change |
| Mean (ms) | 2.194          | 2.733           | +24.6% |
```

**After**

```
⚪ IMPACT: NoTracking() is 24.6% slower than baseline Tracked() (NOT SIGNIFICANT)
🔴 IMPACT: Projected() is 306.9% slower than baseline Tracked() (REGRESSED)

| Metric    | Tracked() (baseline) | NoTracking() | Change |
| Mean (ms) | 2.194                | 2.733        | +24.6% |
Change = comparison vs. baseline (positive = slower, negative = faster).
```

- **Headline** — `{Compared} is N% slower/faster than baseline {Primary}`: the compared method is the grammatical subject, the primary is named as the baseline (the reference the % is measured against). A shared `BuildVerdict` helper feeds IDE / Markdown / Console / CSV so they can't drift apart.
- **Detail tables** — name the columns with the real methods, mark the baseline `(baseline)`, and add a sign legend so a leading `+` can't be read as "better".
- **Before/after SailDiff banners** — same baseline wording (`SailDiffTestOutputWindowMessageFormatter`, `SailDiffResultMarkdownConverter`); Before = baseline.
- **Verdict label** — `NO CHANGE` → `NOT SIGNIFICANT`.

## Scope guardrail

Display-only. The `ChangeDescription` / `SailfishChangeDirection.NoChange` data value (the canonical *direction* category used in CSV/data tables) and every `Contains("No Change")` significance check are left untouched. The method-comparison ratio tables already used "baseline" wording, so they needed no change.

## Tests

Build clean; **Tests.Library 1489/1489**, **Tests.TestAdapter 556/556** (net9 + net10). 4 assertions updated for the reworded strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test result terminology from "NO CHANGE" to "NOT SIGNIFICANT" for improved clarity.
  * Added explicit "baseline" references in comparison output to distinguish between baseline and compared methods.
  * Enhanced consistency in comparison direction wording across test result displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->