### PR TITLE
Trawl (load testing) — Phase 4: SailDiff regression gating

### DIFF
--- a/site/src/pages/docs/2/trawl.md
+++ b/site/src/pages/docs/2/trawl.md
@@ -102,6 +102,16 @@ public async Task Checkout(CancellationToken ct) { /* ... */ }
 
 Each scenario prints a report — a summary line, a latency-percentile table, a latency **distribution plot** (honoring your configured `DistributionPlotStyle`), and Unicode **sparklines** of throughput and p99 over time. The same report is written to `<output>/trawl/<scenario>_<timestamp>.md`, and a machine-readable `…​.json` record (summary + a capped latency sample + the per-second time-series) is written alongside it — that JSON is what later regression analysis reads as a baseline.
 
+## Regression gating
+
+Every run is compared against its **most recent prior run** (the baseline persisted under `<output>/trawl/`) using SailDiff's statistical machinery — the exact same significance test the microbenchmark path uses, applied to the two latency distributions (outlier removal off, so the slow tail counts). The verdict reads either `Current is N% slower/faster than baseline …` or `NOT SIGNIFICANT`.
+
+Turn it into a **CI gate** with `FailOnRegression` — a scenario that regressed significantly then fails its test case (non-zero `dotnet test`):
+
+```jsonc
+{ "TrawlSettings": { "FailOnRegression": true } }
+```
+
 ## Status
 
-Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022), the **closed-model engine**, the **open arrival-rate model with coordinated-omission correction**, and **reporting** (console + Markdown report, distribution plot, time-series sparklines, JSON persistence). Still landing in subsequent releases: multi-stage load profiles (ramp/step) and streaming histograms for long soaks, SailDiff regression gating, and ScaleFish saturation analysis.
+Trawl is being delivered in phases. Shipping now: the public surface (`[Trawl]`, `TrawlSettings`, `TrawlResult`, SF1022), the **closed-model engine**, the **open arrival-rate model with coordinated-omission correction**, **reporting** (console + Markdown report, distribution plot, time-series sparklines, JSON persistence), and **SailDiff regression gating** (`FailOnRegression`). Still landing in subsequent releases: multi-stage load profiles (ramp/step), streaming histograms for long soaks, and ScaleFish saturation analysis.

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -92,6 +92,7 @@ public static class AdapterRunSettingsLoader
         if (parsed.VirtualUsersOverride is not null) mapped.VirtualUsersOverride = parsed.VirtualUsersOverride.Value;
         if (parsed.MaxDurationSecondsOverride is not null) mapped.MaxDurationSecondsOverride = parsed.MaxDurationSecondsOverride.Value;
         if (parsed.WarmupSecondsOverride is not null) mapped.WarmupSecondsOverride = parsed.WarmupSecondsOverride.Value;
+        if (parsed.FailOnRegression is not null) mapped.FailOnRegression = parsed.FailOnRegression.Value;
         return mapped;
     }
 

--- a/source/Sailfish.TestAdapter/TestSettingsParser/TrawlSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/TrawlSettings.cs
@@ -24,4 +24,8 @@ public class TrawlSettings
     /// <summary>Override the warmup duration in seconds for every scenario.</summary>
     [JsonPropertyName("WarmupSecondsOverride")]
     public double? WarmupSecondsOverride { get; set; }
+
+    /// <summary>Fail a scenario's test case when it regresses significantly vs its prior run (CI gate).</summary>
+    [JsonPropertyName("FailOnRegression")]
+    public bool? FailOnRegression { get; set; }
 }

