### PR TITLE
Trawl (load testing) — Phase 0: contracts, [Trawl] attribute & settings wiring

### DIFF
--- a/site/src/pages/docs/2/trawl.md
+++ b/site/src/pages/docs/2/trawl.md
@@ -1,0 +1,83 @@
+---
+title: Trawl (Load Testing)
+---
+
+## Introduction
+
+**Trawl** is Sailfish's **load-testing** mode. Where a `[SailfishMethod]` micro-benchmarks a method by running it sequentially many times, a `[Trawl]` method is invoked **concurrently by many virtual users for a sustained duration** — and Sailfish reports the things load tests care about: **throughput, latency percentiles (p50/p90/p95/p99), and error rate**.
+
+A trawler drags a heavy net through the water under sustained load; that is exactly what this mode does to your system under test. It sits alongside the rest of the family — **SailDiff** (is this change a real regression?), **ScaleFish** (how does it scale?), and **Skipper** (why?) — and is designed to reuse them: the same statistical rigor that tells you a benchmark regressed will tell you a load profile regressed, and the same curve-fitting that classifies algorithmic complexity will find the **saturation knee** of a service.
+
+> **Design principle — thin engine, deep analysis.** Sailfish does not aim to out-generate dedicated load generators. Its edge is turning load numbers into *trustworthy, explained, regression-gating* answers — the quadrant every existing tool leaves empty. Trawl is the minimum concurrent-load engine; the value compounds with SailDiff, ScaleFish, and Skipper.
+
+## Authoring a load scenario
+
+A Trawl scenario is just a method in a normal `[Sailfish]` class, marked with `[Trawl]` instead of `[SailfishMethod]`:
+
+```csharp
+[Sailfish]
+public class CheckoutLoad
+{
+    private HttpClient client = null!;
+
+    [SailfishGlobalSetup]
+    public void Setup() => client = new HttpClient { BaseAddress = new Uri("https://localhost:5001") };
+
+    [Trawl(VirtualUsers = 50, DurationSeconds = 120, WarmupSeconds = 15)]
+    public async Task Checkout(CancellationToken ct)
+    {
+        var response = await client.PostAsJsonAsync("/checkout", Payload, ct);
+        response.EnsureSuccessStatusCode();
+    }
+}
+```
+
+The scenario method is protocol-agnostic — it is any `async` method. Sailfish does not care whether it makes an HTTP call, a database query, or a gRPC request; it only measures how the method behaves under concurrency.
+
+### Lifecycle and thread-safety
+
+The enclosing class is an ordinary `[Sailfish]` class, so the usual hooks apply — warm a shared `HttpClient` or seed data in `[SailfishGlobalSetup]`. Because **all virtual users share the one test instance**, any scenario state must be thread-safe (a shared `HttpClient` is; a mutable field updated per request is not).
+
+### A method is one mode or the other
+
+A method is either a microbenchmark (`[SailfishMethod]`) or a load scenario (`[Trawl]`) — never both. The **SF1022** analyzer enforces this at build time.
+
+## The `[Trawl]` attribute
+
+| Property | Default | Meaning |
+|---|---|---|
+| `VirtualUsers` | `10` | Concurrent virtual users (closed model). |
+| `DurationSeconds` | `30` | Sustained, measured load duration (after warmup). |
+| `WarmupSeconds` | `5` | Warmup duration; traffic is generated but not measured. |
+| `Model` | `ClosedModel` | `ClosedModel` (fixed VUs) or `OpenModel` (target arrival rate). |
+| `TargetRequestsPerSecond` | `0` | Target rate for the open model. |
+| `Disabled` | `false` | Skip this scenario. |
+
+## Run-wide settings (`.sailfish.json`)
+
+The per-scenario attribute authors the scenario; run-wide **`TrawlSettings`** lets you reshape every scenario at run time without editing the test source — most usefully to shrink a load run in CI:
+
+```jsonc
+{
+  "TrawlSettings": {
+    "Disabled": false,            // global kill switch for all [Trawl] scenarios
+    "VirtualUsersOverride": 5,    // clamp every closed-model scenario to 5 VUs
+    "MaxDurationSecondsOverride": 10, // cap sustained duration at 10s
+    "WarmupSecondsOverride": 2
+  }
+}
+```
+
+Every override is absent (`null`) by default, meaning "use the per-scenario attribute value". The same settings are available programmatically:
+
+```csharp
+var settings = RunSettingsBuilder
+    .CreateBuilder()
+    .WithTrawlVirtualUsers(5)
+    .WithTrawlMaxDuration(10)
+    .Build();
+```
+
+## Status
+
+Trawl is being delivered in phases. This release establishes the public surface — the `[Trawl]` attribute, `TrawlSettings`, the `TrawlResult` shape, and the SF1022 analyzer. The concurrent execution engine, reporting/plots, SailDiff regression gating, and ScaleFish saturation analysis land in subsequent releases.

