### PR TITLE
Skipper Phase 4: ScaleFish "why it scales" + documentation

### DIFF
--- a/site/src/components/Layout.jsx
+++ b/site/src/components/Layout.jsx
@@ -61,6 +61,7 @@ const navigation = [
             { title: 'Sailfish', href: '/docs/2/sailfish' },
             { title: 'SailDiff', href: '/docs/2/saildiff' },
             { title: 'ScaleFish', href: '/docs/2/scalefish' },
+            { title: 'Skipper (AI)', href: '/docs/2/skipper', badge: 'NEW' },
         ]
     },
     {

--- a/site/src/pages/docs/2/skipper.md
+++ b/site/src/pages/docs/2/skipper.md
@@ -1,0 +1,119 @@
+---
+title: Skipper (AI)
+---
+
+## Introduction
+
+**Skipper** is Sailfish's optional **AI analysis layer** — the crewmate that reads the instruments (SailDiff and ScaleFish) and tells you, in plain language, **what changed and why**. Where SailDiff tells you a method got 18% slower and ScaleFish tells you it scales like O(n²), Skipper reads the *code under test*, explains the likely cause, and cites the exact `file:line`.
+
+Skipper is **strictly additive and opt-in**. It ships with no model dependencies and no API keys. You bring your own agent — a one-shot completion, a local model, or a full agentic loop (e.g. the Claude Agent SDK / `claude` CLI) — by implementing a single interface. If you don't register one, Sailfish behaves exactly as before.
+
+The guiding principle: **Sailfish owns the intelligence; you own the transport.** Sailfish assembles a *grounded* context packet from the authoritative SailDiff/ScaleFish numbers and your environment, and the model **reasons over those figures — it never recomputes or invents them**. For any claim about your code, it cites a real `file:line` it actually read.
+
+## Enabling Skipper
+
+Two steps: turn it on in the builder, and register an agent.
+
+```csharp
+var settings = RunSettingsBuilder
+    .CreateBuilder()
+    .WithSailDiff()      // Skipper explains "why did this change?"
+    .WithScaleFish()     // Skipper explains "why does this scale like that?"
+    .WithAiAnalysis()    // turn on the Skipper layer
+    .Build();
+```
+
+```csharp
+// Register your agent from an IRegisterSailfishServices provider.
+public class MyRegistration : IRegisterSailfishServices
+{
+    public Task RegisterAsync(IServiceCollection services, CancellationToken ct = default)
+    {
+        services.AddSingleton<ISailfishAgent, MyAgent>();
+        return Task.CompletedTask;
+    }
+}
+```
+
+That's it. With no agent registered, `.WithAiAnalysis()` is a no-op — the feature stays completely invisible.
+
+## The one interface you implement
+
+```csharp
+public interface ISailfishAgent
+{
+    Task<SkipperReview> RunAsync(SkipperSession session, CancellationToken cancellationToken);
+}
+```
+
+`SkipperSession` carries everything your agent needs: the role, the grounded `PerformanceNarrativeContext` (the authoritative numbers), the **capabilities** it has been granted (locally, read-only code access scoped to your repository), and the repository root. Your implementation simply forwards this to a model and returns a `SkipperReview`.
+
+A `SkipperReview` is structured, not just prose:
+
+- **`OverallVerdict`** — `Improved` / `Regressed` / `NotSignificant` / `Inconclusive`.
+- **`Findings`** — per-test diagnoses, each with its own verdict, a summary, and the `file:line` locations it cited.
+- **`ConsoleSummary`** and **`MarkdownReport`** — the terse and the deep renderings.
+
+A reference **agentic** implementation that drives the `claude` CLI (read-only `Read`/`Grep`/`Glob` scoped to the repo) ships in the `ConsoleAppDemo` project — `ClaudeAgentModelProvider`. Copy it and swap the transport to taste.
+
+## What Skipper produces
+
+**Inline in the console**, beneath the SailDiff table:
+
+```
+🧭 Skipper  🔴 REGRESSED
+ParseHeaders is 18% slower than baseline and it's a real change (p<0.001, CV 2.1%).
+  • 🔴 Bench.ParseHeaders — regex compiled inside the per-row loop
+       ↳ Parser.cs:88
+```
+
+Chips: 🔴 regressed · 🟢 improved · ⚪ not significant · 🟡 inconclusive. The verdict vocabulary matches SailDiff (a comparison is *not significant*, never "no change").
+
+**On disk**, beside your run output:
+
+| File | What it is |
+| ---- | ---------- |
+| `skipper-review_<timestamp>_<kind>.json` | The structured review — machine-readable, for a CI bot or orchestrator to consume. |
+| `skipper-report_<timestamp>_<kind>.md` | The deep human-readable write-up: call path, cited code, suggested fix. |
+
+`<kind>` is `saildiff` or `scalefish`, so a run that does both never overwrites itself.
+
+## Reliability-aware verdicts
+
+Skipper's context packet includes an **environment snapshot** drawn from Sailfish's reproducibility manifest and environment health check — runtime, OS, CPU, GC mode, JIT, CPU affinity, timer, plus any health concerns. This lets Skipper *temper* its verdict on a noisy or misconfigured host, which is the dominant failure mode of microbenchmarking:
+
+> *"This 12% 'regression' is low-confidence: CV was 8.4% and the power plan is 'Balanced'. Re-run on a quiet, fixed-clock host before trusting it."*
+
+Each comparison also carries its effect size and the **minimum detectable effect** — so Skipper can tell you when a run was simply underpowered to catch the change you care about.
+
+## Two questions Skipper answers
+
+- **"Why did this change?"** — from SailDiff. Skipper reads the implicated method, follows it into the system under test, and explains the cause (an allocation in a loop, an N+1 query, a lost fast-path) with citations.
+- **"Why does this scale like that, and what happens at 10× the data?"** — from ScaleFish. Skipper takes the best-fit complexity class (and whether it's statistically distinguishable from the runner-up) and projects the fitted curve to larger N: *"O(n²), R²=0.98 — at 10,000 items expect ~500ms."*
+
+## Workflow: rerun in place
+
+The most natural local loop is the simplest one. Sailfish's tracking files capture each run, and SailDiff automatically compares your **latest run against the previous one** — so you just:
+
+1. Run your benchmarks.
+2. Change your code.
+3. Run again.
+
+SailDiff produces the before/after, and Skipper explains it — no file paths to type, nothing to wire up. (You can still point SailDiff at specific prior tracking files when you want a fixed baseline; rerun-in-place is simply the zero-friction default.)
+
+## Settings
+
+`AiAnalysisSettings` (pass via `WithAiAnalysis(settings)`) controls the layer:
+
+| Setting | Default | Effect |
+| ------- | ------- | ------ |
+| `WriteReviewArtifact` | `true` | Write `review.json` + `report.md` beside the run output. |
+| `EmitConsoleSummary` | `true` | Print the inline verdict block beneath the table. |
+| `UseResponseCache` | `true` | Reuse a cached review for an identical context — no re-spend, and stable, reproducible output. |
+| `Role` | `Explain` | The authority the agent runs under. (`Review`/`Remediate`/`Author` are reserved for future CI and automation roles.) |
+
+## Privacy & safety
+
+- **Nothing leaves your machine** unless *your* agent sends it. Sailfish only assembles the context and calls your `ISailfishAgent`.
+- Skipper runs **after** your numbers are computed and printed, and **never throws into a run** — if the agent is missing, offline, or errors, your benchmark output is completely unaffected.
+- The reference agent grants **read-only** code access; Skipper proposes, it does not act.

--- a/source/ConsoleAppDemo/CustomHandlerOverrideExamples/ClaudeAgentModelProvider.cs
+++ b/source/ConsoleAppDemo/CustomHandlerOverrideExamples/ClaudeAgentModelProvider.cs
@@ -47,7 +47,9 @@ internal sealed class ClaudeAgentModelProvider : ISailfishAgent
 
         var sb = new StringBuilder();
         sb.AppendLine("You are Skipper, a performance analyst embedded in the Sailfish benchmarking library.");
-        sb.AppendLine("A SailDiff comparison just completed. Explain WHAT changed and, by reading the code under test, WHY.");
+        sb.AppendLine("A Sailfish analysis just completed. The context may contain a SailDiff before/after comparison");
+        sb.AppendLine("('comparisons') and/or a ScaleFish scaling analysis ('scaling' — best-fit Big-O with projections to");
+        sb.AppendLine("larger N). Explain WHAT it shows and, by reading the code under test, WHY.");
         sb.AppendLine();
         sb.AppendLine("Rules:");
         sb.AppendLine("- Use ONLY the numbers in the context below. Never invent or recompute a measurement.");

--- a/source/Sailfish/Analysis/Ai/ComplexityVerdict.cs
+++ b/source/Sailfish/Analysis/Ai/ComplexityVerdict.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     Grounded ScaleFish result for one (method, variable) pair: the best-fit Big-O class, how well it fit, the
+///     runner-up, whether the data can actually tell them apart, and concrete projections to larger N. As with
+///     every figure in the context, the agent <em>explains</em> these — it never computes them.
+/// </summary>
+public sealed record ComplexityVerdict(
+    string TestMethodName,
+    string PropertyName,
+    string BestFitComplexity,
+    double GoodnessOfFit,
+    string NextBestComplexity,
+    double NextBestGoodnessOfFit,
+    bool IsDistinguishable,
+    int? SuggestedNextN,
+    IReadOnlyList<ComplexityProjection> Projections);
+
+/// <summary>A projection of the fitted curve to a given N — "at N items, expect roughly PredictedValue ms".</summary>
+public sealed record ComplexityProjection(int N, double PredictedValue);

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContext.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContext.cs
@@ -10,7 +10,8 @@ namespace Sailfish.Analysis.Ai;
 public sealed record PerformanceNarrativeContext(
     IReadOnlyList<SailDiffCaseContext> Comparisons,
     string SailDiffMarkdown,
-    EnvironmentSnapshot? Environment);
+    EnvironmentSnapshot? Environment,
+    IReadOnlyList<ComplexityVerdict>? Scaling = null);
 
 /// <summary>Grounded before / after figures for one test case, lifted directly from a SailDiff result.</summary>
 public sealed record SailDiffCaseContext(

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
@@ -4,12 +4,15 @@ using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Diagnostics.Environment;
 using Sailfish.Results;
+using Sailfish.Analysis.ScaleFish;
 
 namespace Sailfish.Analysis.Ai;
 
 internal interface IPerformanceNarrativeContextBuilder
 {
     PerformanceNarrativeContext Build(SailDiffAnalysisCompleteNotification notification, double alpha);
+
+    PerformanceNarrativeContext BuildScaling(ScaleFishAnalysisCompleteNotification notification);
 }
 
 /// <summary>
@@ -37,6 +40,51 @@ internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrative
             .ToList();
 
         return new PerformanceNarrativeContext(comparisons, notification.ResultsAsMarkdown ?? string.Empty, BuildEnvironment());
+    }
+
+    public PerformanceNarrativeContext BuildScaling(ScaleFishAnalysisCompleteNotification notification)
+    {
+        var verdicts = new List<ComplexityVerdict>();
+        foreach (var classModel in notification.TestClassComplexityResults)
+        foreach (var method in classModel.ScaleFishMethodModels)
+        foreach (var property in method.ScaleFishPropertyModels)
+        {
+            var model = property.ScaleFishModel;
+            verdicts.Add(new ComplexityVerdict(
+                method.TestMethodName,
+                property.PropertyName,
+                model.ScaleFishModelFunction.OName,
+                model.GoodnessOfFit,
+                model.NextClosestScaleFishModelFunction.OName,
+                model.NextClosestGoodnessOfFit,
+                model.IsDistinguishable,
+                model.SuggestedNextN,
+                Project(model.ScaleFishModelFunction)));
+        }
+
+        return new PerformanceNarrativeContext(
+            System.Array.Empty<SailDiffCaseContext>(),
+            notification.ScaleFishResultMarkdown ?? string.Empty,
+            BuildEnvironment(),
+            verdicts);
+    }
+
+    private static IReadOnlyList<ComplexityProjection> Project(ScaleFishModelFunction function)
+    {
+        var projections = new List<ComplexityProjection>();
+        foreach (var n in new[] { 100, 1_000, 10_000 })
+        {
+            try
+            {
+                projections.Add(new ComplexityProjection(n, function.Predict(n)));
+            }
+            catch
+            {
+                // Family not fit, or evaluation overflowed at this N — skip the projection rather than fail.
+            }
+        }
+
+        return projections;
     }
 
     /// <summary>

--- a/source/Sailfish/Analysis/Ai/SkipperAnalysisRunner.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperAnalysisRunner.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Logging;
+using Sailfish.Presentation.Console;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     The shared Skipper pipeline used by every analysis handler (SailDiff, ScaleFish, ...). Given a grounded
+///     context it resolves a review (cache-first, then the agent), then persists and renders it. Artifacts are
+///     keyed by <c>analysisKind</c> so analyses that complete in the same run don't overwrite each other.
+/// </summary>
+internal interface ISkipperAnalysisRunner
+{
+    Task RunAsync(PerformanceNarrativeContext context, string analysisKind, CancellationToken cancellationToken);
+}
+
+internal sealed class SkipperAnalysisRunner : ISkipperAnalysisRunner
+{
+    private readonly ISailfishAgent agent;
+    private readonly IConsoleWriter consoleWriter;
+    private readonly ISkipperConsoleFormatter consoleFormatter;
+    private readonly ILogger logger;
+    private readonly ISkipperResponseCache responseCache;
+    private readonly ISkipperReportWriter reportWriter;
+    private readonly ISkipperReviewWriter reviewWriter;
+    private readonly IRunSettings runSettings;
+
+    public SkipperAnalysisRunner(
+        IRunSettings runSettings,
+        ISailfishAgent agent,
+        ISkipperReviewWriter reviewWriter,
+        ISkipperReportWriter reportWriter,
+        ISkipperResponseCache responseCache,
+        IConsoleWriter consoleWriter,
+        ISkipperConsoleFormatter consoleFormatter,
+        ILogger logger)
+    {
+        this.runSettings = runSettings;
+        this.agent = agent;
+        this.reviewWriter = reviewWriter;
+        this.reportWriter = reportWriter;
+        this.responseCache = responseCache;
+        this.consoleWriter = consoleWriter;
+        this.consoleFormatter = consoleFormatter;
+        this.logger = logger;
+    }
+
+    public async Task RunAsync(PerformanceNarrativeContext context, string analysisKind, CancellationToken cancellationToken)
+    {
+        if (agent is NoOpSailfishAgent) return; // no real agent registered — stay invisible
+
+        var hasContent = context.Comparisons.Count > 0 || context.Scaling is { Count: > 0 };
+        if (!hasContent) return;
+
+        try
+        {
+            var settings = runSettings.AiAnalysisSettings;
+
+            var review = await ResolveReviewAsync(context, settings, cancellationToken).ConfigureAwait(false);
+            if (!review.HasContent) return;
+
+            if (settings.WriteReviewArtifact)
+            {
+                await reviewWriter.WriteAsync(review, analysisKind, cancellationToken).ConfigureAwait(false);
+                await reportWriter.WriteAsync(review, analysisKind, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (settings.EmitConsoleSummary)
+                consoleWriter.WriteString(consoleFormatter.Format(review));
+        }
+        catch (Exception ex)
+        {
+            // Strictly additive: AI analysis must never break or alter a benchmark run.
+            logger.Log(LogLevel.Warning, ex, "Skipper AI analysis failed; continuing without it.");
+        }
+    }
+
+    private async Task<SkipperReview> ResolveReviewAsync(
+        PerformanceNarrativeContext context,
+        AiAnalysisSettings settings,
+        CancellationToken cancellationToken)
+    {
+        string? cacheKey = null;
+        if (settings.UseResponseCache)
+        {
+            cacheKey = responseCache.ComputeKey(context, settings.Role);
+            var cached = await responseCache.TryGetAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            if (cached is not null) return cached;
+        }
+
+        var repositoryRoot = ResolveRepositoryRoot();
+        var capabilities = new CapabilityRegistry(new ISkipperCapability[] { new CodeReadCapability(repositoryRoot) });
+        var session = new SkipperSession(settings.Role, context, capabilities, repositoryRoot);
+
+        var review = await agent.RunAsync(session, cancellationToken).ConfigureAwait(false);
+
+        if (cacheKey is not null && review.HasContent)
+            await responseCache.SetAsync(cacheKey, review, cancellationToken).ConfigureAwait(false);
+
+        return review;
+    }
+
+    /// <summary>Walks up from the working directory to the nearest Git root; falls back to the working directory.</summary>
+    private static string ResolveRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git"))) return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+}

--- a/source/Sailfish/Analysis/Ai/SkipperReportWriter.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperReportWriter.cs
@@ -8,7 +8,7 @@ namespace Sailfish.Analysis.Ai;
 
 internal interface ISkipperReportWriter
 {
-    Task WriteAsync(SkipperReview review, CancellationToken cancellationToken);
+    Task WriteAsync(SkipperReview review, string analysisKind, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -25,7 +25,7 @@ internal sealed class SkipperReportWriter : ISkipperReportWriter
         this.runSettings = runSettings;
     }
 
-    public async Task WriteAsync(SkipperReview review, CancellationToken cancellationToken)
+    public async Task WriteAsync(SkipperReview review, string analysisKind, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(review.MarkdownReport)) return;
 
@@ -33,7 +33,7 @@ internal sealed class SkipperReportWriter : ISkipperReportWriter
         Directory.CreateDirectory(directory);
 
         var fileName = DefaultFileSettings.AppendTagsToFilename(
-            $"skipper-report_{runSettings.TimeStamp:yyyyMMdd_HHmmss}.md",
+            $"skipper-report_{runSettings.TimeStamp:yyyyMMdd_HHmmss}_{analysisKind}.md",
             runSettings.Tags);
         var filePath = Path.Join(directory, fileName);
 

--- a/source/Sailfish/Analysis/Ai/SkipperReviewWriter.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperReviewWriter.cs
@@ -10,7 +10,7 @@ namespace Sailfish.Analysis.Ai;
 
 internal interface ISkipperReviewWriter
 {
-    Task WriteAsync(SkipperReview review, CancellationToken cancellationToken);
+    Task WriteAsync(SkipperReview review, string analysisKind, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -33,13 +33,13 @@ internal sealed class SkipperReviewWriter : ISkipperReviewWriter
         this.runSettings = runSettings;
     }
 
-    public async Task WriteAsync(SkipperReview review, CancellationToken cancellationToken)
+    public async Task WriteAsync(SkipperReview review, string analysisKind, CancellationToken cancellationToken)
     {
         var directory = runSettings.LocalOutputDirectory;
         Directory.CreateDirectory(directory);
 
         var fileName = DefaultFileSettings.AppendTagsToFilename(
-            $"skipper-review_{runSettings.TimeStamp:yyyyMMdd_HHmmss}.json",
+            $"skipper-review_{runSettings.TimeStamp:yyyyMMdd_HHmmss}_{analysisKind}.json",
             runSettings.Tags);
         var filePath = Path.Join(directory, fileName);
 

--- a/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Ai/SkipperSailDiffAnalysisHandler.cs
@@ -1,125 +1,38 @@
-using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Sailfish.Analysis.Ai;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
-using Sailfish.Logging;
-using Sailfish.Presentation.Console;
 
 namespace Sailfish.DefaultHandlers.Ai;
 
 /// <summary>
-///     Bridges a completed SailDiff comparison to the AI "Skipper" layer: builds a grounded context packet, runs
-///     the registered <see cref="ISailfishAgent" />, then persists and renders the result.
-///     <para>
-///         The whole path is opt-in (<see cref="IRunSettings.RunAiAnalysis" />), strictly additive, and must never
-///         throw into the run. If no real agent is registered, or anything fails, the benchmark output is entirely
-///         unaffected.
-///     </para>
+///     Bridges a completed SailDiff comparison to the Skipper AI layer: builds the grounded context packet, then
+///     hands it to the shared <see cref="ISkipperAnalysisRunner" />. Opt-in (<see cref="IRunSettings.RunAiAnalysis" />)
+///     and strictly additive — if no real agent is registered the run is entirely unaffected.
 /// </summary>
 internal sealed class SkipperSailDiffAnalysisHandler : INotificationHandler<SailDiffAnalysisCompleteNotification>
 {
-    private readonly ISailfishAgent agent;
-    private readonly IConsoleWriter consoleWriter;
-    private readonly ISkipperConsoleFormatter consoleFormatter;
     private readonly IPerformanceNarrativeContextBuilder contextBuilder;
-    private readonly ILogger logger;
-    private readonly ISkipperResponseCache responseCache;
-    private readonly ISkipperReviewWriter reviewWriter;
-    private readonly ISkipperReportWriter reportWriter;
+    private readonly ISkipperAnalysisRunner runner;
     private readonly IRunSettings runSettings;
 
     public SkipperSailDiffAnalysisHandler(
         IRunSettings runSettings,
-        ISailfishAgent agent,
         IPerformanceNarrativeContextBuilder contextBuilder,
-        ISkipperReviewWriter reviewWriter,
-        ISkipperReportWriter reportWriter,
-        ISkipperResponseCache responseCache,
-        IConsoleWriter consoleWriter,
-        ISkipperConsoleFormatter consoleFormatter,
-        ILogger logger)
+        ISkipperAnalysisRunner runner)
     {
         this.runSettings = runSettings;
-        this.agent = agent;
         this.contextBuilder = contextBuilder;
-        this.reviewWriter = reviewWriter;
-        this.reportWriter = reportWriter;
-        this.responseCache = responseCache;
-        this.consoleWriter = consoleWriter;
-        this.consoleFormatter = consoleFormatter;
-        this.logger = logger;
+        this.runner = runner;
     }
 
     public async Task Handle(SailDiffAnalysisCompleteNotification notification, CancellationToken cancellationToken)
     {
-        if (!runSettings.RunAiAnalysis) return;     // opt-in
-        if (agent is NoOpSailfishAgent) return;     // no real agent registered — stay invisible
+        if (!runSettings.RunAiAnalysis) return;
 
-        try
-        {
-            var settings = runSettings.AiAnalysisSettings;
-
-            var context = contextBuilder.Build(notification, runSettings.SailDiffSettings.Alpha);
-            if (context.Comparisons.Count == 0) return;
-
-            var review = await ResolveReviewAsync(context, settings, cancellationToken).ConfigureAwait(false);
-            if (!review.HasContent) return;
-
-            if (settings.WriteReviewArtifact)
-            {
-                await reviewWriter.WriteAsync(review, cancellationToken).ConfigureAwait(false);
-                await reportWriter.WriteAsync(review, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (settings.EmitConsoleSummary)
-                consoleWriter.WriteString(consoleFormatter.Format(review));
-        }
-        catch (Exception ex)
-        {
-            // Strictly additive: AI analysis must never break or alter a benchmark run.
-            logger.Log(LogLevel.Warning, ex, "Skipper AI analysis failed; continuing without it.");
-        }
-    }
-
-    private async Task<SkipperReview> ResolveReviewAsync(
-        PerformanceNarrativeContext context,
-        AiAnalysisSettings settings,
-        CancellationToken cancellationToken)
-    {
-        string? cacheKey = null;
-        if (settings.UseResponseCache)
-        {
-            cacheKey = responseCache.ComputeKey(context, settings.Role);
-            var cached = await responseCache.TryGetAsync(cacheKey, cancellationToken).ConfigureAwait(false);
-            if (cached is not null) return cached;
-        }
-
-        var repositoryRoot = ResolveRepositoryRoot();
-        var capabilities = new CapabilityRegistry(new ISkipperCapability[] { new CodeReadCapability(repositoryRoot) });
-        var session = new SkipperSession(settings.Role, context, capabilities, repositoryRoot);
-
-        var review = await agent.RunAsync(session, cancellationToken).ConfigureAwait(false);
-
-        if (cacheKey is not null && review.HasContent)
-            await responseCache.SetAsync(cacheKey, review, cancellationToken).ConfigureAwait(false);
-
-        return review;
-    }
-
-    /// <summary>Walks up from the working directory to the nearest Git root; falls back to the working directory.</summary>
-    private static string ResolveRepositoryRoot()
-    {
-        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
-        while (dir is not null)
-        {
-            if (Directory.Exists(Path.Combine(dir.FullName, ".git"))) return dir.FullName;
-            dir = dir.Parent;
-        }
-
-        return Directory.GetCurrentDirectory();
+        var context = contextBuilder.Build(notification, runSettings.SailDiffSettings.Alpha);
+        await runner.RunAsync(context, "saildiff", cancellationToken).ConfigureAwait(false);
     }
 }

--- a/source/Sailfish/DefaultHandlers/Ai/SkipperScaleFishAnalysisHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Ai/SkipperScaleFishAnalysisHandler.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Sailfish.Analysis.Ai;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+
+namespace Sailfish.DefaultHandlers.Ai;
+
+/// <summary>
+///     Bridges a completed ScaleFish complexity analysis to the Skipper AI layer. Builds a scaling context packet
+///     (best-fit Big-O, goodness of fit, distinguishability, and projections to larger N) and hands it to the
+///     shared <see cref="ISkipperAnalysisRunner" /> — answering "how does this scale, and what happens at 10× the
+///     data?". Opt-in and strictly additive.
+/// </summary>
+internal sealed class SkipperScaleFishAnalysisHandler : INotificationHandler<ScaleFishAnalysisCompleteNotification>
+{
+    private readonly IPerformanceNarrativeContextBuilder contextBuilder;
+    private readonly ISkipperAnalysisRunner runner;
+    private readonly IRunSettings runSettings;
+
+    public SkipperScaleFishAnalysisHandler(
+        IRunSettings runSettings,
+        IPerformanceNarrativeContextBuilder contextBuilder,
+        ISkipperAnalysisRunner runner)
+    {
+        this.runSettings = runSettings;
+        this.contextBuilder = contextBuilder;
+        this.runner = runner;
+    }
+
+    public async Task Handle(ScaleFishAnalysisCompleteNotification notification, CancellationToken cancellationToken)
+    {
+        if (!runSettings.RunAiAnalysis) return;
+
+        var context = contextBuilder.BuildScaling(notification);
+        await runner.RunAsync(context, "scalefish", cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -143,6 +143,7 @@ internal static class SailfishModuleRegistrations
         services.AddTransient<ISkipperReportWriter, SkipperReportWriter>();
         services.AddTransient<ISkipperResponseCache, FileSkipperResponseCache>();
         services.AddTransient<ISkipperConsoleFormatter, SkipperConsoleFormatter>();
+        services.AddTransient<ISkipperAnalysisRunner, SkipperAnalysisRunner>();
 
         return services;
     }

--- a/source/Tests.Library/Analysis/Ai/SkipperReportWriterTests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperReportWriterTests.cs
@@ -26,7 +26,7 @@ public class SkipperReportWriterTests
                 "summary",
                 "# Skipper Report\n\nParseHeaders regressed — regex compiled in loop (Parser.cs:88).");
 
-            await writer.WriteAsync(review, CancellationToken.None);
+            await writer.WriteAsync(review, "saildiff", CancellationToken.None);
 
             var file = Directory.GetFiles(dir, "skipper-report_*.md").ShouldHaveSingleItem();
             (await File.ReadAllTextAsync(file)).ShouldContain("Parser.cs:88");
@@ -47,7 +47,7 @@ public class SkipperReportWriterTests
             var writer = new SkipperReportWriter(settings);
             var review = SkipperReview.Empty with { ConsoleSummary = "summary only" };
 
-            await writer.WriteAsync(review, CancellationToken.None);
+            await writer.WriteAsync(review, "saildiff", CancellationToken.None);
 
             Directory.GetFiles(dir, "skipper-report_*.md").ShouldBeEmpty();
         }

--- a/source/Tests.Library/Analysis/Ai/SkipperScalingTests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperScalingTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using NSubstitute;
+using Sailfish.Analysis.Ai;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Results;
+using Shouldly;
+using Tests.Common.Builders.ScaleFish;
+using Xunit;
+
+namespace Tests.Library.Analysis.Ai;
+
+public class SkipperScalingTests
+{
+    [Fact]
+    public void BuildScaling_MapsBestFitRunnerUpAndGoodness()
+    {
+        var primary = new Linear();
+        var secondary = new Quadratic();
+        var model = ScaleFishModelBuilder.Create()
+            .AddPrimaryFunction(primary).SetPrimaryGoodnessOfFit(0.99)
+            .AddSecondaryFunction(secondary).SetSecondaryGoodnessOfFit(0.90)
+            .Build();
+
+        var notification = NotificationFor(model, methodName: "DoWork", propertyName: "N");
+
+        var context = MakeBuilder().BuildScaling(notification);
+
+        // Scaling-only context: no SailDiff comparisons, the ScaleFish markdown carried through.
+        context.Comparisons.ShouldBeEmpty();
+        context.SailDiffMarkdown.ShouldBe("## scalefish");
+        context.Scaling.ShouldNotBeNull();
+
+        var verdict = context.Scaling!.ShouldHaveSingleItem();
+        verdict.TestMethodName.ShouldBe("DoWork");
+        verdict.PropertyName.ShouldBe("N");
+        verdict.BestFitComplexity.ShouldBe(primary.OName);
+        verdict.GoodnessOfFit.ShouldBe(0.99);
+        verdict.NextBestComplexity.ShouldBe(secondary.OName);
+        verdict.NextBestGoodnessOfFit.ShouldBe(0.90);
+        verdict.Projections.ShouldNotBeNull();
+    }
+
+    private static ScaleFishAnalysisCompleteNotification NotificationFor(ScaleFishModel model, string methodName, string propertyName)
+    {
+        var classModel = new ScalefishClassModel(
+            "My.Namespace",
+            "MyClass",
+            new[] { new ScaleFishMethodModel(methodName, new[] { new ScaleFishPropertyModel(propertyName, model) }) });
+
+        return new ScaleFishAnalysisCompleteNotification("## scalefish", new List<ScalefishClassModel> { classModel });
+    }
+
+    private static PerformanceNarrativeContextBuilder MakeBuilder()
+    {
+        return new PerformanceNarrativeContextBuilder(
+            Substitute.For<IReproducibilityManifestProvider>(),
+            Substitute.For<IEnvironmentHealthReportProvider>());
+    }
+}


### PR DESCRIPTION
Builds on the merged Skipper layer (#266–#269). Completes the local Explain experience by teaching Skipper to explain **scaling**, and documents the whole feature on the doc site.

## ScaleFish "why does this scale like that?"

- **`SkipperScaleFishAnalysisHandler`** hangs off `ScaleFishAnalysisCompleteNotification` and answers *"how does this scale, and what happens at 10× the data?"*.
- **`PerformanceNarrativeContext`** gains an optional `Scaling` list of **`ComplexityVerdict`** — best-fit Big-O, goodness of fit, the runner-up, whether the two are statistically **distinguishable**, `SuggestedNextN`, and `Predict()`-based **projections to larger N**. Built by `PerformanceNarrativeContextBuilder.BuildScaling`.
- All grounded: the figures come straight from ScaleFish's fitted models; the agent explains them, it doesn't compute them.

## Refactor: shared pipeline

- Extracted the cache → agent → write → render pipeline into **`ISkipperAnalysisRunner`**. The SailDiff and ScaleFish handlers are now thin context-builders over it — no duplicated logic.
- Artifacts are **keyed by analysis kind** (`skipper-review_*_saildiff.json` / `_scalefish.json`, and the matching `.md`) so a run that does both never overwrites itself.
- The demo `ClaudeAgentModelProvider` prompt is generalized to describe whichever analysis is present.

## Documentation

The feature shipped undocumented — this fixes that.

- New **`site/src/pages/docs/2/skipper.md`** covering the whole Skipper feature: the `ISailfishAgent` seam, `.WithAiAnalysis()`, the grounding/anti-hallucination principle, reliability-aware verdicts, both "why" questions, the `review.json` / `report.md` artifacts, the **rerun-in-place workflow**, settings, and privacy.
- Nav entry added in `Layout.jsx` (Features → **Skipper (AI)**, badged NEW).

## Notes

- On the local comparison workflow: the docs lead with **rerun-in-place** (SailDiff auto-compares latest vs previous tracking file) as the zero-friction default — no file paths to type — while noting you can still pin a specific baseline.
- The **`dotnet sailfish ask`** CLI (natural-language Q&A over historical runs) is intentionally **not** in this PR — there's no CLI/tool project yet, so it's a larger standalone effort. Happy to do it next if you want it.

## Test plan

- 1 new test (26 total across the Skipper suite): `BuildScaling` maps best-fit / runner-up / goodness correctly into a scaling context.
- Core + full solution build clean on **net9.0** and **net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)