--- a/source/Sailfish/Contracts.Public/Models/TrawlRegressionVerdict.cs
+++ b/source/Sailfish/Contracts.Public/Models/TrawlRegressionVerdict.cs
@@ -1,0 +1,35 @@
+namespace Sailfish.Contracts.Public.Models;
+
+/// <summary>The outcome of comparing a Trawl run against its baseline.</summary>
+public enum TrawlRegressionOutcome
+{
+    /// <summary>Significantly faster than baseline.</summary>
+    Improved,
+
+    /// <summary>Significantly slower than baseline.</summary>
+    Regressed,
+
+    /// <summary>No statistically significant change.</summary>
+    NotSignificant,
+
+    /// <summary>Could not be determined (no baseline, no samples, or the test failed).</summary>
+    Inconclusive
+}
+
+/// <summary>
+///     The result of a Trawl regression comparison: a current run's latency distribution tested against the
+///     baseline (most recent prior) run via SailDiff's statistical machinery.
+/// </summary>
+public sealed record TrawlRegressionVerdict
+{
+    public TrawlRegressionOutcome Outcome { get; init; }
+
+    /// <summary>Percentage change in mean latency vs baseline; positive means slower (a regression).</summary>
+    public double PercentChange { get; init; }
+
+    /// <summary>The statistical test's p-value.</summary>
+    public double PValue { get; init; }
+
+    /// <summary>Human-readable verdict line.</summary>
+    public string Message { get; init; } = string.Empty;
+}

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Sailfish.Analysis.SailDiff;
 using Sailfish.Attributes;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Execution.Tuning;
@@ -25,17 +26,20 @@ internal class TestCaseIterator : ITestCaseIterator
     private readonly IRunSettings _runSettings;
     private readonly IIterationStrategy _fixedIterationStrategy;
     private readonly IIterationStrategy _adaptiveIterationStrategy;
+    private readonly IStatisticalTestExecutor? _statExecutor;
 
     public TestCaseIterator(
         IRunSettings runSettings,
         ILogger logger,
         IIterationStrategy fixedIterationStrategy,
-        IIterationStrategy adaptiveIterationStrategy)
+        IIterationStrategy adaptiveIterationStrategy,
+        IStatisticalTestExecutor? statExecutor = null)
     {
         _logger = logger;
         _runSettings = runSettings;
         _fixedIterationStrategy = fixedIterationStrategy;
         _adaptiveIterationStrategy = adaptiveIterationStrategy;
+        _statExecutor = statExecutor;
     }
 
     public async Task<TestCaseExecutionResult> Iterate(
@@ -48,7 +52,7 @@ internal class TestCaseIterator : ITestCaseIterator
         var trawlAttribute = testInstanceContainer.ExecutionMethod.GetCustomAttribute<TrawlAttribute>();
         if (trawlAttribute is not null)
         {
-            var trawlEngine = new TrawlExecutionEngine(_logger, _runSettings);
+            var trawlEngine = new TrawlExecutionEngine(_logger, _runSettings, statExecutor: _statExecutor);
             return await trawlEngine.RunAsync(testInstanceContainer, trawlAttribute, cancellationToken).ConfigureAwait(false);
         }
 

--- a/source/Sailfish/Execution/TrawlBaselineProvider.cs
+++ b/source/Sailfish/Execution/TrawlBaselineProvider.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Text.Json;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Loads the baseline for a Trawl scenario — the most recent prior <see cref="TrawlRunRecord" /> persisted
+///     under <c>&lt;output&gt;/trawl/</c> for the same scenario. Because the current run is persisted only
+///     after the comparison, "most recent on disk" is exactly the previous run.
+/// </summary>
+internal sealed class TrawlBaselineProvider
+{
+    public TrawlRunRecord? GetLatestBaseline(string displayName, string outputDirectory)
+    {
+        var dir = TrawlResultWriter.TrawlDirectory(outputDirectory);
+        if (!Directory.Exists(dir)) return null;
+
+        TrawlRunRecord? latest = null;
+        foreach (var file in Directory.EnumerateFiles(dir, "*.json"))
+        {
+            TrawlRunRecord? record;
+            try
+            {
+                record = JsonSerializer.Deserialize<TrawlRunRecord>(File.ReadAllText(file));
+            }
+            catch
+            {
+                continue; // skip unreadable/foreign files
+            }
+
+            if (record is null || record.Result.DisplayName != displayName) continue;
+            if (latest is null || record.TimestampUtc > latest.TimestampUtc) latest = record;
+        }
+
+        return latest;
+    }
+}

--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Sailfish.Analysis.SailDiff;
 using Sailfish.Attributes;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Exceptions;
@@ -42,15 +43,18 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
     private readonly IRunSettings _runSettings;
     private readonly ClosedModelScheduler _closedModelScheduler;
     private readonly ArrivalRateScheduler _arrivalRateScheduler;
+    private readonly IStatisticalTestExecutor? _statExecutor;
 
     public TrawlExecutionEngine(
         ILogger logger,
         IRunSettings runSettings,
         ClosedModelScheduler? closedModelScheduler = null,
-        ArrivalRateScheduler? arrivalRateScheduler = null)
+        ArrivalRateScheduler? arrivalRateScheduler = null,
+        IStatisticalTestExecutor? statExecutor = null)
     {
         _logger = logger;
         _runSettings = runSettings;
+        _statExecutor = statExecutor;
         _closedModelScheduler = closedModelScheduler ?? new ClosedModelScheduler();
         _arrivalRateScheduler = arrivalRateScheduler ?? new ArrivalRateScheduler();
     }
