### PR TITLE
Trawl (load testing) — Phase 2: open arrival-rate model + coordinated-omission

### DIFF
--- a/site/src/pages/docs/2/trawl.md
+++ b/site/src/pages/docs/2/trawl.md
@@ -87,6 +87,17 @@ Run a `[Trawl]` scenario (via `dotnet test`, the IDE, or the programmatic runner
 
 The latency distribution flows through Sailfish's normal output, so a load case shows up like any other test case. A scenario with zero successful requests fails the case.
 
+## Closed vs open model
+
+By default a scenario runs the **closed model**: `VirtualUsers` concurrent users, each looping as fast as the system allows. Throughput is emergent.
+
+Set `Model = LoadModel.OpenModel` with a `TargetRequestsPerSecond` to run the **open model**: requests are dispatched at the target arrival rate regardless of how many are already in flight (`VirtualUsers` then caps concurrent in-flight requests — think connection-pool size). The open model is what exposes a system that can't keep up, and it applies **coordinated-omission correction**: latency is measured from each request's *intended* send time, so a stall is counted as latency on the requests that "should" have been sent during it — rather than being silently omitted (an overloaded system otherwise looks deceptively healthy).
+
+```csharp
+[Trawl(Model = LoadModel.OpenModel, TargetRequestsPerSecond = 500, VirtualUsers = 64, DurationSeconds = 120)]
+public async Task Checkout(CancellationToken ct) { /* ... */ }
+```
+
 ## Status
 
-Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022) and the **closed-model execution engine**. Still landing in subsequent releases: the open (arrival-rate) model with load profiles and coordinated-omission correction, dedicated reporting/plots and result persistence, SailDiff regression gating, and ScaleFish saturation analysis.
+Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022), the **closed-model engine**, and the **open arrival-rate model with coordinated-omission correction**. Still landing in subsequent releases: multi-stage load profiles (ramp/step) and time-series capture, dedicated reporting/plots and result persistence, SailDiff regression gating, and ScaleFish saturation analysis.

--- a/source/Sailfish/Execution/ArrivalRateScheduler.cs
+++ b/source/Sailfish/Execution/ArrivalRateScheduler.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     The open-model load scheduler: requests are dispatched at a fixed target arrival rate regardless of
+///     how many are already in flight, which is what exposes a system that can't keep up. Concurrency is
+///     bounded by <c>maxInFlight</c> (think connection-pool size); when that cap is reached the dispatcher
+///     blocks, and because scheduled send times keep advancing at the target rate, the backlog shows up as a
+///     growing gap between a request's intended send time and its completion.
+///     <para>
+///         <b>Coordinated-omission correction.</b> Latency is measured from each request's <i>intended</i>
+///         (scheduled) send time, not from when it actually got dispatched. So if the system stalls, the
+///         requests that "should" have been sent during the stall are still counted — with the full waiting
+///         time folded into their latency — instead of being silently omitted. This is the correction Gil
+///         Tene popularized; without it an overloaded system can look deceptively healthy.
+///     </para>
+/// </summary>
+internal sealed class ArrivalRateScheduler
+{
+    public async Task<LoadRunData> RunAsync(
+        Func<CancellationToken, ValueTask> invoke,
+        double requestsPerSecond,
+        TimeSpan duration,
+        int maxInFlight,
+        bool record,
+        CancellationToken cancellationToken)
+    {
+        if (invoke is null) throw new ArgumentNullException(nameof(invoke));
+        if (requestsPerSecond <= 0) requestsPerSecond = 1;
+        if (maxInFlight < 1) maxInFlight = 1;
+
+        var runStartWallClock = DateTimeOffset.UtcNow;
+        var runStartTimestamp = Stopwatch.GetTimestamp();
+        var frequency = (double)Stopwatch.Frequency;
+        var deadlineTimestamp = runStartTimestamp + (long)(Math.Max(0, duration.TotalSeconds) * frequency);
+        var intervalTicks = frequency / requestsPerSecond;
+
+        var samples = record ? new ConcurrentQueue<RequestSample>() : null;
+        long success = 0;
+        long errors = 0;
+        var inFlight = new SemaphoreSlim(maxInFlight, maxInFlight);
+
+        long index = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            // Stop dispatching once the wall-clock run duration has elapsed. Under overload the index-based
+            // schedule falls far behind real time, so this real-time check — not the schedule — bounds the run.
+            if (Stopwatch.GetTimestamp() >= deadlineTimestamp) break;
+
+            var scheduledTimestamp = runStartTimestamp + (long)(index * intervalTicks);
+            if (scheduledTimestamp >= deadlineTimestamp) break;
+
+            await PaceUntilAsync(scheduledTimestamp, frequency, cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) break;
+
+            try
+            {
+                await inFlight.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            var scheduled = scheduledTimestamp;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await invoke(cancellationToken).ConfigureAwait(false);
+                    // Coordinated-omission correction: measure from the intended send time, not the actual one.
+                    var latency = Stopwatch.GetTimestamp() - scheduled;
+                    Interlocked.Increment(ref success);
+                    samples?.Enqueue(new RequestSample(scheduled, latency));
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // shutting down
+                }
+                catch
+                {
+                    Interlocked.Increment(ref errors);
+                }
+                finally
+                {
+                    inFlight.Release();
+                }
+            }, CancellationToken.None);
+
+            index++;
+        }
+
+        // Drain: acquiring every permit can only succeed once all in-flight requests have released theirs.
+        for (var i = 0; i < maxInFlight; i++)
+            await inFlight.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var elapsedTimestamp = Stopwatch.GetTimestamp() - runStartTimestamp;
+        var elapsed = TimeSpan.FromSeconds((double)elapsedTimestamp / frequency);
+
+        IReadOnlyList<RequestSample> merged = samples is null
+            ? Array.Empty<RequestSample>()
+            : new List<RequestSample>(samples);
+
+        return new LoadRunData(merged, success, errors, elapsed, runStartTimestamp, runStartWallClock);
+    }
+
+    /// <summary>
+    ///     Waits until the scheduled timestamp. Uses <see cref="Task.Delay(TimeSpan, CancellationToken)" /> for
+    ///     longer waits and a short spin for sub-millisecond precision. If already on or behind schedule it
+    ///     returns immediately — the lateness is intentionally folded into the next request's measured latency.
+    /// </summary>
+    private static async Task PaceUntilAsync(long targetTimestamp, double frequency, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var remainingTicks = targetTimestamp - Stopwatch.GetTimestamp();
+            if (remainingTicks <= 0) return;
+
+            var remainingMs = remainingTicks * 1000.0 / frequency;
+            if (remainingMs > 4)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(remainingMs - 2), cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+            else
+            {
+                Thread.SpinWait(50);
+            }
+        }
+    }
+}