--- a/source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md
@@ -16,6 +16,7 @@ SF1015 | Sailfish.Usage | Error | Properties assigned in the global setup must h
 SF1016 | Sailfish.Usage | Warning | Variable-dependent state built in a once-per-class hook (GlobalSetup/GlobalTeardown) is silently frozen; build it in MethodSetup
 SF1020 | Sailfish.Usage | Error | Sailfish lifecycle methods must be public
 SF1021 | Sailfish.Usage | Error | Only one Sailfish lifecycle attribute is allowed per method
+SF1022 | Sailfish.Usage | Error | A method may not be decorated with both [SailfishMethod] and [Trawl]
 SF7000 | Sailfish.Suppression | Hidden | Suppresses warnings when a non nullable property is set in the global setup method
 SF1300 | Sailfish.Usage | Error | IsBaseline=true on a method that isn't in any comparison group
 SF1301 | Sailfish.Usage | Error | At most one method per comparison group (explicit or implicit) may set IsBaseline=true

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/Trawl/TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/Trawl/TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Sailfish.Analyzers.Utils;
+using Sailfish.Analyzers.Utils.TreeParsingExtensionMethods;
+
+namespace Sailfish.Analyzers.DiagnosticAnalyzers.Trawl;
+
+/// <summary>
+///     SF1022 — a method may not be decorated with both <c>[SailfishMethod]</c> and <c>[Trawl]</c>.
+///     <c>[SailfishMethod]</c> runs a method as a sequential microbenchmark; <c>[Trawl]</c> runs it as a
+///     concurrent load scenario. The two execution modes are mutually exclusive.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
+{
+    private static readonly string[] SailfishMethodNames = { "SailfishMethod", "SailfishMethodAttribute" };
+    private static readonly string[] TrawlNames = { "Trawl", "TrawlAttribute" };
+
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        "SF1022",
+        "A method may not be both a microbenchmark and a load scenario",
+        "Method '{0}' is decorated with both [SailfishMethod] and [Trawl]; a method is either a microbenchmark or a load scenario, not both",
+        AnalyzerGroups.EssentialAnalyzers.Category,
+        isEnabledByDefault: AnalyzerGroups.EssentialAnalyzers.IsEnabledByDefault,
+        defaultSeverity: DiagnosticSeverity.Error,
+        description: "[SailfishMethod] runs a method as a sequential microbenchmark; [Trawl] runs it as a concurrent load scenario. The two execution modes are mutually exclusive.",
+        helpLinkUri: AnalyzerGroups.EssentialAnalyzers.HelpLink);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    protected override void AnalyzeNode(TypeDeclarationSyntax classDeclaration, SemanticModel semanticModel, SyntaxNodeAnalysisContext context)
+    {
+        if (!classDeclaration.IsASailfishTestType(semanticModel)) return;
+
+        foreach (var method in classDeclaration.Members.OfType<MethodDeclarationSyntax>())
+        {
+            var attributeNames = method
+                .AttributeLists
+                .SelectMany(list => list.Attributes)
+                .Select(attribute => attribute.Name.ToString())
+                .ToList();
+
+            var hasSailfishMethod = attributeNames.Any(name => SailfishMethodNames.Contains(name));
+            var hasTrawl = attributeNames.Any(name => TrawlNames.Contains(name));
+
+            if (hasSailfishMethod && hasTrawl)
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, method.Identifier.GetLocation(), method.Identifier.Text));
+        }
+    }
+}