@@ -182,10 +186,36 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
             TimeSeries = timeSeries
         };
 
+        // Compare against the latest prior run BEFORE persisting this one (so it isn't its own baseline).
+        var verdict = TryCompareRegression(trawlResult);
+        if (verdict is not null)
+            _logger.Log(LogLevel.Information, "      ---- Trawl regression: {Verdict}", verdict.Message);
+
         InjectSamples(container, runData, frequency);
         ReportAndPersist(trawlResult);
 
+        if (verdict is not null && _runSettings.TrawlSettings.FailOnRegression && verdict.Outcome == TrawlRegressionOutcome.Regressed)
+            return new TestCaseExecutionResult(container, new SailfishException($"Trawl regression gate failed — {verdict.Message}"));
+
         return new TestCaseExecutionResult(container);
+    }
+
+    private TrawlRegressionVerdict? TryCompareRegression(TrawlResult current)
+    {
+        if (_statExecutor is null || current.LatencySamplesMs.Length == 0) return null;
+
+        var baseline = new TrawlBaselineProvider().GetLatestBaseline(current.DisplayName, _runSettings.LocalOutputDirectory);
+        if (baseline is null || baseline.Result.LatencySamplesMs.Length == 0) return null;
+
+        return new TrawlRegressionAnalyzer(_statExecutor)
+            .Compare(baseline.Result.LatencySamplesMs, current.LatencySamplesMs, BuildTrawlSailDiffSettings());
+    }
+
+    private SailDiffSettings BuildTrawlSailDiffSettings()
+    {
+        var source = _runSettings.SailDiffSettings;
+        // Keep the slow tail (no outlier removal) — for a load test the tail is the signal, not noise.
+        return new SailDiffSettings(alpha: source.Alpha, round: 3, useOutlierDetection: false, testType: source.TestType);
     }
 
     private void ReportAndPersist(TrawlResult result)