--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -6,6 +6,7 @@ using Sailfish.Attributes;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Exceptions;
 using Sailfish.Logging;
+using Sailfish.Trawl;
 
 namespace Sailfish.Execution;
 
@@ -39,13 +40,19 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
 
     private readonly ILogger _logger;
     private readonly IRunSettings _runSettings;
-    private readonly ClosedModelScheduler _scheduler;
+    private readonly ClosedModelScheduler _closedModelScheduler;
+    private readonly ArrivalRateScheduler _arrivalRateScheduler;
 
-    public TrawlExecutionEngine(ILogger logger, IRunSettings runSettings, ClosedModelScheduler? scheduler = null)
+    public TrawlExecutionEngine(
+        ILogger logger,
+        IRunSettings runSettings,
+        ClosedModelScheduler? closedModelScheduler = null,
+        ArrivalRateScheduler? arrivalRateScheduler = null)
     {
         _logger = logger;
         _runSettings = runSettings;
-        _scheduler = scheduler ?? new ClosedModelScheduler();
+        _closedModelScheduler = closedModelScheduler ?? new ClosedModelScheduler();
+        _arrivalRateScheduler = arrivalRateScheduler ?? new ArrivalRateScheduler();
     }
 
     public async Task<TestCaseExecutionResult> RunAsync(TestInstanceContainer container, TrawlAttribute attribute, CancellationToken cancellationToken)
@@ -83,18 +90,43 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
             return new TestCaseExecutionResult(container, ex);
         }
 
+        // Select the load model. Closed: a fixed number of virtual users loop as fast as the system allows.
+        // Open: requests arrive at a target rate regardless of in-flight count, with coordinated-omission
+        // correction; there VirtualUsers caps concurrent in-flight requests (the connection-pool size).
+        Func<TimeSpan, bool, Task<LoadRunData>> runPhase;
+        if (attribute.Model == LoadModel.OpenModel)
+        {
+            var rate = attribute.TargetRequestsPerSecond;
+            if (rate <= 0)
+            {
+                return new TestCaseExecutionResult(container, new SailfishException(
+                    $"Trawl scenario '{container.TestCaseId.DisplayName}' uses LoadModel.OpenModel but TargetRequestsPerSecond is not set (must be > 0)."));
+            }
+
+            runPhase = (phaseDuration, phaseRecord) =>
+                _arrivalRateScheduler.RunAsync(invoke, rate, phaseDuration, maxInFlight: virtualUsers, phaseRecord, cancellationToken);
+        }
+        else
+        {
+            runPhase = (phaseDuration, phaseRecord) =>
+                _closedModelScheduler.RunAsync(invoke, virtualUsers, phaseDuration, phaseRecord, cancellationToken);
+        }
+
         LoadRunData runData;
         try
         {
             _logger.Log(LogLevel.Information,
-                "      ---- Trawl: {VirtualUsers} virtual users, warmup {Warmup}s, duration {Duration}s ({Model})",
-                virtualUsers, warmup.TotalSeconds, duration.TotalSeconds, attribute.Model);
+                "      ---- Trawl: {Model} | {VirtualUsers} {Unit} | warmup {Warmup}s | duration {Duration}s{RateSuffix}",
+                attribute.Model, virtualUsers,
+                attribute.Model == LoadModel.OpenModel ? "max in-flight" : "virtual users",
+                warmup.TotalSeconds, duration.TotalSeconds,
+                attribute.Model == LoadModel.OpenModel ? $" | {attribute.TargetRequestsPerSecond:0.#} req/s target" : string.Empty);
 
             if (warmup > TimeSpan.Zero)
