### PR TITLE
Enable Skipper in the VS Test Adapter (.sailfish.json)

### DIFF
--- a/site/src/pages/docs/2/skipper.md
+++ b/site/src/pages/docs/2/skipper.md
@@ -37,6 +37,20 @@ public class MyRegistration : IRegisterSailfishServices
 
 That's it. With no agent registered, `.WithAiAnalysis()` is a no-op — the feature stays completely invisible.
 
+### In a test project (`dotnet test` / Test Explorer)
+
+When you run `[Sailfish]` tests through the VS Test Adapter instead of the programmatic `SailfishRunner`, there's no builder to call — the adapter loads its configuration from a **`.sailfish.json`** file at (or above) your test directory. Turn Skipper on there:
+
+```json
+{
+  "AiAnalysisSettings": {
+    "Enabled": true
+  }
+}
+```
+
+Then register your agent from an `IRegisterSailfishServices` provider in the test project (exactly as shown above) — the adapter discovers it automatically. Optional keys mirror the programmatic settings: `WriteReviewArtifact`, `EmitConsoleSummary`, `UseResponseCache`. Without a registered agent, enabling this is a harmless no-op.
+
 ## The one interface you implement
 
 ```csharp

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -5,6 +5,7 @@ using Sailfish.TestAdapter.Discovery;
 using Sailfish.TestAdapter.TestSettingsParser;
 using SailDiffSettings = Sailfish.Analysis.SailDiff.SailDiffSettings;
 using RuntimeScaleFishSettings = Sailfish.Analysis.ScaleFish.ScaleFishSettings;
+using CoreAiAnalysisSettings = Sailfish.Analysis.Ai.AiAnalysisSettings;
 
 namespace Sailfish.TestAdapter.Execution;
 
@@ -47,6 +48,14 @@ public static class AdapterRunSettingsLoader
 
         if (parsedSettings.GlobalSettings.EmitDistributionHtmlReport is not null)
             runSettingsBuilder = runSettingsBuilder.WithDistributionHtmlReport(parsedSettings.GlobalSettings.EmitDistributionHtmlReport.Value);
+
+        // Skipper AI analysis is opt-in via .sailfish.json. A custom ISailfishAgent must also be registered
+        // through IRegisterSailfishServices; without one, enabling this is a harmless no-op.
+        if (parsedSettings.AiAnalysisSettings is { Enabled: true } ai)
+            runSettingsBuilder = runSettingsBuilder.WithAiAnalysis(new CoreAiAnalysisSettings(
+                writeReviewArtifact: ai.WriteReviewArtifact ?? true,
+                emitConsoleSummary: ai.EmitConsoleSummary ?? true,
+                useResponseCache: ai.UseResponseCache ?? true));
 
         var testSettings = MapToTestSettings(parsedSettings);
         var scaleFishSettings = MapToScaleFishSettings(parsedSettings);

--- a/source/Sailfish.TestAdapter/TestSettingsParser/AiAnalysisSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/AiAnalysisSettings.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Sailfish.TestAdapter.TestSettingsParser;
+
+/// <summary>
+///     <c>.sailfish.json</c> section that turns the Skipper AI analysis layer on for the VS Test Adapter
+///     (<c>dotnet test</c> / Test Explorer) path. Mirrors <c>Sailfish.Analysis.Ai.AiAnalysisSettings</c>.
+///     A custom <c>ISailfishAgent</c> must still be registered via <c>IRegisterSailfishServices</c>; without one,
+///     enabling this is a no-op (the run is unaffected).
+/// </summary>
+public class AiAnalysisSettings
+{
+    [JsonPropertyName("Enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonPropertyName("WriteReviewArtifact")]
+    public bool? WriteReviewArtifact { get; set; }
+
+    [JsonPropertyName("EmitConsoleSummary")]
+    public bool? EmitConsoleSummary { get; set; }
+
+    [JsonPropertyName("UseResponseCache")]
+    public bool? UseResponseCache { get; set; }
+}

--- a/source/Sailfish.TestAdapter/TestSettingsParser/SettingsConfiguration.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/SettingsConfiguration.cs
@@ -8,5 +8,7 @@ public class SettingsConfiguration
 
     public ScaleFishSettings ScaleFishSettings { get; set; } = new();
 
+    public AiAnalysisSettings AiAnalysisSettings { get; set; } = new();
+
     public GlobalSettings GlobalSettings { get; set; } = new();
 }

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
@@ -63,6 +63,32 @@ public class AdapterRunSettingsLoaderTests
         LoadFromConfig(json).DistributionPlotStyle.ShouldBe(DistributionPlotStyle.Histogram);
     }
 
+    [Fact]
+    public void AiAnalysis_Enabled_FlowsTo_RunAiAnalysis_AndSettings()
+    {
+        var json = """
+        {
+          "AiAnalysisSettings": {
+            "Enabled": true,
+            "EmitConsoleSummary": false
+          },
+          "GlobalSettings": {},
+          "SailDiffSettings": {},
+          "ScaleFishSettings": {}
+        }
+        """;
+
+        var runSettings = LoadFromConfig(json);
+        runSettings.RunAiAnalysis.ShouldBeTrue();
+        runSettings.AiAnalysisSettings.EmitConsoleSummary.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AiAnalysis_DefaultsOff_WhenNoSection()
+    {
+        LoadFromConfig("{ \"GlobalSettings\": {} }").RunAiAnalysis.ShouldBeFalse();
+    }
+
     // Writes the config in a parent dir and runs from a nested dir, because the loader recurses
     // UPWARDS to find .sailfish.json (it doesn't match a file sitting in the current directory).
     private static Sailfish.Contracts.Public.Models.IRunSettings LoadFromConfig(string json)
@@ -85,4 +111,3 @@ public class AdapterRunSettingsLoaderTests
         }
     }
 }
-


### PR DESCRIPTION
> **Stacked on #271.** Fixes the "Skipper needs the programmatic runner" gap reported when integrating into a **test project** (not a console app).

## The deal

Skipper's on-switch (`.WithAiAnalysis()`) only existed on the programmatic `RunSettingsBuilder` path. When you run `[Sailfish]` tests through the VS Test Adapter (`dotnet test` / Test Explorer), the adapter builds its own `IRunSettings` in `AdapterRunSettingsLoader` from `.sailfish.json` — and it never called `.WithAiAnalysis()`, with no settings key to do so. So `RunAiAnalysis` was always `false` and Skipper's handlers short-circuited.

**Everything else was already in place** (verified):
- `TestExecutor` calls `services.AddSailfish(...)` → Skipper's handlers, the shared runner, writers, cache, formatter and no-op agent are all registered.
- `TestExecutor` calls `InvokeRegistrationProviderCallbackMain(...)` → the adapter **discovers `IRegisterSailfishServices`**, so a custom `ISailfishAgent` registered in a test project is picked up.
- `AdapterSailDiff` / `AdapterScaleFish` **publish** the analysis-complete notifications Skipper subscribes to.

The only missing link was the toggle. This PR adds it.

## Changes

- New **`AiAnalysisSettings`** section in the `.sailfish.json` schema (`Enabled` + optional `WriteReviewArtifact` / `EmitConsoleSummary` / `UseResponseCache`), added to `SettingsConfiguration`.
- `AdapterRunSettingsLoader` calls `.WithAiAnalysis(...)` when `Enabled` is `true`, mapping the optional keys.
- Docs: `skipper.md` gains an **"In a test project"** section.

## How a test project uses Skipper now

1. Drop a `.sailfish.json` at (or above) the test directory:
   ```json
   { "AiAnalysisSettings": { "Enabled": true } }
   ```
2. Register your agent in the test project:
   ```csharp
   public class SkipperRegistration : IRegisterSailfishServices
   {
       public Task RegisterAsync(IServiceCollection services, CancellationToken ct = default)
       {
           services.AddSingleton<ISailfishAgent, MyAgent>();
           return Task.CompletedTask;
       }
   }
   ```

That's it — no programmatic runner required. Without a registered agent, enabling it is a harmless no-op.

## Test plan

- 2 new `AdapterRunSettingsLoader` tests: the toggle flows to `RunAiAnalysis` (and a sub-setting flows through), and it defaults off when the section is absent.
- Full solution builds clean on **net9.0** and **net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)