### PR TITLE
Trawl (load testing) — Phase 3: reporting, plots, time-series & persistence

### DIFF
--- a/site/src/pages/docs/2/trawl.md
+++ b/site/src/pages/docs/2/trawl.md
@@ -98,6 +98,10 @@ Set `Model = LoadModel.OpenModel` with a `TargetRequestsPerSecond` to run the **
 public async Task Checkout(CancellationToken ct) { /* ... */ }
 ```
 
+## Reports & artifacts
+
+Each scenario prints a report — a summary line, a latency-percentile table, a latency **distribution plot** (honoring your configured `DistributionPlotStyle`), and Unicode **sparklines** of throughput and p99 over time. The same report is written to `<output>/trawl/<scenario>_<timestamp>.md`, and a machine-readable `…​.json` record (summary + a capped latency sample + the per-second time-series) is written alongside it — that JSON is what later regression analysis reads as a baseline.
+
 ## Status
 
-Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022), the **closed-model engine**, and the **open arrival-rate model with coordinated-omission correction**. Still landing in subsequent releases: multi-stage load profiles (ramp/step) and time-series capture, dedicated reporting/plots and result persistence, SailDiff regression gating, and ScaleFish saturation analysis.
+Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022), the **closed-model engine**, the **open arrival-rate model with coordinated-omission correction**, and **reporting** (console + Markdown report, distribution plot, time-series sparklines, JSON persistence). Still landing in subsequent releases: multi-stage load profiles (ramp/step) and streaming histograms for long soaks, SailDiff regression gating, and ScaleFish saturation analysis.

--- a/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
+++ b/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
@@ -36,6 +36,16 @@ public sealed record TrawlResult
 
     /// <summary>Latency distribution summary (milliseconds).</summary>
     public LatencyStats Latency { get; init; } = LatencyStats.Empty;
+
+    /// <summary>
+    ///     A (possibly down-sampled) sample of per-request latencies in milliseconds, retained for the
+    ///     distribution plot and for downstream statistical comparison. The summary percentiles in
+    ///     <see cref="Latency" /> are computed from the full sample set; this array may be capped.
+    /// </summary>
+    public double[] LatencySamplesMs { get; init; } = Array.Empty<double>();
+
+    /// <summary>Per-second throughput and tail latency over the run, or null if not captured.</summary>
+    public TrawlTimeSeries? TimeSeries { get; init; }
 }
 
 /// <summary>
@@ -69,4 +79,32 @@ public sealed record LatencyStats
 
     /// <summary>An all-zero instance, used before a run has produced measurements.</summary>
     public static LatencyStats Empty => new();
+}
+
+/// <summary>
+///     Per-second time-series for a Trawl run: throughput and tail latency bucketed by whole-second offset
+///     from the start of the measured window.
+/// </summary>
+public sealed record TrawlTimeSeries
+{
+    /// <summary>Whole-second offsets from the start of the measured window (0, 1, 2, ...).</summary>
+    public double[] SecondOffsets { get; init; } = Array.Empty<double>();
+
+    /// <summary>Completed requests in each one-second bucket (i.e. throughput for that second).</summary>
+    public double[] RequestsPerSecond { get; init; } = Array.Empty<double>();
+
+    /// <summary>p99 latency (ms) within each one-second bucket.</summary>
+    public double[] P99Ms { get; init; } = Array.Empty<double>();
+
+    public static TrawlTimeSeries Empty => new();
+}
+
+/// <summary>
+///     A persisted Trawl run: a <see cref="TrawlResult" /> plus the wall-clock timestamp it was captured at.
+///     Written to the tracking directory as JSON and read back by regression analysis.
+/// </summary>
+public sealed record TrawlRunRecord
+{
+    public DateTime TimestampUtc { get; init; }
+    public TrawlResult Result { get; init; } = new();
 }

--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -165,6 +165,7 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
         var stats = LatencyStatsCalculator.Compute(latenciesMs);
         var throughput = runData.Elapsed.TotalSeconds > 0 ? totalRequests / runData.Elapsed.TotalSeconds : 0;
         var errorRate = totalRequests > 0 ? (double)runData.ErrorCount / totalRequests : 0;
+        var timeSeries = TrawlTimeSeriesCalculator.Compute(runData.Samples, runData.RunStartTimestamp, frequency);
 
         var trawlResult = new TrawlResult
         {
@@ -176,16 +177,49 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
             TotalErrors = runData.ErrorCount,
             RequestsPerSecond = throughput,
             ErrorRate = errorRate,
-            Latency = stats
+            Latency = stats,
+            LatencySamplesMs = Downsample(latenciesMs),
+            TimeSeries = timeSeries
         };
 
         InjectSamples(container, runData, frequency);
-
-        _logger.Log(LogLevel.Information,
-            "      ---- Trawl result: {Rps:0.#} req/s | p50 {P50:0.##}ms p95 {P95:0.##}ms p99 {P99:0.##}ms max {Max:0.##}ms | errors {Errors}/{Total} ({Rate:0.##%})",
-            trawlResult.RequestsPerSecond, stats.P50, stats.P95, stats.P99, stats.Max, trawlResult.TotalErrors, trawlResult.TotalRequests, trawlResult.ErrorRate);
+        ReportAndPersist(trawlResult);
 
         return new TestCaseExecutionResult(container);
+    }
+
+    private void ReportAndPersist(TrawlResult result)
+    {
+        var report = TrawlReportRenderer.Render(result, _runSettings.DistributionPlotStyle);
+        _logger.Log(LogLevel.Information, "{TrawlReport}", Environment.NewLine + report);
+
+        // Best-effort: an IO failure persisting artifacts must not fail the test case.
+        try
+        {
+            var writer = new TrawlResultWriter();
+            var timestamp = DateTime.UtcNow;
+            var outputDirectory = _runSettings.LocalOutputDirectory;
+            writer.PersistRecord(result, timestamp, outputDirectory);
+            writer.WriteReport(report, result, timestamp, outputDirectory);
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Warning, ex, "      ---- Trawl: failed to persist result/report");
+        }
+    }
+
+    /// <summary>Caps the latency sample array for plotting/persistence via uniform stride down-sampling.</summary>
+    private static double[] Downsample(double[] all)
+    {
+        var count = all.Length;
+        if (count <= MaxInjectedSamples) return all;
+
+        var stride = (int)Math.Ceiling(count / (double)MaxInjectedSamples);
+        var size = (count + stride - 1) / stride;
+        var result = new double[size];
+        var j = 0;
+        for (var i = 0; i < count && j < size; i += stride) result[j++] = all[i];
+        return result;
     }
 
     /// <summary>

--- a/source/Sailfish/Execution/TrawlReportRenderer.cs
+++ b/source/Sailfish/Execution/TrawlReportRenderer.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Presentation;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Renders a Trawl run into a Markdown/console report: a summary line, a latency-percentile table, the
+///     latency distribution (reusing <see cref="DistributionPlotRenderer" /> so it honors the configured
+///     plot style), and Unicode sparklines for throughput and p99 over time.
+/// </summary>
+internal static class TrawlReportRenderer
+{
+    private const string SparkChars = "▁▂▃▄▅▆▇█";
+
+    public static string Render(TrawlResult result, DistributionPlotStyle plotStyle)
+    {
+        var latency = result.Latency;
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"## Trawl — {result.DisplayName}");
+        sb.AppendLine();
+        sb.AppendLine($"- Model: **{result.Model}** | Virtual users: **{result.VirtualUsers}** | Duration: **{result.Duration.TotalSeconds:0.##}s**");
+        sb.AppendLine($"- Throughput: **{result.RequestsPerSecond:0.#} req/s** | Requests: **{result.TotalRequests}** | Errors: **{result.TotalErrors}** ({result.ErrorRate:0.##%})");
+        sb.AppendLine();
+        sb.AppendLine("| latency (ms) | p50 | p90 | p95 | p99 | max | mean | min |");
+        sb.AppendLine("|---|----:|----:|----:|----:|----:|-----:|----:|");
+        sb.AppendLine($"| | {latency.P50:0.##} | {latency.P90:0.##} | {latency.P95:0.##} | {latency.P99:0.##} | {latency.Max:0.##} | {latency.Mean:0.##} | {latency.Min:0.##} |");
+        sb.AppendLine();
+
+        if (result.LatencySamplesMs.Length > 0)
+        {
+            var plot = DistributionPlotRenderer.Render(
+                new[] { new DistributionPlotRenderer.Series("Latency (ms)", result.LatencySamplesMs, latency.Mean, latency.P50, null) },
+                DurationUnit.Milliseconds,
+                plotStyle);
+
+            if (!string.IsNullOrWhiteSpace(plot))
+            {
+                sb.AppendLine("```");
+                sb.AppendLine(plot.TrimEnd());
+                sb.AppendLine("```");
+                sb.AppendLine();
+            }
+        }
+
+        if (result.TimeSeries is { } timeSeries && timeSeries.RequestsPerSecond.Length > 0)
+        {
+            sb.AppendLine($"Throughput/s : {Sparkline(timeSeries.RequestsPerSecond)}");
+            sb.AppendLine($"p99 (ms)/s   : {Sparkline(timeSeries.P99Ms)}");
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Maps a series of values onto Unicode block characters by normalized magnitude.</summary>
+    internal static string Sparkline(double[] values)
+    {
+        if (values is null || values.Length == 0) return string.Empty;
+
+        var min = double.MaxValue;
+        var max = double.MinValue;
+        foreach (var value in values)
+        {
+            if (value < min) min = value;
+            if (value > max) max = value;
+        }
+
+        var range = max - min;
+        var sb = new StringBuilder(values.Length);
+        foreach (var value in values)
+        {
+            var index = range <= 0 ? 0 : (int)Math.Round((value - min) / range * (SparkChars.Length - 1));
+            sb.Append(SparkChars[Math.Clamp(index, 0, SparkChars.Length - 1)]);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/source/Sailfish/Execution/TrawlResultWriter.cs
+++ b/source/Sailfish/Execution/TrawlResultWriter.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Persists a Trawl run to the output directory: a machine-readable JSON record (consumed by regression
+///     analysis) and the human-readable Markdown report, both under a <c>trawl/</c> subdirectory.
+/// </summary>
+internal sealed class TrawlResultWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public static string TrawlDirectory(string outputDirectory) => Path.Combine(outputDirectory, "trawl");
+
+    public string PersistRecord(TrawlResult result, DateTime timestampUtc, string outputDirectory)
+    {
+        var path = Path.Combine(EnsureDirectory(outputDirectory), Stem(result, timestampUtc) + ".json");
+        var record = new TrawlRunRecord { TimestampUtc = timestampUtc, Result = result };
+        File.WriteAllText(path, JsonSerializer.Serialize(record, JsonOptions));
+        return path;
+    }
+
+    public string WriteReport(string markdown, TrawlResult result, DateTime timestampUtc, string outputDirectory)
+    {
+        var path = Path.Combine(EnsureDirectory(outputDirectory), Stem(result, timestampUtc) + ".md");
+        File.WriteAllText(path, markdown);
+        return path;
+    }
+
+    private static string EnsureDirectory(string outputDirectory)
+    {
+        var dir = TrawlDirectory(outputDirectory);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string Stem(TrawlResult result, DateTime timestampUtc)
+        => $"{Sanitize(result.DisplayName)}_{timestampUtc:yyyy-MM-ddTHH-mm-ss-fffZ}";
+
+    private static string Sanitize(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+            sb.Append(Array.IndexOf(invalid, c) >= 0 || c == ' ' ? '_' : c);
+        return sb.Length == 0 ? "trawl" : sb.ToString();
+    }
+}

--- a/source/Sailfish/Execution/TrawlTimeSeriesCalculator.cs
+++ b/source/Sailfish/Execution/TrawlTimeSeriesCalculator.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Buckets a run's request samples into whole-second windows (from the start of the measured window) to
+///     produce a throughput-and-tail-latency time-series. Pure post-processing over the samples the
+///     scheduler already captured — no extra cost during the run.
+/// </summary>
+internal static class TrawlTimeSeriesCalculator
+{
+    public static TrawlTimeSeries Compute(IReadOnlyList<RequestSample> samples, long runStartTimestamp, long frequency)
+    {
+        if (samples is null || samples.Count == 0 || frequency <= 0) return TrawlTimeSeries.Empty;
+
+        var buckets = new SortedDictionary<long, List<double>>();
+        foreach (var sample in samples)
+        {
+            var offsetSeconds = (long)((double)(sample.StartTimestamp - runStartTimestamp) / frequency);
+            if (offsetSeconds < 0) offsetSeconds = 0;
+            if (!buckets.TryGetValue(offsetSeconds, out var latencies))
+            {
+                latencies = new List<double>();
+                buckets[offsetSeconds] = latencies;
+            }
+
+            latencies.Add(sample.LatencyTicks * 1000.0 / frequency);
+        }
+
+        var count = buckets.Count;
+        var offsets = new double[count];
+        var rps = new double[count];
+        var p99 = new double[count];
+
+        var i = 0;
+        foreach (var bucket in buckets)
+        {
+            offsets[i] = bucket.Key;
+            rps[i] = bucket.Value.Count; // a one-second bucket, so the count is requests/second
+            p99[i] = LatencyStatsCalculator.Compute(bucket.Value).P99;
+            i++;
+        }
+
+        return new TrawlTimeSeries { SecondOffsets = offsets, RequestsPerSecond = rps, P99Ms = p99 };
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlReportRendererTests.cs
+++ b/source/Tests.Library/Trawl/TrawlReportRendererTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Sailfish.Presentation;
+using Sailfish.Trawl;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class TrawlReportRendererTests
+{
+    private static TrawlResult SampleResult() => new()
+    {
+        DisplayName = "My.Load(scenario: 1)",
+        Model = LoadModel.OpenModel,
+        VirtualUsers = 8,
+        Duration = TimeSpan.FromSeconds(3),
+        TotalRequests = 300,
+        TotalErrors = 6,
+        RequestsPerSecond = 100,
+        ErrorRate = 0.02,
+        Latency = new LatencyStats { Min = 1, Mean = 6, P50 = 5, P90 = 12, P95 = 18, P99 = 40, Max = 80 },
+        LatencySamplesMs = new[] { 1.0, 2, 3, 5, 8, 12, 18, 40, 80 },
+        TimeSeries = new TrawlTimeSeries
+        {
+            SecondOffsets = new double[] { 0, 1, 2 },
+            RequestsPerSecond = new double[] { 90, 100, 110 },
+            P99Ms = new double[] { 30, 40, 50 }
+        }
+    };
+
+    [Fact]
+    public void Render_ContainsHeadlineFiguresAndTimeSeries()
+    {
+        var report = TrawlReportRenderer.Render(SampleResult(), DistributionPlotStyle.Histogram);
+
+        report.ShouldContain("Trawl — My.Load(scenario: 1)");
+        report.ShouldContain("req/s");
+        report.ShouldContain("p99");
+        report.ShouldContain("Throughput/s");
+    }
+
+    [Fact]
+    public void Sparkline_FlatInput_IsLowestBar()
+    {
+        TrawlReportRenderer.Sparkline(new[] { 0.0, 0.0, 0.0 }).ShouldBe("▁▁▁");
+    }
+
+    [Fact]
+    public void Sparkline_Ascending_RisesToFull()
+    {
+        var spark = TrawlReportRenderer.Sparkline(new[] { 0.0, 1, 2, 3, 4, 5, 6, 7 });
+        spark[0].ShouldBe('▁');
+        spark[^1].ShouldBe('█');
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlResultWriterTests.cs
+++ b/source/Tests.Library/Trawl/TrawlResultWriterTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Sailfish.Trawl;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class TrawlResultWriterTests
+{
+    [Fact]
+    public void PersistRecord_RoundTripsThroughJson_AndWritesReport()
+    {
+        var result = new TrawlResult
+        {
+            DisplayName = "My.Test(x: 1)",
+            Model = LoadModel.ClosedModel,
+            VirtualUsers = 4,
+            Duration = TimeSpan.FromSeconds(2),
+            TotalRequests = 100,
+            TotalErrors = 2,
+            RequestsPerSecond = 50,
+            ErrorRate = 0.02,
+            Latency = new LatencyStats { Min = 1, Mean = 6, P50 = 5, P99 = 20, Max = 25 },
+            LatencySamplesMs = new[] { 1.0, 2, 3 },
+            TimeSeries = new TrawlTimeSeries
+            {
+                SecondOffsets = new double[] { 0, 1 },
+                RequestsPerSecond = new double[] { 50, 50 },
+                P99Ms = new double[] { 20, 21 }
+            }
+        };
+
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_writer_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var writer = new TrawlResultWriter();
+            var timestamp = DateTime.UtcNow;
+
+            var jsonPath = writer.PersistRecord(result, timestamp, dir);
+            var mdPath = writer.WriteReport("# report body", result, timestamp, dir);
+
+            File.Exists(jsonPath).ShouldBeTrue();
+            File.Exists(mdPath).ShouldBeTrue();
+            jsonPath.ShouldContain(Path.Combine("trawl", "My.Test")); // sanitized into the trawl subdir
+
+            var record = JsonSerializer.Deserialize<TrawlRunRecord>(File.ReadAllText(jsonPath));
+            record.ShouldNotBeNull();
+            record!.Result.DisplayName.ShouldBe("My.Test(x: 1)");
+            record.Result.Model.ShouldBe(LoadModel.ClosedModel);
+            record.Result.RequestsPerSecond.ShouldBe(50);
+            record.Result.Latency.P99.ShouldBe(20);
+            record.Result.LatencySamplesMs.Length.ShouldBe(3);
+            record.Result.TimeSeries.ShouldNotBeNull();
+            record.Result.TimeSeries!.RequestsPerSecond.Length.ShouldBe(2);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlTimeSeriesCalculatorTests.cs
+++ b/source/Tests.Library/Trawl/TrawlTimeSeriesCalculatorTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class TrawlTimeSeriesCalculatorTests
+{
+    private static readonly long Freq = Stopwatch.Frequency;
+
+    private static long At(double secondsFromStart, long runStart) => runStart + (long)(secondsFromStart * Freq);
+    private static long Ms(double ms) => (long)(ms / 1000.0 * Freq);
+
+    [Fact]
+    public void Empty_ReturnsEmpty()
+    {
+        TrawlTimeSeriesCalculator.Compute(new List<RequestSample>(), 0, Freq).RequestsPerSecond.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public void BucketsBySecond_CountsThroughput_AndTailLatency()
+    {
+        const long runStart = 1_000_000;
+        var samples = new List<RequestSample>
+        {
+            // second 0: three requests (10/20/30 ms)
+            new(At(0.1, runStart), Ms(10)),
+            new(At(0.4, runStart), Ms(20)),
+            new(At(0.9, runStart), Ms(30)),
+            // second 1: two requests (40/50 ms)
+            new(At(1.2, runStart), Ms(40)),
+            new(At(1.7, runStart), Ms(50)),
+        };
+
+        var ts = TrawlTimeSeriesCalculator.Compute(samples, runStart, Freq);
+
+        ts.SecondOffsets.ShouldBe(new double[] { 0, 1 });
+        ts.RequestsPerSecond.ShouldBe(new double[] { 3, 2 }); // one-second buckets => count is req/s
+        ts.P99Ms[0].ShouldBe(30, 0.5); // nearest-rank p99 of {10,20,30}
+        ts.P99Ms[1].ShouldBe(50, 0.5);
+    }
+}


### PR DESCRIPTION
## Phase 3 of the Trawl stack — reporting & persistence

**Stacked on [#276](https://github.com/paulegradie/Sailfish/pull/276) (Phase 2).** Base is `claude/trawl-p2-openmodel`.

Turns a Trawl run into a readable report and a persisted artifact (the latter is what Phase 4's regression gate will read as a baseline).

### What lands
- **`TrawlResult`** now carries a (capped) `LatencySamplesMs` distribution and a per-second `TimeSeries`.
- **`TrawlTimeSeriesCalculator`** buckets the samples the scheduler *already captured* into one-second windows (throughput + p99 per second) — pure post-processing, zero added run-time cost.
- **`TrawlReportRenderer`** renders a Markdown/console report: summary line, latency-percentile table, the latency **distribution plot** (reusing `DistributionPlotRenderer`, so it honors the configured `DistributionPlotStyle`), and Unicode **sparklines** for throughput and p99 over time.
- **`TrawlResultWriter`** persists a `TrawlRunRecord` as JSON plus the Markdown report under `<output>/trawl/<scenario>_<timestamp>.{json,md}`.
- The **engine** computes the time-series + capped samples, logs the report to the console, and best-effort persists the artifacts (an IO failure never fails the test case).

### Why the JSON matters
The persisted record includes the capped latency sample array and the time-series — exactly what **Phase 4 (SailDiff regression gating)** needs to compare a baseline run against the current one.

### Tests (all green)
`Tests.Library`: time-series bucketing (throughput + tail latency per second), report rendering + sparkline magnitude mapping, and a JSON round-trip through the writer. Full suite: **Tests.Library 1588** — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)