--- a/source/Sailfish.Analyzers/DiagnosticAnalyzers/Trawl/TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer.cs
+++ b/source/Sailfish.Analyzers/DiagnosticAnalyzers/Trawl/TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer.cs
@@ -15,8 +15,8 @@ namespace Sailfish.Analyzers.DiagnosticAnalyzers.Trawl;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer : AnalyzerBase<ClassDeclarationSyntax>
 {
-    private static readonly string[] SailfishMethodNames = { "SailfishMethod", "SailfishMethodAttribute" };
-    private static readonly string[] TrawlNames = { "Trawl", "TrawlAttribute" };
+    private const string SailfishMethodAttributeName = "SailfishMethodAttribute";
+    private const string TrawlAttributeName = "TrawlAttribute";
 
     public static readonly DiagnosticDescriptor Descriptor = new(
         "SF1022",
@@ -36,14 +36,25 @@ public class TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer : AnalyzerBase<C
 
         foreach (var method in classDeclaration.Members.OfType<MethodDeclarationSyntax>())
         {
-            var attributeNames = method
-                .AttributeLists
-                .SelectMany(list => list.Attributes)
-                .Select(attribute => attribute.Name.ToString())
-                .ToList();
+            // Resolve attributes semantically (via the bound symbol) rather than by syntactic name, so
+            // namespace-qualified, global::-qualified, or aliased usages are still detected. Mirrors the
+            // codebase's other semantic attribute checks (e.g. the global-setup analyzers).
+            if (semanticModel.GetDeclaredSymbol(method) is not { } methodSymbol) continue;
 
-            var hasSailfishMethod = attributeNames.Any(name => SailfishMethodNames.Contains(name));
-            var hasTrawl = attributeNames.Any(name => TrawlNames.Contains(name));
+            var hasSailfishMethod = false;
+            var hasTrawl = false;
+            foreach (var attribute in methodSymbol.GetAttributes())
+            {
+                switch (attribute.AttributeClass?.Name)
+                {
+                    case SailfishMethodAttributeName:
+                        hasSailfishMethod = true;
+                        break;
+                    case TrawlAttributeName:
+                        hasTrawl = true;
+                        break;
+                }
+            }
 
             if (hasSailfishMethod && hasTrawl)
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, method.Identifier.GetLocation(), method.Identifier.Text));

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -5,6 +5,7 @@ using Sailfish.TestAdapter.Discovery;
 using Sailfish.TestAdapter.TestSettingsParser;
 using SailDiffSettings = Sailfish.Analysis.SailDiff.SailDiffSettings;
 using RuntimeScaleFishSettings = Sailfish.Analysis.ScaleFish.ScaleFishSettings;
+using RuntimeTrawlSettings = Sailfish.Trawl.TrawlSettings;
 
 namespace Sailfish.TestAdapter.Execution;
 
@@ -50,10 +51,12 @@ public static class AdapterRunSettingsLoader
 
         var testSettings = MapToTestSettings(parsedSettings);
         var scaleFishSettings = MapToScaleFishSettings(parsedSettings);
+        var trawlSettings = MapToTrawlSettings(parsedSettings);
         var runSettings = runSettingsBuilder
             .CreateTrackingFiles()
             .WithSailDiff(testSettings)
             .WithScaleFish(scaleFishSettings)
+            .WithTrawl(trawlSettings)
             .Build();
         return runSettings;
     }
@@ -75,6 +78,20 @@ public static class AdapterRunSettingsLoader
         if (parsed.TailPercentiles is not null && parsed.TailPercentiles.Length > 0) mapped.TailPercentiles = parsed.TailPercentiles;
         if (parsed.EnableTrendTracking is not null) mapped.EnableTrendTracking = parsed.EnableTrendTracking.Value;
         if (parsed.EmitHtmlReport is not null) mapped.EmitHtmlReport = parsed.EmitHtmlReport.Value;
+        return mapped;
+    }
+
+    private static RuntimeTrawlSettings MapToTrawlSettings(SettingsConfiguration settingsConfiguration)
+    {
+        var mapped = new RuntimeTrawlSettings();
+        var parsed = settingsConfiguration.TrawlSettings;
+        // `SettingsConfiguration.TrawlSettings` is initialized inline to a default instance, but a user can
+        // explicitly set the JSON property to null. Return defaults in that case rather than NRE.
+        if (parsed is null) return mapped;
+        if (parsed.Disabled is not null) mapped.Disabled = parsed.Disabled.Value;
+        if (parsed.VirtualUsersOverride is not null) mapped.VirtualUsersOverride = parsed.VirtualUsersOverride.Value;
+        if (parsed.MaxDurationSecondsOverride is not null) mapped.MaxDurationSecondsOverride = parsed.MaxDurationSecondsOverride.Value;
+        if (parsed.WarmupSecondsOverride is not null) mapped.WarmupSecondsOverride = parsed.WarmupSecondsOverride.Value;
         return mapped;
     }
 

--- a/source/Sailfish.TestAdapter/TestSettingsParser/SettingsConfiguration.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/SettingsConfiguration.cs
@@ -9,4 +9,6 @@ public class SettingsConfiguration
     public ScaleFishSettings ScaleFishSettings { get; set; } = new();
 
     public GlobalSettings GlobalSettings { get; set; } = new();
+
+    public TrawlSettings TrawlSettings { get; set; } = new();
 }