-                await _scheduler.RunAsync(invoke, virtualUsers, warmup, record: false, cancellationToken).ConfigureAwait(false);
+                await runPhase(warmup, false).ConfigureAwait(false);
 
             container.CoreInvoker.SetTestCaseStart();
-            runData = await _scheduler.RunAsync(invoke, virtualUsers, duration, record: true, cancellationToken).ConfigureAwait(false);
+            runData = await runPhase(duration, true).ConfigureAwait(false);
             container.CoreInvoker.SetTestCaseStop();
         }
         catch (Exception ex)

--- a/source/Tests.Library/Trawl/ArrivalRateSchedulerTests.cs
+++ b/source/Tests.Library/Trawl/ArrivalRateSchedulerTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class ArrivalRateSchedulerTests
+{
+    private static double ToMs(long ticks) => ticks * 1000.0 / Stopwatch.Frequency;
+
+    [Fact]
+    public async Task DispatchesAtBoundedRate_NotAsFastAsPossible()
+    {
+        var scheduler = new ArrivalRateScheduler();
+        Func<CancellationToken, ValueTask> invoke = async ct => await Task.Delay(1, ct);
+
+        // 200 req/s for ~400ms ≈ 80 requests. A closed model with this many in-flight would do far more —
+        // the point of the open model is that arrivals are paced by the rate, not by how fast the SUT is.
+        var data = await scheduler.RunAsync(invoke, requestsPerSecond: 200, TimeSpan.FromMilliseconds(400), maxInFlight: 50, record: true, CancellationToken.None);
+
+        data.SuccessCount.ShouldBeGreaterThan(0);
+        data.SuccessCount.ShouldBeLessThanOrEqualTo(220); // paced — never dispatches ahead of schedule
+        data.Samples.Count.ShouldBe((int)data.SuccessCount);
+    }
+
+    [Fact]
+    public async Task CoordinatedOmission_FoldsQueueingDelayIntoLatency()
+    {
+        var scheduler = new ArrivalRateScheduler();
+        // Schedule 100 req/s through a server that can only serve ~25 req/s (40ms each, one at a time).
+        // A naive measurement would report ~40ms for every served request and silently omit the rest;
+        // CO correction measures from the intended send time, so the growing backlog shows up as latency.
+        Func<CancellationToken, ValueTask> invoke = async ct => await Task.Delay(40, ct);
+
+        var data = await scheduler.RunAsync(invoke, requestsPerSecond: 100, TimeSpan.FromMilliseconds(600), maxInFlight: 1, record: true, CancellationToken.None);
+
+        data.SuccessCount.ShouldBeGreaterThan(0);
+
+        double maxMs = 0;
+        foreach (var sample in data.Samples)
+        {
+            var ms = ToMs(sample.LatencyTicks);
+            if (ms > maxMs) maxMs = ms;
+        }
+
+        // With a sustained 4x overload the corrected latency must be far larger than the ~40ms service time.
+        maxMs.ShouldBeGreaterThan(120);
+    }
+
+    [Fact]
+    public async Task HonorsCancellation_ReturnsPromptly()
+    {
+        var scheduler = new ArrivalRateScheduler();
+        Func<CancellationToken, ValueTask> invoke = async ct => await Task.Delay(5, ct);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(150));
+
+        var sw = Stopwatch.StartNew();
+        var data = await scheduler.RunAsync(invoke, requestsPerSecond: 200, TimeSpan.FromSeconds(10), maxInFlight: 16, record: true, cts.Token);
+        sw.Stop();
+
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
+        data.ShouldNotBeNull();
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlOpenModelRoutingTests.cs
+++ b/source/Tests.Library/Trawl/TrawlOpenModelRoutingTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Sailfish.Analysis;
+using Sailfish.Attributes;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Sailfish.Trawl;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+/// <summary>
+/// Routes [Trawl(Model = OpenModel)] scenarios through the real TestCaseIterator to prove the engine
+/// dispatches them via the arrival-rate scheduler and validates the open-model configuration.
+/// </summary>
+public class TrawlOpenModelRoutingTests
+{
+    private static TestCaseIterator NewIterator()
+    {
+        var logger = Substitute.For<ILogger>();
+        var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder().Build();
+        return new TestCaseIterator(runSettings, logger,
+            new FixedIterationStrategy(logger),
+            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()));
+    }
+
+    private static TestInstanceContainer ContainerFor(object instance, string methodName)
+    {
+        var method = instance.GetType().GetMethod(methodName)!;
+        var settings = new ExecutionSettings { NumWarmupIterations = 0, SampleSize = 1, UseAdaptiveSampling = false };
+        return TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+    }
+
+    [Fact]
+    public async Task OpenModelScenario_IsRouted_ProducesSamples()
+    {
+        var instance = new OpenModelWork();
+        var container = ContainerFor(instance, nameof(OpenModelWork.Scenario));
+
+        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        instance.Calls.ShouldBeGreaterThan(0);
+        result.PerformanceTimerResults!.ExecutionIterationPerformances.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task OpenModel_WithoutTargetRate_FailsWithHelpfulMessage()
+    {
+        var container = ContainerFor(new MisconfiguredOpenModel(), nameof(MisconfiguredOpenModel.Scenario));
+
+        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Exception.ShouldNotBeNull();
+        result.Exception!.Message.ShouldContain("TargetRequestsPerSecond");
+    }
+
+    [Sailfish]
+    private sealed class OpenModelWork
+    {
+        public int Calls;
+
+        [Trawl(Model = LoadModel.OpenModel, TargetRequestsPerSecond = 100, DurationSeconds = 0.3, WarmupSeconds = 0, VirtualUsers = 8)]
+        public async Task Scenario(CancellationToken ct)
+        {
+            Interlocked.Increment(ref Calls);
+            await Task.Delay(2, ct);
+        }
+    }
+
+    [Sailfish]
+    private sealed class MisconfiguredOpenModel
+    {
+        // OpenModel but no TargetRequestsPerSecond — should fail fast with a clear message.
+        [Trawl(Model = LoadModel.OpenModel, DurationSeconds = 0.2, WarmupSeconds = 0)]
+        public Task Scenario(CancellationToken ct) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Phase 2 of the Trawl stack — the open model

**Stacked on [#275](https://github.com/paulegradie/Sailfish/pull/275) (Phase 1).** Base is `claude/trawl-p1-engine`.

Adds the **open (arrival-rate) load model** alongside the closed model, with **coordinated-omission correction** — the thing most load tools get wrong.

```csharp
[Trawl(Model = LoadModel.OpenModel, TargetRequestsPerSecond = 500, VirtualUsers = 64, DurationSeconds = 120)]
public async Task Checkout(CancellationToken ct) { /* ... */ }
```

### `ArrivalRateScheduler`
- Dispatches requests at the **target arrival rate** regardless of how many are already in flight (`VirtualUsers` caps concurrent in-flight requests — the connection-pool size). This is what surfaces a system that can't keep up; a closed model would just slow its own loop and hide the problem.
- **Coordinated-omission correction:** latency is measured from each request's *intended* (scheduled) send time, not from when it actually got dispatched. So when the system stalls, the requests that "should" have been sent during the stall are counted with the full wait folded in — instead of being silently omitted (which makes an overloaded system look deceptively healthy).
- The run is bounded by **wall-clock** duration — under overload the index-based schedule lags real time, so the schedule alone can't bound it.
- Concurrency bounded by a `SemaphoreSlim`; in-flight work is drained by acquiring all permits (no task-list bookkeeping).

### Engine
`TrawlExecutionEngine` now picks the scheduler from `attribute.Model`. `OpenModel` without a positive `TargetRequestsPerSecond` fails the case with a clear message.

### Scope note
To keep this PR focused on the genuinely tricky open-model + CO mechanics, **multi-stage profiles (ramp/step)** and **time-series capture** move forward to fold into the reporting phase (where time-series is consumed), and streaming-histogram (soak) support rides with them. The attribute already carries the knobs; nothing here is throwaway.

### Tests (all green)
`Tests.Library`: bounded-rate dispatch (paced, not as-fast-as-possible), **coordinated-omission** queueing-delay capture under sustained 4× overload, cancellation, and open-model engine routing + the misconfiguration failure. Full suite: **Tests.Library 1582** — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)