### PR TITLE
Trawl (load testing) — Phase 1: closed-model execution engine (MVP)

### DIFF
--- a/site/src/pages/docs/2/trawl.md
+++ b/site/src/pages/docs/2/trawl.md
@@ -78,6 +78,15 @@ var settings = RunSettingsBuilder
     .Build();
 ```
 
+## What you get today
+
+Run a `[Trawl]` scenario (via `dotnet test`, the IDE, or the programmatic runner) and Sailfish executes the **closed model**: the configured number of virtual users hammer the scenario concurrently for the duration, after an unmeasured warmup. Each successful request's latency is recorded; failures are counted toward the error rate. Sailfish reports:
+
+- **Throughput** (requests/second) and **error rate**
+- **Latency percentiles** — p50/p90/p95/p99 and max — computed from the *full* sample set with **no outlier removal** (the slow tail is the point of a load test)
+
+The latency distribution flows through Sailfish's normal output, so a load case shows up like any other test case. A scenario with zero successful requests fails the case.
+
 ## Status
 
-Trawl is being delivered in phases. This release establishes the public surface — the `[Trawl]` attribute, `TrawlSettings`, the `TrawlResult` shape, and the SF1022 analyzer. The concurrent execution engine, reporting/plots, SailDiff regression gating, and ScaleFish saturation analysis land in subsequent releases.
+Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022) and the **closed-model execution engine**. Still landing in subsequent releases: the open (arrival-rate) model with load profiles and coordinated-omission correction, dedicated reporting/plots and result persistence, SailDiff regression gating, and ScaleFish saturation analysis.

--- a/source/Sailfish.TestAdapter/Discovery/DiscoveryAnalysisMethods.cs
+++ b/source/Sailfish.TestAdapter/Discovery/DiscoveryAnalysisMethods.cs
@@ -88,9 +88,7 @@ public static class DiscoveryAnalysisMethods
                         .OfType<MethodDeclarationSyntax>()
                         .Where(method => method.AttributeLists
                             .SelectMany(attrList => attrList.Attributes)
-                            .Any(attr =>
-                                attr.Name.ToString() == methodAttributePrefix
-                                || attr.Name.ToString() == $"{methodAttributePrefix}Attribute"));
+                            .Any(attr => IsRunnableMethodAttribute(attr.Name.ToString(), methodAttributePrefix)));
 
                     // var className = classDeclaration.Identifier.ValueText;
                     var classFullName = RetrieveClassFullName(classDeclaration);
@@ -108,7 +106,7 @@ public static class DiscoveryAnalysisMethods
                             from methodDeclaration in methodDeclarations
                             let lineSpan = syntaxTree.GetLineSpan(methodDeclaration.Span)
                             let lineNumber = lineSpan.StartLinePosition.Line + 1
-                            let comparisonGroup = ExtractComparisonInfo(methodDeclaration, classFullName, classDisablesComparison)
+                            let comparisonGroup = IsTrawlMethod(methodDeclaration) ? null : ExtractComparisonInfo(methodDeclaration, classFullName, classDisablesComparison)
                             select new MethodMetaData(
                                 methodDeclaration.Identifier.ValueText,
                                 lineNumber,
@@ -122,6 +120,25 @@ public static class DiscoveryAnalysisMethods
 
         if (!result.IsCompleted) throw new TestAdapterException("Exception encountered while reading and parsing source files");
         return classMetas;
+    }
+
+    /// <summary>
+    /// Both [SailfishMethod] microbenchmarks and [Trawl] load scenarios are runnable test cases that the
+    /// adapter should surface to VSTest.
+    /// </summary>
+    private static bool IsRunnableMethodAttribute(string attributeName, string methodAttributePrefix)
+    {
+        return attributeName == methodAttributePrefix
+               || attributeName == $"{methodAttributePrefix}Attribute"
+               || attributeName == "Trawl"
+               || attributeName == "TrawlAttribute";
+    }
+
+    private static bool IsTrawlMethod(MethodDeclarationSyntax method)
+    {
+        return method.AttributeLists
+            .SelectMany(attrList => attrList.Attributes)
+            .Any(attr => attr.Name.ToString() == "Trawl" || attr.Name.ToString() == "TrawlAttribute");
     }
 
     private static string RetrieveClassFullName(ClassDeclarationSyntax classDeclarationSyntax)

--- a/source/Sailfish/Execution/ClosedModelScheduler.cs
+++ b/source/Sailfish/Execution/ClosedModelScheduler.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     A single successful request's timing, captured with <see cref="Stopwatch" /> timestamps so the
+///     scheduler stays allocation-light per request and the engine can derive both latency and a wall-clock
+///     position later.
+/// </summary>
+internal readonly struct RequestSample
+{
+    public RequestSample(long startTimestamp, long latencyTicks)
+    {
+        StartTimestamp = startTimestamp;
+        LatencyTicks = latencyTicks;
+    }
+
+    /// <summary><see cref="Stopwatch.GetTimestamp" /> captured at request start.</summary>
+    public long StartTimestamp { get; }
+
+    /// <summary>Elapsed <see cref="Stopwatch" /> ticks for the request.</summary>
+    public long LatencyTicks { get; }
+}
+
+/// <summary>The merged outcome of a closed-model load run.</summary>
+internal sealed class LoadRunData
+{
+    public LoadRunData(
+        IReadOnlyList<RequestSample> samples,
+        long successCount,
+        long errorCount,
+        TimeSpan elapsed,
+        long runStartTimestamp,
+        DateTimeOffset runStartWallClock)
+    {
+        Samples = samples;
+        SuccessCount = successCount;
+        ErrorCount = errorCount;
+        Elapsed = elapsed;
+        RunStartTimestamp = runStartTimestamp;
+        RunStartWallClock = runStartWallClock;
+    }
+
+    /// <summary>Per-successful-request latency samples (empty when the run was not recording).</summary>
+    public IReadOnlyList<RequestSample> Samples { get; }
+
+    public long SuccessCount { get; }
+    public long ErrorCount { get; }
+    public TimeSpan Elapsed { get; }
+    public long RunStartTimestamp { get; }
+    public DateTimeOffset RunStartWallClock { get; }
+}
+
+/// <summary>
+///     The closed-model load scheduler: a fixed number of virtual users each loop "invoke → invoke again"
+///     for a fixed duration, so throughput is emergent. Workers are async <see cref="Task" />s (not threads)
+///     so an IO-bound scenario frees its thread while awaiting; each worker keeps its own latency buffer so
+///     there is no shared mutable state on the hot path. Buffers are merged single-threaded after the run.
+/// </summary>
+internal sealed class ClosedModelScheduler
+{
+    public async Task<LoadRunData> RunAsync(
+        Func<CancellationToken, ValueTask> invoke,
+        int virtualUsers,
+        TimeSpan duration,
+        bool record,
+        CancellationToken cancellationToken)
+    {
+        if (invoke is null) throw new ArgumentNullException(nameof(invoke));
+        if (virtualUsers < 1) virtualUsers = 1;
+
+        var runStartWallClock = DateTimeOffset.UtcNow;
+        var runStartTimestamp = Stopwatch.GetTimestamp();
+        var deadlineTimestamp = runStartTimestamp + (long)(Math.Max(0, duration.TotalSeconds) * Stopwatch.Frequency);
+
+        var workers = new Task<WorkerResult>[virtualUsers];
+        for (var i = 0; i < virtualUsers; i++)
+        {
+            // Task.Run so each virtual user is scheduled independently even if a scenario blocks synchronously.
+            workers[i] = Task.Run(() => RunWorkerAsync(invoke, deadlineTimestamp, record, cancellationToken), CancellationToken.None);
+        }
+
+        var workerResults = await Task.WhenAll(workers).ConfigureAwait(false);
+
+        var elapsedTimestamp = Stopwatch.GetTimestamp() - runStartTimestamp;
+        var elapsed = TimeSpan.FromSeconds((double)elapsedTimestamp / Stopwatch.Frequency);
+
+        long success = 0;
+        long errors = 0;
+        var totalSamples = 0;
+        foreach (var worker in workerResults)
+        {
+            success += worker.SuccessCount;
+            errors += worker.ErrorCount;
+            totalSamples += worker.Samples.Count;
+        }
+
+        var merged = new List<RequestSample>(record ? totalSamples : 0);
+        if (record)
+        {
+            foreach (var worker in workerResults) merged.AddRange(worker.Samples);
+        }
+
+        return new LoadRunData(merged, success, errors, elapsed, runStartTimestamp, runStartWallClock);
+    }
+
+    private static async Task<WorkerResult> RunWorkerAsync(
+        Func<CancellationToken, ValueTask> invoke,
+        long deadlineTimestamp,
+        bool record,
+        CancellationToken cancellationToken)
+    {
+        var samples = record ? new List<RequestSample>() : null;
+        long success = 0;
+        long errors = 0;
+
+        while (!cancellationToken.IsCancellationRequested && Stopwatch.GetTimestamp() < deadlineTimestamp)
+        {
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                await invoke(cancellationToken).ConfigureAwait(false);
+                var latency = Stopwatch.GetTimestamp() - start;
+                success++;
+                samples?.Add(new RequestSample(start, latency));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch
+            {
+                // A failed request counts toward the error rate but contributes no latency sample —
+                // a time-to-failure is rarely comparable to a successful-response latency.
+                errors++;
+            }
+        }
+
+        return new WorkerResult(samples ?? (IReadOnlyList<RequestSample>)Array.Empty<RequestSample>(), success, errors);
+    }
+
+    private readonly struct WorkerResult
+    {
+        public WorkerResult(IReadOnlyList<RequestSample> samples, long successCount, long errorCount)
+        {
+            Samples = samples;
+            SuccessCount = successCount;
+            ErrorCount = errorCount;
+        }
+
+        public IReadOnlyList<RequestSample> Samples { get; }
+        public long SuccessCount { get; }
+        public long ErrorCount { get; }
+    }
+}

--- a/source/Sailfish/Execution/LatencyStatsCalculator.cs
+++ b/source/Sailfish/Execution/LatencyStatsCalculator.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Computes a <see cref="LatencyStats" /> summary (milliseconds) from raw latency samples. Unlike the
+///     microbenchmark path, Trawl does <b>not</b> remove outliers — the slow tail is exactly what a load test
+///     is trying to surface, so p95/p99 must include it. Percentiles use the nearest-rank method.
+/// </summary>
+internal static class LatencyStatsCalculator
+{
+    public static LatencyStats Compute(IReadOnlyList<double> latenciesMs)
+    {
+        if (latenciesMs is null || latenciesMs.Count == 0) return LatencyStats.Empty;
+
+        var sorted = new double[latenciesMs.Count];
+        for (var i = 0; i < latenciesMs.Count; i++) sorted[i] = latenciesMs[i];
+        Array.Sort(sorted);
+
+        double sum = 0;
+        foreach (var value in sorted) sum += value;
+
+        return new LatencyStats
+        {
+            Min = sorted[0],
+            Max = sorted[sorted.Length - 1],
+            Mean = sum / sorted.Length,
+            P50 = Percentile(sorted, 0.50),
+            P75 = Percentile(sorted, 0.75),
+            P90 = Percentile(sorted, 0.90),
+            P95 = Percentile(sorted, 0.95),
+            P99 = Percentile(sorted, 0.99)
+        };
+    }
+
+    /// <summary>Nearest-rank percentile on an ascending-sorted array. <paramref name="p" /> is in (0, 1].</summary>
+    private static double Percentile(double[] sortedAscending, double p)
+    {
+        var n = sortedAscending.Length;
+        if (n == 1) return sortedAscending[0];
+
+        var rank = (int)Math.Ceiling(p * n);
+        if (rank < 1) rank = 1;
+        if (rank > n) rank = n;
+        return sortedAscending[rank - 1];
+    }
+}

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Sailfish.Attributes;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Execution.Tuning;
 using Sailfish.Logging;
@@ -41,6 +43,15 @@ internal class TestCaseIterator : ITestCaseIterator
         bool disableOverheadEstimation,
         CancellationToken cancellationToken)
     {
+        // Load scenarios ([Trawl]) run concurrently for a duration rather than as sequential timed
+        // iterations, so they bypass warmup, overhead calibration, and the iteration strategy entirely.
+        var trawlAttribute = testInstanceContainer.ExecutionMethod.GetCustomAttribute<TrawlAttribute>();
+        if (trawlAttribute is not null)
+        {
+            var trawlEngine = new TrawlExecutionEngine(_logger, _runSettings);
+            return await trawlEngine.RunAsync(testInstanceContainer, trawlAttribute, cancellationToken).ConfigureAwait(false);
+        }
+
         var calibrator = new HarnessBaselineCalibrator();
         var warmupResult = await WarmupIterations(testInstanceContainer, cancellationToken);
         if (!warmupResult.IsSuccess) return warmupResult;

--- a/source/Sailfish/Execution/TestInstanceContainerCreator.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerCreator.cs
@@ -53,8 +53,13 @@ internal class TestInstanceContainerCreator : ITestInstanceContainerCreator
             variableSetsList = variableSetsList.OrderBy(_ => rngForProps.Next()).ToList();
         }
 
-        // Preserve explicit method Order; randomize only among unordered methods when seeded
-        var allMethods = testType.GetMethodsWithAttribute<SailfishMethodAttribute>().ToList();
+        // Preserve explicit method Order; randomize only among unordered methods when seeded.
+        // [Trawl] load-scenario methods are discovered alongside [SailfishMethod] microbenchmarks; they
+        // carry no SailfishMethodAttribute, so they fall through to the unordered set below.
+        var allMethods = testType.GetMethodsWithAttribute<SailfishMethodAttribute>()
+            .Concat(testType.GetMethodsWithAttribute<TrawlAttribute>())
+            .Distinct()
+            .ToList();
         var orderedMethods = allMethods
             .Select(m => new { Method = m, Attr = m.GetCustomAttribute<SailfishMethodAttribute>() })
             .Where(x => (x.Attr?.Order ?? int.MaxValue) < int.MaxValue)

--- a/source/Sailfish/Execution/TestInstanceContainerProvider.cs
+++ b/source/Sailfish/Execution/TestInstanceContainerProvider.cs
@@ -97,11 +97,20 @@ internal class TestInstanceContainerProvider : ITestInstanceContainerProvider
         }
     }
 
-    private static bool TestIsDisabled(MemberInfo test, MemberInfo method)
+    private bool TestIsDisabled(MemberInfo test, MemberInfo method)
     {
         var typeIsDisabled = test.GetCustomAttributes<SailfishAttribute>().Single().Disabled;
-        var methodIsDisabled = method.GetCustomAttributes<SailfishMethodAttribute>().Single().Disabled;
-        return methodIsDisabled || typeIsDisabled;
+
+        // A method is either a [SailfishMethod] microbenchmark or a [Trawl] load scenario (SF1022 forbids
+        // both), so use SingleOrDefault and consider whichever is present.
+        var sailfishMethod = method.GetCustomAttributes<SailfishMethodAttribute>().SingleOrDefault();
+        var trawl = method.GetCustomAttributes<TrawlAttribute>().SingleOrDefault();
+        var methodIsDisabled = (sailfishMethod?.Disabled ?? false) || (trawl?.Disabled ?? false);
+
+        // Run-wide kill switch: a globally disabled Trawl skips load scenarios but leaves benchmarks alone.
+        var trawlGloballyDisabled = trawl is not null && _runSettings.TrawlSettings.Disabled;
+
+        return typeIsDisabled || methodIsDisabled || trawlGloballyDisabled;
     }
 
     private static void HydrateInstanceTestProperties(object obj, PropertySet propertySet)

--- a/source/Sailfish/Execution/TestListValidator.cs
+++ b/source/Sailfish/Execution/TestListValidator.cs
@@ -62,10 +62,9 @@ internal class TestListValidator : ITestListValidator
 
     private static bool TypeHasMoreThanZeroExecutionMethods(Type type)
     {
-        return type
-            .GetMethodsWithAttribute<SailfishMethodAttribute>()
-            .ToArray()
-            .Length > 0;
+        // A runnable execution method is either a [SailfishMethod] microbenchmark or a [Trawl] load scenario.
+        return type.GetMethodsWithAttribute<SailfishMethodAttribute>().Any()
+            || type.GetMethodsWithAttribute<TrawlAttribute>().Any();
     }
 
     private static bool TestsAreRequestedButFailedToDisambiguate(

--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Exceptions;
+using Sailfish.Logging;
+
+namespace Sailfish.Execution;
+
+internal interface ITrawlExecutionEngine
+{
+    Task<TestCaseExecutionResult> RunAsync(TestInstanceContainer container, TrawlAttribute attribute, CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Runs a <c>[Trawl]</c> method as a concurrent load scenario instead of a sequential microbenchmark.
+///     <para>
+///         It reuses the existing machinery wherever it can: <see cref="CompiledInvoker" /> builds the
+///         direct-call delegate from the shared instance (so all virtual users hit one instance —
+///         scenario state must be thread-safe), and the per-case lifecycle hooks run via the container's
+///         <see cref="CoreInvoker" />. It replaces only the "invoke N times sequentially" loop with the
+///         concurrent <see cref="ClosedModelScheduler" />, and replaces the sequential
+///         <see cref="PerformanceTimer" /> recording (which is not thread-safe) with per-worker buffers that
+///         are merged and injected into the timer single-threaded afterwards — so a Trawl case still reports
+///         its latency distribution through the normal pipeline.
+///     </para>
+/// </summary>
+internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
+{
+    /// <summary>
+    ///     Upper bound on the number of latency samples injected into the shared <see cref="PerformanceTimer" />.
+    ///     A long load run can produce millions of samples; injecting all of them would bloat the tracking
+    ///     file and downstream summary. The authoritative percentiles in <see cref="TrawlResult" /> are always
+    ///     computed from the full sample set — this cap only governs what the existing pipeline renders.
+    /// </summary>
+    private const int MaxInjectedSamples = 10_000;
+
+    private readonly ILogger _logger;
+    private readonly IRunSettings _runSettings;
+    private readonly ClosedModelScheduler _scheduler;
+
+    public TrawlExecutionEngine(ILogger logger, IRunSettings runSettings, ClosedModelScheduler? scheduler = null)
+    {
+        _logger = logger;
+        _runSettings = runSettings;
+        _scheduler = scheduler ?? new ClosedModelScheduler();
+    }
+
+    public async Task<TestCaseExecutionResult> RunAsync(TestInstanceContainer container, TrawlAttribute attribute, CancellationToken cancellationToken)
+    {
+        var settings = _runSettings.TrawlSettings;
+
+        var virtualUsers = Math.Max(1, settings.VirtualUsersOverride ?? attribute.VirtualUsers);
+        var durationSeconds = attribute.DurationSeconds;
+        if (settings.MaxDurationSecondsOverride is { } cap && cap > 0) durationSeconds = Math.Min(durationSeconds, cap);
+        var warmupSeconds = settings.WarmupSecondsOverride ?? attribute.WarmupSeconds;
+
+        var duration = TimeSpan.FromSeconds(Math.Max(0, durationSeconds));
+        var warmup = TimeSpan.FromSeconds(Math.Max(0, warmupSeconds));
+
+        // Build the direct-call delegate once; all virtual users invoke this single delegate.
+        Func<CancellationToken, ValueTask> invoke;
+        try
+        {
+            invoke = CompiledInvoker.Build(container.Instance, container.ExecutionMethod);
+        }
+        catch (Exception ex)
+        {
+            return new TestCaseExecutionResult(container, ex);
+        }
+
+        // Overhead estimation is meaningless for load scenarios (latency is dominated by the work under test).
+        container.CoreInvoker.SetOverheadDisabled(true);
+
+        try
+        {
+            await container.CoreInvoker.IterationSetup(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new TestCaseExecutionResult(container, ex);
+        }
+
+        LoadRunData runData;
+        try
+        {
+            _logger.Log(LogLevel.Information,
+                "      ---- Trawl: {VirtualUsers} virtual users, warmup {Warmup}s, duration {Duration}s ({Model})",
+                virtualUsers, warmup.TotalSeconds, duration.TotalSeconds, attribute.Model);
+
+            if (warmup > TimeSpan.Zero)
+                await _scheduler.RunAsync(invoke, virtualUsers, warmup, record: false, cancellationToken).ConfigureAwait(false);
+
+            container.CoreInvoker.SetTestCaseStart();
+            runData = await _scheduler.RunAsync(invoke, virtualUsers, duration, record: true, cancellationToken).ConfigureAwait(false);
+            container.CoreInvoker.SetTestCaseStop();
+        }
+        catch (Exception ex)
+        {
+            return new TestCaseExecutionResult(container, ex);
+        }
+        finally
+        {
+            try
+            {
+                await container.CoreInvoker.IterationTearDown(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Warning, ex, "      ---- Trawl iteration teardown threw");
+            }
+        }
+
+        var frequency = Stopwatch.Frequency;
+        var latenciesMs = new double[runData.Samples.Count];
+        for (var i = 0; i < runData.Samples.Count; i++)
+            latenciesMs[i] = runData.Samples[i].LatencyTicks * 1000.0 / frequency;
+
+        var totalRequests = runData.SuccessCount + runData.ErrorCount;
+
+        // No successful requests is a failed scenario — surface it as a failing test case rather than an
+        // empty (and meaningless) latency distribution.
+        if (runData.SuccessCount == 0)
+        {
+            var message = totalRequests == 0
+                ? $"Trawl scenario '{container.TestCaseId.DisplayName}' produced no requests in {duration.TotalSeconds:0.##}s."
+                : $"Trawl scenario '{container.TestCaseId.DisplayName}' had no successful requests ({runData.ErrorCount} failed).";
+            return new TestCaseExecutionResult(container, new SailfishException(message));
+        }
+
+        var stats = LatencyStatsCalculator.Compute(latenciesMs);
+        var throughput = runData.Elapsed.TotalSeconds > 0 ? totalRequests / runData.Elapsed.TotalSeconds : 0;
+        var errorRate = totalRequests > 0 ? (double)runData.ErrorCount / totalRequests : 0;
+
+        var trawlResult = new TrawlResult
+        {
+            DisplayName = container.TestCaseId.DisplayName,
+            Model = attribute.Model,
+            VirtualUsers = virtualUsers,
+            Duration = runData.Elapsed,
+            TotalRequests = totalRequests,
+            TotalErrors = runData.ErrorCount,
+            RequestsPerSecond = throughput,
+            ErrorRate = errorRate,
+            Latency = stats
+        };
+
+        InjectSamples(container, runData, frequency);
+
+        _logger.Log(LogLevel.Information,
+            "      ---- Trawl result: {Rps:0.#} req/s | p50 {P50:0.##}ms p95 {P95:0.##}ms p99 {P99:0.##}ms max {Max:0.##}ms | errors {Errors}/{Total} ({Rate:0.##%})",
+            trawlResult.RequestsPerSecond, stats.P50, stats.P95, stats.P99, stats.Max, trawlResult.TotalErrors, trawlResult.TotalRequests, trawlResult.ErrorRate);
+
+        return new TestCaseExecutionResult(container);
+    }
+
+    /// <summary>
+    ///     Injects the (optionally down-sampled) latency distribution into the shared
+    ///     <see cref="PerformanceTimer" /> single-threaded, so the Trawl case reports through the existing
+    ///     console/markdown/tracking pipeline like any other case.
+    /// </summary>
+    private static void InjectSamples(TestInstanceContainer container, LoadRunData runData, long frequency)
+    {
+        var timer = container.CoreInvoker.GetPerformanceResults();
+        var samples = runData.Samples;
+        var count = samples.Count;
+        if (count == 0) return;
+
+        var stride = count > MaxInjectedSamples ? (int)Math.Ceiling(count / (double)MaxInjectedSamples) : 1;
+        for (var i = 0; i < count; i += stride)
+        {
+            var sample = samples[i];
+            var startWall = runData.RunStartWallClock + TimeSpan.FromSeconds((double)(sample.StartTimestamp - runData.RunStartTimestamp) / frequency);
+            var stopWall = startWall + TimeSpan.FromSeconds((double)sample.LatencyTicks / frequency);
+            timer.ExecutionIterationPerformances.Add(new IterationPerformance(startWall, stopWall, sample.LatencyTicks));
+        }
+    }
+}

--- a/source/Tests.Library/Trawl/ClosedModelSchedulerTests.cs
+++ b/source/Tests.Library/Trawl/ClosedModelSchedulerTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class ClosedModelSchedulerTests
+{
+    [Fact]
+    public async Task RecordsSamples_AndRunsForRoughlyTheDuration()
+    {
+        var scheduler = new ClosedModelScheduler();
+        Func<CancellationToken, ValueTask> invoke = async ct => await Task.Delay(2, ct);
+
+        var data = await scheduler.RunAsync(invoke, virtualUsers: 4, TimeSpan.FromMilliseconds(300), record: true, CancellationToken.None);
+
+        data.SuccessCount.ShouldBeGreaterThan(0);
+        data.ErrorCount.ShouldBe(0);
+        data.Samples.Count.ShouldBe((int)data.SuccessCount);
+        data.Elapsed.ShouldBeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Fact]
+    public async Task WhenNotRecording_NoSamplesButStillCountsSuccesses()
+    {
+        var scheduler = new ClosedModelScheduler();
+        Func<CancellationToken, ValueTask> invoke = async ct => await Task.Delay(2, ct);
+
+        var data = await scheduler.RunAsync(invoke, virtualUsers: 2, TimeSpan.FromMilliseconds(150), record: false, CancellationToken.None);
+
+        data.Samples.Count.ShouldBe(0);
+        data.SuccessCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task CountsErrors_WithoutFaultingTheRun()
+    {
+        var scheduler = new ClosedModelScheduler();
+        var counter = 0;
+        Func<CancellationToken, ValueTask> invoke = async ct =>
+        {
+            var n = Interlocked.Increment(ref counter);
+            await Task.Delay(1, ct);
+            if (n % 2 == 0) throw new InvalidOperationException("boom");
+        };
+
+        var data = await scheduler.RunAsync(invoke, virtualUsers: 2, TimeSpan.FromMilliseconds(250), record: true, CancellationToken.None);
+
+        data.SuccessCount.ShouldBeGreaterThan(0);
+        data.ErrorCount.ShouldBeGreaterThan(0);
+        data.Samples.Count.ShouldBe((int)data.SuccessCount); // failures contribute no latency sample
+    }
+
+    [Fact]
+    public async Task NeverExceedsVirtualUserConcurrency()
+    {
+        var scheduler = new ClosedModelScheduler();
+        var current = 0;
+        var max = 0;
+        var gate = new object();
+        Func<CancellationToken, ValueTask> invoke = async ct =>
+        {
+            var c = Interlocked.Increment(ref current);
+            lock (gate)
+                if (c > max) max = c;
+            await Task.Delay(20, ct);
+            Interlocked.Decrement(ref current);
+        };
+
+        await scheduler.RunAsync(invoke, virtualUsers: 5, TimeSpan.FromMilliseconds(400), record: true, CancellationToken.None);
+
+        max.ShouldBeLessThanOrEqualTo(5); // never more than the configured virtual users
+        max.ShouldBeGreaterThanOrEqualTo(2); // genuinely concurrent
+    }
+
+    [Fact]
+    public async Task HonorsCancellation_ReturnsPromptly()
+    {
+        var scheduler = new ClosedModelScheduler();
+        Func<CancellationToken, ValueTask> invoke = async ct => await Task.Delay(5, ct);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(150));
+
+        var sw = Stopwatch.StartNew();
+        // A 10s nominal duration that must be cut short by cancellation.
+        var data = await scheduler.RunAsync(invoke, virtualUsers: 4, TimeSpan.FromSeconds(10), record: true, cts.Token);
+        sw.Stop();
+
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
+        data.ShouldNotBeNull();
+    }
+}

--- a/source/Tests.Library/Trawl/LatencyStatsCalculatorTests.cs
+++ b/source/Tests.Library/Trawl/LatencyStatsCalculatorTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class LatencyStatsCalculatorTests
+{
+    [Fact]
+    public void Empty_Input_Returns_AllZero()
+    {
+        var stats = LatencyStatsCalculator.Compute(new double[0]);
+
+        stats.Min.ShouldBe(0);
+        stats.Max.ShouldBe(0);
+        stats.Mean.ShouldBe(0);
+        stats.P99.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SingleSample_AllPercentilesEqualThatSample()
+    {
+        var stats = LatencyStatsCalculator.Compute(new[] { 42.0 });
+
+        stats.Min.ShouldBe(42.0);
+        stats.Max.ShouldBe(42.0);
+        stats.Mean.ShouldBe(42.0);
+        stats.P50.ShouldBe(42.0);
+        stats.P99.ShouldBe(42.0);
+    }
+
+    [Fact]
+    public void NearestRankPercentiles_OnOneToHundred()
+    {
+        // 1..100, shuffled, to prove the calculator sorts internally.
+        var data = Enumerable.Range(1, 100).Select(i => (double)i).Reverse().ToArray();
+
+        var stats = LatencyStatsCalculator.Compute(data);
+
+        stats.Min.ShouldBe(1);
+        stats.Max.ShouldBe(100);
+        stats.Mean.ShouldBe(50.5);
+        stats.P50.ShouldBe(50);  // ceil(0.50*100)=50 -> index 49 -> value 50
+        stats.P90.ShouldBe(90);
+        stats.P95.ShouldBe(95);
+        stats.P99.ShouldBe(99);
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlEndToEndTests.cs
+++ b/source/Tests.Library/Trawl/TrawlEndToEndTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish;
+using Sailfish.Attributes;
+using Shouldly;
+using Tests.Common.Utils;
+using Tests.E2E.TestSuite;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+// A Trawl-only [Sailfish] class (no [SailfishMethod]) — proves discovery, validation, routing, and
+// result reporting all accept load scenarios end-to-end through the programmatic runner.
+[Sailfish]
+public class TrawlSmokeScenario
+{
+    [Trawl(VirtualUsers = 2, DurationSeconds = 0.3, WarmupSeconds = 0)]
+    public async Task Ping(CancellationToken ct) => await Task.Delay(2, ct);
+}
+
+public class TrawlEndToEndTests
+{
+    [Fact]
+    public async Task TrawlScenario_RunsThroughTheRunner_AndReportsACase()
+    {
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(Some.RandomString())
+            .ProvidersFromAssembliesContaining(typeof(E2ETestRegistrationProvider))
+            .TestsFromAssembliesContaining(typeof(TrawlSmokeScenario))
+            .WithTestNames(typeof(TrawlSmokeScenario).FullName!)
+            .DisableOverheadEstimation()
+            .WithAnalysisDisabledGlobally()
+            .Build();
+
+        var result = await SailfishRunner.Run(runSettings);
+
+        result.IsValid.ShouldBeTrue();
+        result.Exceptions.ShouldNotBeNull();
+        result.Exceptions.Count().ShouldBe(0);
+        result.ExecutionSummaries.Count().ShouldBe(1);
+
+        var caseResult = result.ExecutionSummaries.Single().CompiledTestCaseResults.Single();
+        caseResult.PerformanceRunResult.ShouldNotBeNull();
+        caseResult.PerformanceRunResult!.RawExecutionResults.Length.ShouldBeGreaterThan(0);
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlIterationRoutingTests.cs
+++ b/source/Tests.Library/Trawl/TrawlIterationRoutingTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Sailfish.Analysis;
+using Sailfish.Attributes;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+/// <summary>
+/// Drives a [Trawl] method through the real TestCaseIterator to prove routing: the iterator detects the
+/// attribute, runs the load engine instead of the sequential strategy, and injects latency samples so the
+/// case reports through the normal pipeline.
+/// </summary>
+public class TrawlIterationRoutingTests
+{
+    private static TestCaseIterator NewIterator()
+    {
+        var logger = Substitute.For<ILogger>();
+        var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder().Build();
+        return new TestCaseIterator(runSettings, logger,
+            new FixedIterationStrategy(logger),
+            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()));
+    }
+
+    private static TestInstanceContainer ContainerFor(object instance, string methodName)
+    {
+        var method = instance.GetType().GetMethod(methodName)!;
+        var settings = new ExecutionSettings { NumWarmupIterations = 0, SampleSize = 1, UseAdaptiveSampling = false };
+        return TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+    }
+
+    [Fact]
+    public async Task TrawlMethod_IsRouted_RunsConcurrently_AndInjectsSamples()
+    {
+        var instance = new LoadWork();
+        var container = ContainerFor(instance, nameof(LoadWork.Scenario));
+
+        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        instance.Calls.ShouldBeGreaterThan(0);
+        result.PerformanceTimerResults.ShouldNotBeNull();
+        result.PerformanceTimerResults!.ExecutionIterationPerformances.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task TrawlMethod_WithAllFailures_FailsTheCase()
+    {
+        var container = ContainerFor(new AlwaysThrows(), nameof(AlwaysThrows.Scenario));
+
+        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Exception.ShouldNotBeNull();
+    }
+
+    [Sailfish]
+    private sealed class LoadWork
+    {
+        public int Calls;
+
+        [Trawl(VirtualUsers = 3, DurationSeconds = 0.25, WarmupSeconds = 0)]
+        public async Task Scenario(CancellationToken ct)
+        {
+            Interlocked.Increment(ref Calls);
+            await Task.Delay(2, ct);
+        }
+    }
+
+    [Sailfish]
+    private sealed class AlwaysThrows
+    {
+        [Trawl(VirtualUsers = 2, DurationSeconds = 0.2, WarmupSeconds = 0)]
+        public Task Scenario(CancellationToken ct) => throw new InvalidOperationException("always fails");
+    }
+}


### PR DESCRIPTION
## Phase 1 of the Trawl stack — the working load engine

**Stacked on [#274](https://github.com/paulegradie/Sailfish/pull/274) (Phase 0).** Base is `claude/trawl-p0-contracts`; review/merge that first.

This makes `[Trawl]` *run*. A `[Trawl]` method is now executed as a concurrent **closed-model** load scenario (fixed virtual users hammering for a duration) instead of a sequential microbenchmark — via `dotnet test`, the IDE, or the programmatic runner.

### The engine (`Sailfish.Execution`)
- **`ClosedModelScheduler`** — N virtual users invoke the scenario concurrently for the duration. Async `Task` workers (not threads) so IO-bound scenarios free their thread; each worker keeps its **own** latency buffer (the sequential `PerformanceTimer` list is *not* thread-safe), merged single-threaded after the run.
- **`TrawlExecutionEngine`** — reuses `CompiledInvoker.Build` (one delegate, all VUs hit the shared instance — state must be thread-safe) and the `CoreInvoker` lifecycle. Runs an unmeasured warmup, then the measured phase; computes a `TrawlResult` (throughput, error rate, latency percentiles); injects the (capped at 10k) latency distribution into `PerformanceTimer` so a load case reports through the **existing** console/markdown/tracking pipeline. Zero successful requests ⇒ the case fails.
- **`LatencyStatsCalculator`** — p50/p90/p95/p99 + max via nearest-rank, **no outlier removal** (the slow tail is the point of a load test).

### Wiring
- `TestCaseIterator` routes `[Trawl]` methods to the engine (bypassing warmup / overhead calibration / iteration strategy).
- `TestInstanceContainerCreator` + `TestListValidator` discover and accept `[Trawl]` alongside `[SailfishMethod]`; `TestInstanceContainerProvider` no longer throws on Trawl-only methods (the old `.Single<SailfishMethodAttribute>()`) and honors `TrawlSettings.Disabled`.
- Adapter `DiscoveryAnalysisMethods` surfaces `[Trawl]` cases to VSTest and excludes them from comparison groups.

### Design notes
- **Single node** (distributed generation is explicitly out of scope).
- **SharedInstance semantics**: all VUs share the one scenario instance (warm an `HttpClient` in `[SailfishGlobalSetup]`); per-VU isolation is a later option.
- Comparison-group purity for *mixed* benchmark+load classes under SailDiff is handled where it matters (Phase 4); the adapter path already excludes Trawl methods.

### Tests (all green)
`Tests.Library`: latency-stats math, scheduler (records samples, counts errors without faulting, never exceeds VU concurrency, honors cancellation, runs ~duration), iterator **routing**, and a full programmatic **end-to-end** run of a Trawl-only `[Sailfish]` class. Full suites: **Tests.Library 1577**, **Tests.TestAdapter 565** — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)