--- a/source/Sailfish.TestAdapter/TestSettingsParser/TrawlSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/TrawlSettings.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Sailfish.TestAdapter.TestSettingsParser;
+
+/// <summary>
+/// JSON-deserialised Trawl (load testing) settings from <c>.sailfish.json</c>. All fields are nullable so
+/// the loader can tell "absent" (use the library default / per-scenario attribute value) from "explicitly
+/// set" (override every scenario).
+/// </summary>
+public class TrawlSettings
+{
+    /// <summary>Global kill switch for <c>[Trawl]</c> load scenarios.</summary>
+    [JsonPropertyName("Disabled")]
+    public bool? Disabled { get; set; }
+
+    /// <summary>Override the number of virtual users for every closed-model scenario.</summary>
+    [JsonPropertyName("VirtualUsersOverride")]
+    public int? VirtualUsersOverride { get; set; }
+
+    /// <summary>Cap the sustained (measured) load duration in seconds for every scenario.</summary>
+    [JsonPropertyName("MaxDurationSecondsOverride")]
+    public double? MaxDurationSecondsOverride { get; set; }
+
+    /// <summary>Override the warmup duration in seconds for every scenario.</summary>
+    [JsonPropertyName("WarmupSecondsOverride")]
+    public double? WarmupSecondsOverride { get; set; }
+}

--- a/source/Sailfish/Attributes/TrawlAttribute.cs
+++ b/source/Sailfish/Attributes/TrawlAttribute.cs
@@ -1,0 +1,50 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Sailfish.Trawl;
+
+namespace Sailfish.Attributes;
+
+/// <summary>
+///     Marks a method as a Trawl <b>load-testing scenario</b>. Instead of being micro-benchmarked
+///     sequentially (as with <see cref="SailfishMethodAttribute" />), the method is invoked
+///     <i>concurrently</i> by many virtual users for a sustained duration, and Sailfish reports throughput,
+///     latency percentiles, and error rate.
+/// </summary>
+/// <remarks>
+///     A method is either a microbenchmark (<see cref="SailfishMethodAttribute" />) or a load scenario
+///     (<see cref="TrawlAttribute" />), never both — the <c>SF1022</c> analyzer enforces this. The enclosing
+///     class is a normal <c>[Sailfish]</c> class, so the usual lifecycle hooks apply: warm a shared
+///     <c>HttpClient</c> or seed data in <c>[SailfishGlobalSetup]</c>. Because all virtual users share the one
+///     test instance, scenario state must be thread-safe.
+/// </remarks>
+/// <seealso cref="SailfishAttribute" />
+/// <seealso cref="LoadModel" />
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class TrawlAttribute : Attribute
+{
+    public TrawlAttribute()
+    {
+    }
+
+    /// <summary>Number of concurrent virtual users (closed model). Default 10.</summary>
+    [Range(1, int.MaxValue)]
+    public int VirtualUsers { get; set; } = 10;
+
+    /// <summary>Sustained, measured load duration in seconds (after warmup). Default 30.</summary>
+    public double DurationSeconds { get; set; } = 30;
+
+    /// <summary>Warmup duration in seconds; traffic is generated but not measured. Default 5.</summary>
+    public double WarmupSeconds { get; set; } = 5;
+
+    /// <summary>The load model to apply. Default <see cref="LoadModel.ClosedModel" />.</summary>
+    public LoadModel Model { get; set; } = LoadModel.ClosedModel;
+
+    /// <summary>
+    ///     Target arrival rate in requests/second for <see cref="LoadModel.OpenModel" />. Ignored by the
+    ///     closed model. 0 (default) means unset.
+    /// </summary>
+    public double TargetRequestsPerSecond { get; set; }
+
+    /// <summary>When <c>true</c>, this load scenario is skipped. Default <c>false</c>.</summary>
+    public bool Disabled { get; set; }
+}

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -4,6 +4,7 @@ using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Analysis.Ai;
+using Sailfish.Trawl;
 
 using Sailfish.Extensions.Types;
 using Sailfish.Logging;
@@ -21,6 +22,9 @@ public interface IRunSettings
     SailDiffSettings SailDiffSettings { get; }
     ScaleFishSettings ScaleFishSettings { get; }
     AiAnalysisSettings AiAnalysisSettings { get; }
+
+    // Trawl (load testing) global settings/overrides for [Trawl] load scenarios
+    TrawlSettings TrawlSettings { get; }
     IEnumerable<Type> TestLocationAnchors { get; }
     IEnumerable<Type> RegistrationProviderAnchors { get; }
     OrderedDictionary Tags { get; }