--- a/source/Sailfish/Execution/TrawlRegressionAnalyzer.cs
+++ b/source/Sailfish/Execution/TrawlRegressionAnalyzer.cs
@@ -1,0 +1,68 @@
+using System;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public.Models;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Compares a Trawl run's latency distribution against a baseline using SailDiff's statistical test
+///     executor — the exact same significance machinery the microbenchmark path uses, reused at the raw
+///     <c>double[]</c> seam. The verdict follows the project's comparison vocabulary: a significant slowdown
+///     is "Current is N% slower than baseline", otherwise "NOT SIGNIFICANT".
+/// </summary>
+internal sealed class TrawlRegressionAnalyzer
+{
+    private readonly IStatisticalTestExecutor _executor;
+
+    public TrawlRegressionAnalyzer(IStatisticalTestExecutor executor)
+    {
+        _executor = executor;
+    }
+
+    public TrawlRegressionVerdict Compare(double[] baselineLatenciesMs, double[] currentLatenciesMs, SailDiffSettings settings)
+    {
+        if (baselineLatenciesMs is null || currentLatenciesMs is null || baselineLatenciesMs.Length == 0 || currentLatenciesMs.Length == 0)
+            return new TrawlRegressionVerdict { Outcome = TrawlRegressionOutcome.Inconclusive, Message = "No baseline or current samples to compare." };
+
+        TestResultWithOutlierAnalysis result;
+        try
+        {
+            // before = baseline, after = current.
+            result = _executor.ExecuteStatisticalTest(baselineLatenciesMs, currentLatenciesMs, settings);
+        }
+        catch (Exception ex)
+        {
+            return new TrawlRegressionVerdict { Outcome = TrawlRegressionOutcome.Inconclusive, Message = $"Comparison failed: {ex.Message}" };
+        }
+
+        var stat = result.StatisticalTestResult;
+        if (stat.Failed)
+            return new TrawlRegressionVerdict { Outcome = TrawlRegressionOutcome.Inconclusive, Message = $"Comparison failed: {result.ExceptionMessage}" };
+
+        var before = stat.MeanBefore;
+        var after = stat.MeanAfter;
+        var percentChange = before > 0 ? (after - before) / before * 100.0 : 0;
+        var significant = stat.PValue < settings.Alpha;
+
+        if (!significant)
+        {
+            return new TrawlRegressionVerdict
+            {
+                Outcome = TrawlRegressionOutcome.NotSignificant,
+                PercentChange = percentChange,
+                PValue = stat.PValue,
+                Message = $"NOT SIGNIFICANT: current vs baseline mean latency {before:0.##}ms -> {after:0.##}ms (p={stat.PValue:0.####}, alpha={settings.Alpha})"
+            };
+        }
+
+        var slower = after > before;
+        return new TrawlRegressionVerdict
+        {
+            Outcome = slower ? TrawlRegressionOutcome.Regressed : TrawlRegressionOutcome.Improved,
+            PercentChange = percentChange,
+            PValue = stat.PValue,
+            Message = $"Current is {Math.Abs(percentChange):0.##}% {(slower ? "slower" : "faster")} than baseline (mean latency {before:0.##}ms -> {after:0.##}ms, p={stat.PValue:0.####})"
+        };
+    }
+}

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -81,7 +81,8 @@ internal static class SailfishModuleRegistrations
             sp.GetRequiredService<IRunSettings>(),
             sp.GetRequiredService<ILogger>(),
             sp.GetRequiredKeyedService<IIterationStrategy>(FixedIterationStrategyKey),
-            sp.GetRequiredKeyedService<IIterationStrategy>(AdaptiveIterationStrategyKey)));
+            sp.GetRequiredKeyedService<IIterationStrategy>(AdaptiveIterationStrategyKey),
+            sp.GetService<IStatisticalTestExecutor>()));
 
         services.AddTransient<IStatisticsCompiler, StatisticsCompiler>();
         services.AddTransient<IClassExecutionSummaryCompiler, ClassExecutionSummaryCompiler>();

--- a/source/Sailfish/Trawl/TrawlSettings.cs
+++ b/source/Sailfish/Trawl/TrawlSettings.cs
@@ -37,6 +37,12 @@ public class TrawlSettings
     /// </summary>
     public double? WarmupSecondsOverride { get; set; }
 
+    /// <summary>
+    ///     When <c>true</c>, a Trawl scenario that has regressed significantly against its most recent prior
+    ///     run (per SailDiff) fails the test case — a CI regression gate. Default <c>false</c>.
+    /// </summary>
+    public bool FailOnRegression { get; set; }
+
     /// <summary>A fresh instance with all-default (no-override) values.</summary>
     public static TrawlSettings Default => new();
 }

