### PR TITLE
Wire the claude-CLI Skipper agent into both demos

### DIFF
--- a/site/src/pages/docs/2/skipper.md
+++ b/site/src/pages/docs/2/skipper.md
@@ -51,6 +51,13 @@ When you run `[Sailfish]` tests through the VS Test Adapter instead of the progr
 
 Then register your agent from an `IRegisterSailfishServices` provider in the test project (exactly as shown above) — the adapter discovers it automatically. Optional keys mirror the programmatic settings: `WriteReviewArtifact`, `EmitConsoleSummary`, `UseResponseCache`. Without a registered agent, enabling this is a harmless no-op.
 
+### Working examples in the repo
+
+A complete, runnable reference ships in the repo. `ClaudeAgentModelProvider` (a reference agent that drives the local `claude` CLI with read-only tools) is registered two ways:
+
+- **Test Adapter path** — the `PerformanceTests` project registers it in its `RegistrationProvider` and enables Skipper via `.sailfish.json`. Run a single benchmark test to see it (the agent is invoked once per analyzed comparison, so target one test rather than the whole suite).
+- **Programmatic path** — `ConsoleAppDemo` reuses the same provider and enables Skipper with `.WithAiAnalysis()`.
+
 ## The one interface you implement
 
 ```csharp

--- a/source/ConsoleAppDemo/AppRegistrationProvider.cs
+++ b/source/ConsoleAppDemo/AppRegistrationProvider.cs
@@ -6,6 +6,7 @@ using PerformanceTestingUserInvokedConsoleApp.CustomHandlerOverrideExamples;
 using Sailfish.Analysis.Ai;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Registration;
+using PerformanceTests.Skipper;
 
 namespace PerformanceTestingUserInvokedConsoleApp;
 

--- a/source/PerformanceTests/.sailfish.json
+++ b/source/PerformanceTests/.sailfish.json
@@ -10,6 +10,9 @@
     "Disabled": false
   },
   "ScaleFishSettings": {},
+  "AiAnalysisSettings": {
+    "Enabled": true
+  },
   "GlobalSettings": {
     "DisableOutlierDetection": false,
     "ResultsDirectory": "SailfishIDETestOutput",

--- a/source/PerformanceTests/RegistrationProvider.cs
+++ b/source/PerformanceTests/RegistrationProvider.cs
@@ -3,7 +3,9 @@ using System.Threading.Tasks;
 using Demo.API;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Sailfish.Analysis.Ai;
 using Sailfish.Registration;
+using PerformanceTests.Skipper;
 
 namespace PerformanceTests;
 
@@ -13,5 +15,9 @@ public class RegistrationProvider : IRegisterSailfishServices
     {
         await Task.CompletedTask;
         services.AddTransient<WebApplicationFactory<DemoApp>>();
+
+        // Skipper AI analysis: register the agentic provider. Combined with "AiAnalysisSettings": { "Enabled": true }
+        // in .sailfish.json, this lights up Skipper for the Test Adapter (dotnet test / Test Explorer) path.
+        services.AddSingleton<ISailfishAgent, ClaudeAgentModelProvider>();
     }
 }

--- a/source/PerformanceTests/Skipper/ClaudeAgentModelProvider.cs
+++ b/source/PerformanceTests/Skipper/ClaudeAgentModelProvider.cs
@@ -1,25 +1,37 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Sailfish.Analysis.Ai;
 
-namespace PerformanceTestingUserInvokedConsoleApp.CustomHandlerOverrideExamples;
+namespace PerformanceTests.Skipper;
 
 /// <summary>
-///     Reference <see cref="ISailfishAgent" /> that drives the <c>claude</c> CLI as an agentic, code-aware
-///     analyst. This is the "one seam, two power levels" payoff: the same interface that accepts a dumb one-shot
-///     completion also accepts a full agent that <em>reads the code under test</em> and cites <c>file:line</c>.
+///     Reference <see cref="ISailfishAgent" /> that drives the local <c>claude</c> CLI as an agentic, code-aware
+///     analyst — the "one seam, two power levels" payoff: the same interface that accepts a one-shot completion
+///     also accepts a full agent that <em>reads the code under test</em> and cites <c>file:line</c>.
+///     <para>
+///         This single copy is shared by both demos: the programmatic <c>ConsoleAppDemo</c> registers it directly,
+///         and the test-adapter <c>PerformanceTests</c> project registers it from its <c>RegistrationProvider</c>.
+///         Copy it into your own project and swap the transport (Anthropic SDK, Bedrock, a local model) to taste.
+///     </para>
 ///     <para>
 ///         It hands Skipper's grounded context to <c>claude -p</c> with read-only tools (Read/Grep/Glob) scoped to
-///         the repository root, then parses the returned JSON into a <see cref="SkipperReview" />. Everything
-///         degrades gracefully — if the CLI is absent or errors, a short note is returned and the benchmark run is
-///         unaffected. Copy this into your own project and adapt the transport (Anthropic SDK, Bedrock, a local
-///         model) to taste; the CLI flags below may need tweaking for your installed version.
+///         the repository root, parses the returned JSON into a <see cref="SkipperReview" />, and degrades
+///         gracefully — a missing/offline CLI, a non-zero exit, or a timeout yields a short note and never throws
+///         into the benchmark run.
 ///     </para>
 /// </summary>
-internal sealed class ClaudeAgentModelProvider : ISailfishAgent
+public sealed class ClaudeAgentModelProvider : ISailfishAgent
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(2);
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -36,7 +48,7 @@ internal sealed class ClaudeAgentModelProvider : ISailfishAgent
         }
         catch (Exception ex)
         {
-            // The CLI may be missing, unauthenticated, or offline. Skipper is strictly additive — never throw.
+            // The CLI may be missing, unauthenticated, offline, or slow. Skipper is strictly additive — never throw.
             return SkipperReview.Empty with { ConsoleSummary = $"(Skipper unavailable: {ex.Message})" };
         }
     }
@@ -83,23 +95,36 @@ internal sealed class ClaudeAgentModelProvider : ISailfishAgent
             UseShellExecute = false,
             WorkingDirectory = Directory.Exists(repositoryRoot) ? repositoryRoot : Directory.GetCurrentDirectory()
         };
-        startInfo.ArgumentList.Add("-p");                 // headless "print" mode; prompt arrives on stdin
+        startInfo.ArgumentList.Add("-p");             // headless "print" mode; the prompt arrives on stdin
         startInfo.ArgumentList.Add("--output-format");
         startInfo.ArgumentList.Add("text");
-        startInfo.ArgumentList.Add("--allowedTools");     // read-only investigation only
-        startInfo.ArgumentList.Add("Read");
-        startInfo.ArgumentList.Add("Grep");
-        startInfo.ArgumentList.Add("Glob");
+        startInfo.ArgumentList.Add("--allowedTools"); // read-only investigation only (space-separated list)
+        startInfo.ArgumentList.Add("Read Grep Glob");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(Timeout);
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();
 
-        await process.StandardInput.WriteAsync(prompt);
+        await process.StandardInput.WriteAsync(prompt.AsMemory(), timeout.Token);
         process.StandardInput.Close();
 
-        var stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(timeout.Token);
+        var stderrTask = process.StandardError.ReadToEndAsync(timeout.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new TimeoutException($"The claude CLI did not respond within {Timeout.TotalSeconds:F0}s.");
+        }
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
 
         if (process.ExitCode != 0)
             throw new InvalidOperationException($"claude exited with code {process.ExitCode}: {stderr}");


### PR DESCRIPTION
> **Stacked on #272** (which is stacked on #271). Makes Skipper runnable from a local `claude` CLI in both entry-point styles.

## What & why

You have the `claude` CLI locally, so this turns the reference agent into a working, copy-pasteable example in **both** styles — the programmatic console path and the test-adapter path — sharing one provider.

- **Shared provider.** Moved `ClaudeAgentModelProvider` into `PerformanceTests/Skipper/` (now `public`) so both demos use one copy (`ConsoleAppDemo` already references `PerformanceTests`). No more console-only duplicate.
- **Hardened it.** Added a **2-minute timeout** that kills a hung CLI (so a stuck `claude` can never hang a benchmark run), and switched to the verified single-arg `--allowedTools "Read Grep Glob"` form.
- **Verified against your CLI.** Smoke-tested the exact invocation on **claude 2.1.32**: piping a prompt to `claude -p --output-format text --allowedTools "Read Grep Glob"` returns the expected output.

## The two demos

**Test adapter (`PerformanceTests`)** — the `dotnet test` / Test Explorer path:
- `RegistrationProvider` registers `services.AddSingleton<ISailfishAgent, ClaudeAgentModelProvider>()`.
- `.sailfish.json` enables it: `{ "AiAnalysisSettings": { "Enabled": true } }`.

**Programmatic (`ConsoleAppDemo`)**:
- `AppRegistrationProvider` resolves the shared provider; `Program.cs` already enables it via `.WithAiAnalysis()` (and runs just `ReadmeExample`, so the call count stays bounded).

## How to see it

- **Console:** run `ConsoleAppDemo` twice (the second run gives SailDiff a prior tracking file to compare) → Skipper analyzes and prints the verdict block, and writes `skipper-report_*.md`.
- **Test project:** run a **single** benchmark test from `PerformanceTests` (the agent is invoked once per analyzed comparison, so target one test, not the whole suite).

## Notes / trade-offs

- I enabled AI in `PerformanceTests/.sailfish.json` by default so the demo is live. Because it calls the agent per comparison, running the *entire* PerformanceTests suite with it on is slow — flip `Enabled` to `false` if you'd rather keep it opt-in there. Happy to default it off if you prefer.
- No-`claude` environments (e.g., CI) hit the graceful fallback: a short `(Skipper unavailable)` note, no failure, fast.
- Full solution builds clean on **net9.0** and **net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)