--- a/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
+++ b/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
@@ -1,0 +1,72 @@
+using System;
+using Sailfish.Trawl;
+
+namespace Sailfish.Contracts.Public.Models;
+
+/// <summary>
+///     Summary of one Trawl (load) scenario run: how much traffic was generated, how fast it went, how
+///     often it failed, and the latency distribution. All latency figures are in milliseconds (Sailfish's
+///     canonical duration unit).
+/// </summary>
+public sealed record TrawlResult
+{
+    /// <summary>The scenario's display name (test case id).</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>The load model that was applied.</summary>
+    public LoadModel Model { get; init; }
+
+    /// <summary>The number of concurrent virtual users used (closed model).</summary>
+    public int VirtualUsers { get; init; }
+
+    /// <summary>The measured (post-warmup) wall-clock duration of the run.</summary>
+    public TimeSpan Duration { get; init; }
+
+    /// <summary>Total completed requests in the measured window (successes + failures).</summary>
+    public long TotalRequests { get; init; }
+
+    /// <summary>Total failed requests (threw, or were reported as errors) in the measured window.</summary>
+    public long TotalErrors { get; init; }
+
+    /// <summary>Achieved throughput, requests per second, over the measured window.</summary>
+    public double RequestsPerSecond { get; init; }
+
+    /// <summary>Error rate in the range [0, 1].</summary>
+    public double ErrorRate { get; init; }
+
+    /// <summary>Latency distribution summary (milliseconds).</summary>
+    public LatencyStats Latency { get; init; } = LatencyStats.Empty;
+}
+
+/// <summary>
+///     Latency distribution summary for a Trawl run, in milliseconds.
+/// </summary>
+public sealed record LatencyStats
+{
+    /// <summary>Fastest observed latency (ms).</summary>
+    public double Min { get; init; }
+
+    /// <summary>Arithmetic mean latency (ms).</summary>
+    public double Mean { get; init; }
+
+    /// <summary>Median (50th percentile) latency (ms).</summary>
+    public double P50 { get; init; }
+
+    /// <summary>75th percentile latency (ms).</summary>
+    public double P75 { get; init; }
+
+    /// <summary>90th percentile latency (ms).</summary>
+    public double P90 { get; init; }
+
+    /// <summary>95th percentile latency (ms).</summary>
+    public double P95 { get; init; }
+
+    /// <summary>99th percentile latency (ms).</summary>
+    public double P99 { get; init; }
+
+    /// <summary>Slowest observed latency (ms).</summary>
+    public double Max { get; init; }
+
+    /// <summary>An all-zero instance, used before a run has produced measurements.</summary>
+    public static LatencyStats Empty => new();
+}

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -5,6 +5,7 @@ using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Analysis.Ai;
+using Sailfish.Trawl;
 
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Extensions.Types;
@@ -51,7 +52,8 @@ internal class RunSettings : IRunSettings
         AiAnalysisSettings? aiAnalysisSettings = null,
         bool enableDistributionPlots = true,
         bool emitDistributionHtmlReport = false,
-        DistributionPlotStyle distributionPlotStyle = DistributionPlotStyle.Histogram)
+        DistributionPlotStyle distributionPlotStyle = DistributionPlotStyle.Histogram,
+        TrawlSettings? trawlSettings = null)
     {
         TestNames = testNames;
         LocalOutputDirectory = localOutputDirectory;
@@ -89,6 +91,7 @@ internal class RunSettings : IRunSettings
         EnableDistributionPlots = enableDistributionPlots;
         EmitDistributionHtmlReport = emitDistributionHtmlReport;
         DistributionPlotStyle = distributionPlotStyle;
+        TrawlSettings = trawlSettings ?? new TrawlSettings();
         MinimumLogLevel = minimumLogLevel;
     }
 
@@ -130,6 +133,7 @@ internal class RunSettings : IRunSettings
     public bool EnableDistributionPlots { get; }
     public bool EmitDistributionHtmlReport { get; }
     public DistributionPlotStyle DistributionPlotStyle { get; }
+    public TrawlSettings TrawlSettings { get; }
 
     public LogLevel MinimumLogLevel { get; }
 

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -4,6 +4,7 @@ using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Analysis.Ai;
+using Sailfish.Trawl;
 
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Extensions.Types;
@@ -45,6 +46,7 @@ public class RunSettingsBuilder
     private bool _enableDistributionPlots = true;
     private bool _emitDistributionHtmlReport;
     private DistributionPlotStyle _distributionPlotStyle = DistributionPlotStyle.Histogram;
+    private TrawlSettings? _trawlSettings;
 
 
     // Optional deterministic randomization seed for reproducible ordering
@@ -149,6 +151,38 @@ public class RunSettingsBuilder
     public RunSettingsBuilder WithDistributionPlotStyle(DistributionPlotStyle style)
     {
         _distributionPlotStyle = style;
+        return this;
+    }
+
+    /// <summary>
+    ///     Supplies run-wide Trawl (load testing) settings/overrides. Unlike SailDiff/ScaleFish, Trawl is not
+    ///     gated by a builder flag — a scenario runs whenever a method carries <c>[Trawl]</c>. These settings
+    ///     only reshape or disable those scenarios at run time.
+    /// </summary>
+    public RunSettingsBuilder WithTrawl(TrawlSettings settings)
+    {
+        _trawlSettings = settings;
+        return this;
+    }
+
+    /// <summary>Overrides the number of virtual users for every closed-model Trawl scenario.</summary>
+    public RunSettingsBuilder WithTrawlVirtualUsers(int virtualUsers)
+    {
+        (_trawlSettings ??= new TrawlSettings()).VirtualUsersOverride = virtualUsers;
+        return this;
+    }
+
+    /// <summary>Caps the sustained (measured) load duration in seconds for every Trawl scenario.</summary>
+    public RunSettingsBuilder WithTrawlMaxDuration(double seconds)
+    {
+        (_trawlSettings ??= new TrawlSettings()).MaxDurationSecondsOverride = seconds;
+        return this;
+    }
+
+    /// <summary>Disables every <c>[Trawl]</c> load scenario for this run (the rest of the run proceeds normally).</summary>
+    public RunSettingsBuilder DisableTrawl()
+    {
+        (_trawlSettings ??= new TrawlSettings()).Disabled = true;
         return this;
     }
 