--- a/source/Tests.Library/Trawl/TrawlBaselineProviderTests.cs
+++ b/source/Tests.Library/Trawl/TrawlBaselineProviderTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class TrawlBaselineProviderTests
+{
+    [Fact]
+    public void ReturnsMostRecentRecord_ForMatchingDisplayName()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_baseline_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var writer = new TrawlResultWriter();
+            writer.PersistRecord(new TrawlResult { DisplayName = "X.Y", LatencySamplesMs = new[] { 1.0, 2 }, RequestsPerSecond = 10 }, DateTime.UtcNow.AddMinutes(-10), dir);
+            writer.PersistRecord(new TrawlResult { DisplayName = "X.Y", LatencySamplesMs = new[] { 3.0, 4 }, RequestsPerSecond = 20 }, DateTime.UtcNow.AddMinutes(-1), dir);
+            writer.PersistRecord(new TrawlResult { DisplayName = "Other.Z", LatencySamplesMs = new[] { 9.0 }, RequestsPerSecond = 99 }, DateTime.UtcNow, dir);
+
+            var baseline = new TrawlBaselineProvider().GetLatestBaseline("X.Y", dir);
+
+            baseline.ShouldNotBeNull();
+            baseline!.Result.RequestsPerSecond.ShouldBe(20); // the most recent X.Y record, not the Other.Z one
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenNoMatchingScenario()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_baseline_none_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            new TrawlBaselineProvider().GetLatestBaseline("Nope", dir).ShouldBeNull();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlRegressionAnalyzerTests.cs
+++ b/source/Tests.Library/Trawl/TrawlRegressionAnalyzerTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using NSubstitute;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+public class TrawlRegressionAnalyzerTests
+{
+    private static readonly double[] Baseline = { 10, 11, 12, 10, 11 };
+    private static readonly double[] Current = { 14, 15, 16, 15, 14 };
+    private static SailDiffSettings Settings => new(alpha: 0.05, useOutlierDetection: false);
+
+    private static IStatisticalTestExecutor StubReturning(double meanBefore, double meanAfter, double pValue)
+    {
+        var stat = new StatisticalTestResult(meanBefore, meanAfter, meanBefore, meanAfter, 0, pValue, "change", 5, 5,
+            new double[0], new double[0], new Dictionary<string, object>());
+        var exec = Substitute.For<IStatisticalTestExecutor>();
+        exec.ExecuteStatisticalTest(Arg.Any<double[]>(), Arg.Any<double[]>(), Arg.Any<SailDiffSettings>())
+            .Returns(new TestResultWithOutlierAnalysis(stat, null, null));
+        return exec;
+    }
+
+    [Fact]
+    public void SignificantSlowdown_IsRegressed_WithRequiredWording()
+    {
+        var verdict = new TrawlRegressionAnalyzer(StubReturning(10, 15, 0.001)).Compare(Baseline, Current, Settings);
+
+        verdict.Outcome.ShouldBe(TrawlRegressionOutcome.Regressed);
+        verdict.Message.ShouldContain("slower than baseline");
+        verdict.PercentChange.ShouldBe(50, 0.001); // 10ms -> 15ms
+    }
+
+    [Fact]
+    public void SignificantSpeedup_IsImproved()
+    {
+        var verdict = new TrawlRegressionAnalyzer(StubReturning(15, 10, 0.001)).Compare(Baseline, Current, Settings);
+
+        verdict.Outcome.ShouldBe(TrawlRegressionOutcome.Improved);
+        verdict.Message.ShouldContain("faster than baseline");
+    }
+
+    [Fact]
+    public void HighPValue_IsNotSignificant()
+    {
+        var verdict = new TrawlRegressionAnalyzer(StubReturning(10, 15, 0.5)).Compare(Baseline, Current, Settings);
+
+        verdict.Outcome.ShouldBe(TrawlRegressionOutcome.NotSignificant);
+        verdict.Message.ShouldContain("NOT SIGNIFICANT");
+    }
+
+    [Fact]
+    public void EmptyArrays_AreInconclusive()
+    {
+        new TrawlRegressionAnalyzer(StubReturning(10, 15, 0.001))
+            .Compare(new double[0], Current, Settings).Outcome.ShouldBe(TrawlRegressionOutcome.Inconclusive);
+    }
+}

--- a/source/Tests.Library/Trawl/TrawlRegressionGatingTests.cs
+++ b/source/Tests.Library/Trawl/TrawlRegressionGatingTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Trawl;
+
+/// <summary>
+/// Drives a [Trawl] scenario through the iterator with a seeded baseline and a stubbed statistical
+/// executor, proving the regression gate fails (or not) the case based on TrawlSettings.FailOnRegression.
+/// </summary>
+public class TrawlRegressionGatingTests
+{
+    [Fact]
+    public async Task FailOnRegression_FailsTheCase_WhenRegressed()
+    {
+        var result = await RunWithSeededBaseline(failOnRegression: true);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Exception.ShouldNotBeNull();
+        result.Exception!.Message.ShouldContain("regression");
+    }
+
+    [Fact]
+    public async Task WithoutGate_RegressionIsReportedButCasePasses()
+    {
+        var result = await RunWithSeededBaseline(failOnRegression: false);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    private static async Task<TestCaseExecutionResult> RunWithSeededBaseline(bool failOnRegression)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_gate_" + Guid.NewGuid().ToString("N"));
+        var logger = Substitute.For<ILogger>();
+
+        var instance = new GateWork();
+        var method = typeof(GateWork).GetMethod(nameof(GateWork.Scenario))!;
+        var execSettings = new ExecutionSettings { NumWarmupIterations = 0, SampleSize = 1, UseAdaptiveSampling = false };
+        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, execSettings);
+
+        // Seed a baseline for this scenario so the engine has something to compare against.
+        new TrawlResultWriter().PersistRecord(
+            new TrawlResult { DisplayName = container.TestCaseId.DisplayName, LatencySamplesMs = new[] { 1.0, 2, 3, 4, 5 } },
+            DateTime.UtcNow.AddMinutes(-5), dir);
+
+        // Stub the statistical executor to report a significant slowdown (10ms -> 20ms).
+        var stat = new StatisticalTestResult(10, 20, 10, 20, 0, 0.001, "change", 5, 5,
+            new double[0], new double[0], new Dictionary<string, object>());
+        var exec = Substitute.For<IStatisticalTestExecutor>();
+        exec.ExecuteStatisticalTest(Arg.Any<double[]>(), Arg.Any<double[]>(), Arg.Any<SailDiffSettings>())
+            .Returns(new TestResultWithOutlierAnalysis(stat, null, null));
+
+        var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(dir)
+            .WithTrawl(new Sailfish.Trawl.TrawlSettings { FailOnRegression = failOnRegression })
+            .Build();
+
+        var iterator = new TestCaseIterator(runSettings, logger,
+            new FixedIterationStrategy(logger),
+            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()),
+            exec);
+
+        try
+        {
+            return await iterator.Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Sailfish]
+    private sealed class GateWork
+    {
+        [Trawl(VirtualUsers = 2, DurationSeconds = 0.2, WarmupSeconds = 0)]
+        public async Task Scenario(CancellationToken ct) => await Task.Delay(2, ct);
+    }
+}