@@ -420,7 +454,8 @@ public class RunSettingsBuilder
             aiAnalysisSettings: _aiSettings,
             enableDistributionPlots: _enableDistributionPlots,
             emitDistributionHtmlReport: _emitDistributionHtmlReport,
-            distributionPlotStyle: _distributionPlotStyle);
+            distributionPlotStyle: _distributionPlotStyle,
+            trawlSettings: _trawlSettings);
     }
 
     private void ApplyPreset(SailfishPreset preset)

--- a/source/Sailfish/Trawl/LoadModel.cs
+++ b/source/Sailfish/Trawl/LoadModel.cs
@@ -1,0 +1,22 @@
+namespace Sailfish.Trawl;
+
+/// <summary>
+///     Selects how load is applied to a <see cref="Sailfish.Attributes.TrawlAttribute" /> scenario.
+/// </summary>
+public enum LoadModel
+{
+    /// <summary>
+    ///     A fixed number of concurrent virtual users, each looping (run the scenario, then immediately
+    ///     run it again) for the scenario duration. Throughput is emergent — it is whatever the system
+    ///     under test can sustain at that concurrency. This is the default and the only model honored by
+    ///     the initial Trawl execution engine.
+    /// </summary>
+    ClosedModel = 0,
+
+    /// <summary>
+    ///     Requests are dispatched at a fixed target arrival rate (requests/second) regardless of how many
+    ///     are already in flight — the "open" model that proper load tests use to expose coordinated
+    ///     omission. Honored once the arrival-rate scheduler ships in a later release.
+    /// </summary>
+    OpenModel = 1
+}

--- a/source/Sailfish/Trawl/TrawlSettings.cs
+++ b/source/Sailfish/Trawl/TrawlSettings.cs
@@ -1,0 +1,42 @@
+namespace Sailfish.Trawl;
+
+/// <summary>
+///     Run-wide knobs and overrides for Trawl (load testing) scenarios. These are distinct from the
+///     per-scenario <see cref="Sailfish.Attributes.TrawlAttribute" />: the attribute authors the scenario,
+///     while these settings let you reshape every scenario at run time — most usefully to shrink a load run
+///     in CI (fewer virtual users, a capped duration) without editing the test source.
+///     <para>
+///         Every override is <c>null</c> / <c>false</c> by default, meaning "use the per-scenario attribute
+///         value". A non-null override replaces the attribute value for every scenario in the run.
+///     </para>
+/// </summary>
+public class TrawlSettings
+{
+    /// <summary>
+    ///     Global kill switch. When <c>true</c>, every <c>[Trawl]</c> load scenario is skipped while the
+    ///     rest of the run proceeds normally. Default <c>false</c>.
+    /// </summary>
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    ///     Overrides the number of concurrent virtual users for every closed-model scenario. <c>null</c>
+    ///     (default) leaves each scenario's own <see cref="Sailfish.Attributes.TrawlAttribute.VirtualUsers" />
+    ///     in effect.
+    /// </summary>
+    public int? VirtualUsersOverride { get; set; }
+
+    /// <summary>
+    ///     Caps the sustained (measured) load duration in seconds for every scenario. A scenario whose
+    ///     attribute requests a longer duration is clamped to this value. <c>null</c> (default) means no cap.
+    /// </summary>
+    public double? MaxDurationSecondsOverride { get; set; }
+
+    /// <summary>
+    ///     Overrides the warmup duration in seconds for every scenario. <c>null</c> (default) leaves each
+    ///     scenario's own warmup in effect.
+    /// </summary>
+    public double? WarmupSecondsOverride { get; set; }
+
+    /// <summary>A fresh instance with all-default (no-override) values.</summary>
+    public static TrawlSettings Default => new();
+}

--- a/source/Tests.Analyzers/Trawl/TrawlAndSailfishMethodAreMutuallyExclusive.cs
+++ b/source/Tests.Analyzers/Trawl/TrawlAndSailfishMethodAreMutuallyExclusive.cs
@@ -1,0 +1,63 @@
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Testing;
+using Sailfish.Analyzers.DiagnosticAnalyzers.Trawl;
+using Tests.Analyzers.Utils;
+using Xunit;
+
+namespace Tests.Analyzers.Trawl;
+
+public class TrawlAndSailfishMethodAreMutuallyExclusive
+{
+    [Fact]
+    public async Task ReportsWhenMethodHasBothAttributes()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod]
+    [Trawl]
+    public void {|#0:DoWork|}()
+    {
+    }
+}";
+        await AnalyzerVerifier<TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies(),
+            new DiagnosticResult(TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer.Descriptor).WithLocation(0).WithArguments("DoWork")
+        );
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForTrawlOnly()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [Trawl]
+    public void DoWork()
+    {
+    }
+}";
+        await AnalyzerVerifier<TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies()
+        );
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForSailfishMethodOnly()
+    {
+        const string source = @"
+[Sailfish]
+public class TestCode
+{
+    [SailfishMethod]
+    public void DoWork()
+    {
+    }
+}";
+        await AnalyzerVerifier<TrawlAndSailfishMethodAreMutuallyExclusiveAnalyzer>.VerifyAnalyzerAsync(
+            source.AddSailfishAttributeDependencies()
+        );
+    }
+}