### PR DESCRIPTION
## Phase 4 of the Trawl stack — regression gating

**Stacked on [#277](https://github.com/paulegradie/Sailfish/pull/277) (Phase 3).** Base is `claude/trawl-p3-reporting`.

Brings Sailfish's statistical rigor to load results: every run is compared against its baseline, and a significant regression can fail the build. This is the wedge — load tools give you a number; this tells you whether the number *changed for real*.

### How it works
- **`TrawlRegressionAnalyzer`** feeds the baseline and current latency arrays into SailDiff's **`IStatisticalTestExecutor`** — the *same* significance test (`ExecuteStatisticalTest(double[] before, double[] after, …)`) the microbenchmark path uses — and maps the result to a verdict in the project's vocabulary: `Current is N% slower/faster than baseline …` or **`NOT SIGNIFICANT`**. Outlier detection is forced **off** (for a load test the slow tail is the signal, not noise).
- **`TrawlBaselineProvider`** loads the most recent prior `TrawlRunRecord` for the scenario from `<output>/trawl/` (Phase 3's JSON) — read *before* the current run is persisted, so a run is never its own baseline.
- **`TrawlSettings.FailOnRegression`** (core + `.sailfish.json` + adapter): a significantly-regressed scenario fails its test case → non-zero `dotnet test`. A CI gate.

### Integration
`IStatisticalTestExecutor` is threaded through as an **optional** `TestCaseIterator`/engine parameter, resolved from DI. Existing 4-arg `TestCaseIterator` callers are unaffected; when the executor is absent (null), gating is simply skipped.

### Tests (all green)
`Tests.Library`: analyzer verdicts (regressed / improved / not-significant / inconclusive) via a stubbed executor; baseline selection (latest matching record, ignores other scenarios); and the **end-to-end gate** — a seeded baseline + stubbed regression fails the case when `FailOnRegression` is on and passes (verdict only) when off. Full suite: **Tests.Library 1596** — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)