--- a/source/Tests.Analyzers/Utils/TestDependencyExtensionMethods.cs
+++ b/source/Tests.Analyzers/Utils/TestDependencyExtensionMethods.cs
@@ -104,6 +104,14 @@ public sealed class SailfishMethodAttribute : Attribute
     public bool IsBaseline { get; set; }
 }
 
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class TrawlAttribute : Attribute
+{
+    public int VirtualUsers { get; set; }
+    public double DurationSeconds { get; set; }
+    public double WarmupSeconds { get; set; }
+}
+
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public sealed class SailfishMethodSetupAttribute : Attribute, IInnerLifecycleAttribute
 {

--- a/source/Tests.Library/Trawl/TrawlSettingsWiringTests.cs
+++ b/source/Tests.Library/Trawl/TrawlSettingsWiringTests.cs
@@ -1,0 +1,53 @@
+using Sailfish;
+using Sailfish.Trawl;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class TrawlSettingsWiringTests
+{
+    [Fact]
+    public void RunSettings_Has_NonNull_Default_TrawlSettings()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder().Build();
+
+        settings.TrawlSettings.ShouldNotBeNull();
+        settings.TrawlSettings.Disabled.ShouldBeFalse();
+        settings.TrawlSettings.VirtualUsersOverride.ShouldBeNull();
+        settings.TrawlSettings.MaxDurationSecondsOverride.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Builder_WithTrawl_RoundTrips_The_Settings_Object()
+    {
+        var trawl = new TrawlSettings
+        {
+            Disabled = true,
+            VirtualUsersOverride = 8,
+            MaxDurationSecondsOverride = 20,
+            WarmupSecondsOverride = 3
+        };
+
+        var settings = RunSettingsBuilder.CreateBuilder().WithTrawl(trawl).Build();
+
+        settings.TrawlSettings.Disabled.ShouldBeTrue();
+        settings.TrawlSettings.VirtualUsersOverride.ShouldBe(8);
+        settings.TrawlSettings.MaxDurationSecondsOverride.ShouldBe(20.0);
+        settings.TrawlSettings.WarmupSecondsOverride.ShouldBe(3.0);
+    }
+
+    [Fact]
+    public void Builder_Granular_Trawl_Helpers_Compose()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithTrawlVirtualUsers(16)
+            .WithTrawlMaxDuration(45)
+            .DisableTrawl()
+            .Build();
+
+        settings.TrawlSettings.VirtualUsersOverride.ShouldBe(16);
+        settings.TrawlSettings.MaxDurationSecondsOverride.ShouldBe(45.0);
+        settings.TrawlSettings.Disabled.ShouldBeTrue();
+    }
+}

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoader_Trawl_Tests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoader_Trawl_Tests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using Sailfish.TestAdapter.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.TestAdapter;
+
+// Serialize with the sibling AdapterRunSettingsLoader tests — they all mutate the process-wide
+// current working directory via Directory.SetCurrentDirectory, which races under xUnit's default
+// class-parallel execution.
+[Collection("CwdMutatingAdapterRunSettingsLoader")]
+public class AdapterRunSettingsLoaderTrawlTests
+{
+    [Fact]
+    public void TrawlSettings_Are_Mapped_From_Json()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var root = Path.Combine(Path.GetTempPath(), "sf_adapter_trawl_" + Guid.NewGuid().ToString("N"));
+        var nested = Path.Combine(root, "a", "b");
+        Directory.CreateDirectory(nested);
+
+        try
+        {
+            var json = """
+            {
+              "GlobalSettings": {},
+              "SailDiffSettings": {},
+              "ScaleFishSettings": {},
+              "TrawlSettings": {
+                "Disabled": true,
+                "VirtualUsersOverride": 4,
+                "MaxDurationSecondsOverride": 12.5,
+                "WarmupSecondsOverride": 2.0
+              }
+            }
+            """;
+            File.WriteAllText(Path.Combine(root, ".sailfish.json"), json);
+
+            Directory.SetCurrentDirectory(nested);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
+
+            runSettings.TrawlSettings.Disabled.ShouldBeTrue();
+            runSettings.TrawlSettings.VirtualUsersOverride.ShouldBe(4);
+            runSettings.TrawlSettings.MaxDurationSecondsOverride.ShouldBe(12.5);
+            runSettings.TrawlSettings.WarmupSecondsOverride.ShouldBe(2.0);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            try { Directory.Delete(root, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public void TrawlSettings_Default_To_NoOverride_When_Absent()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var root = Path.Combine(Path.GetTempPath(), "sf_adapter_trawl_default_" + Guid.NewGuid().ToString("N"));
+        var nested = Path.Combine(root, "a", "b");
+        Directory.CreateDirectory(nested);
+
+        try
+        {
+            var json = """
+            {
+              "GlobalSettings": {},
+              "SailDiffSettings": {},
+              "ScaleFishSettings": {}
+            }
+            """;
+            File.WriteAllText(Path.Combine(root, ".sailfish.json"), json);
+
+            Directory.SetCurrentDirectory(nested);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
+
+            runSettings.TrawlSettings.ShouldNotBeNull();
+            runSettings.TrawlSettings.Disabled.ShouldBeFalse();
+            runSettings.TrawlSettings.VirtualUsersOverride.ShouldBeNull();
+            runSettings.TrawlSettings.MaxDurationSecondsOverride.ShouldBeNull();
+            runSettings.TrawlSettings.WarmupSecondsOverride.ShouldBeNull();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            try { Directory.Delete(root, true); } catch { /* ignore */ }
+        }
+    }
+}


### PR DESCRIPTION
## Trawl — a load-testing mode for Sailfish

This is **Phase 0 of a stacked series** building **Trawl**, a dedicated load-testing mode that sits alongside SailDiff / ScaleFish / Skipper and reuses their analysis. The guiding principle is *thin engine, deep analysis*: Sailfish doesn't try to out-generate dedicated load tools — its edge is turning load numbers into trustworthy, explained, regression-gating answers.

Phase 0 establishes the **public surface only — no execution behavior yet** (the concurrent engine is the next PR in the stack).

### What's in this PR

- **`[Trawl]` method attribute** (`Sailfish.Attributes`) — marks a method as a load scenario (VirtualUsers / DurationSeconds / WarmupSeconds / Model), plus the **`LoadModel`** enum (`Sailfish.Trawl`).
- **`TrawlResult` / `LatencyStats`** result contracts (`Contracts.Public.Models`) — throughput, error rate, latency percentiles (ms).
- **Run-wide `TrawlSettings`** wired end-to-end, mirroring the existing `DistributionPlotStyle` path: `.sailfish.json` → `SettingsConfiguration` → `AdapterRunSettingsLoader` → `RunSettingsBuilder` (`WithTrawl` / `WithTrawlVirtualUsers` / `WithTrawlMaxDuration` / `DisableTrawl`) → `IRunSettings.TrawlSettings`. Useful for shrinking a load run in CI without editing test source.
- **SF1022 analyzer** — a method may not carry both `[SailfishMethod]` and `[Trawl]` (a method is either a microbenchmark or a load scenario).
- **`docs/2/trawl.md`** — introduces the mode, the attribute, and the settings.

### Tests

All additive and green:
- Adapter settings round-trip (`.sailfish.json` → `IRunSettings.TrawlSettings`)
- Builder/`RunSettings` wiring
- SF1022 (positive + two negatives)

Full suites: **Tests.Library 1566**, **Tests.Analyzers 87**, **Tests.TestAdapter 565** — 0 failures.

### Not in this PR (later phases in the stack)

Concurrent execution engine (closed model MVP) → open model + profiles + coordinated-omission → reporting/plots + tracking → SailDiff regression gating → ScaleFish saturation → Skipper "why".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Trawl scenario attribute for load-testing (virtual users, duration, warmup, load model, disable).
  * Added global and per-run Trawl configuration and builder APIs to override runtime behavior.
  * Added load-test result models capturing throughput, error rates, and latency stats.
* **Bug Fixes / Validation**
  * Analyzer now reports an error when a method is configured as both a normal test and a Trawl scenario.
* **Tests**
  * Added unit tests covering Trawl wiring, settings loading, and analyzer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->