### PR TITLE
Trawl: fix stale LoadModel docs + clarify VirtualUsers/threading

### DIFF
--- a/site/src/pages/docs/2/trawl.md
+++ b/site/src/pages/docs/2/trawl.md
@@ -38,6 +38,8 @@ The scenario method is protocol-agnostic — it is any `async` method. Sailfish 
 
 The enclosing class is an ordinary `[Sailfish]` class, so the usual hooks apply — warm a shared `HttpClient` or seed data in `[SailfishGlobalSetup]`. Because **all virtual users share the one test instance**, any scenario state must be thread-safe (a shared `HttpClient` is; a mutable field updated per request is not).
 
+Trawl scenarios should also be **`async` and non-blocking**. In the closed model each virtual user is an independent task, so a scenario that blocks a thread synchronously (rather than `await`-ing) ties up a thread-pool thread for the whole run; at high `VirtualUsers` counts that can starve the pool and distort the ramp. Prefer `await`-ing genuinely asynchronous work.
+
 ### A method is one mode or the other
 
 A method is either a microbenchmark (`[SailfishMethod]`) or a load scenario (`[Trawl]`) — never both. The **SF1022** analyzer enforces this at build time.

--- a/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
+++ b/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
@@ -16,7 +16,10 @@ public sealed record TrawlResult
     /// <summary>The load model that was applied.</summary>
     public LoadModel Model { get; init; }
 
-    /// <summary>The number of concurrent virtual users used (closed model).</summary>
+    /// <summary>
+    ///     The configured virtual-user count: the number of concurrent users in the closed model, or the
+    ///     cap on concurrent in-flight requests (connection-pool size) in the open model.
+    /// </summary>
     public int VirtualUsers { get; init; }
 
     /// <summary>The measured (post-warmup) wall-clock duration of the run.</summary>

--- a/source/Sailfish/Trawl/LoadModel.cs
+++ b/source/Sailfish/Trawl/LoadModel.cs
@@ -8,15 +8,16 @@ public enum LoadModel
     /// <summary>
     ///     A fixed number of concurrent virtual users, each looping (run the scenario, then immediately
     ///     run it again) for the scenario duration. Throughput is emergent — it is whatever the system
-    ///     under test can sustain at that concurrency. This is the default and the only model honored by
-    ///     the initial Trawl execution engine.
+    ///     under test can sustain at that concurrency. This is the default model.
     /// </summary>
     ClosedModel = 0,
 
     /// <summary>
     ///     Requests are dispatched at a fixed target arrival rate (requests/second) regardless of how many
-    ///     are already in flight — the "open" model that proper load tests use to expose coordinated
-    ///     omission. Honored once the arrival-rate scheduler ships in a later release.
+    ///     are already in flight — the "open" model that proper load tests use to expose a system that
+    ///     can't keep up. Latency is measured from each request's <i>intended</i> send time
+    ///     (coordinated-omission correction), and <see cref="Sailfish.Attributes.TrawlAttribute.VirtualUsers" />
+    ///     caps the number of concurrent in-flight requests (think connection-pool size).
     /// </summary>
     OpenModel = 1
 }


### PR DESCRIPTION
## What

Documentation/comment-only follow-up from the post-merge Trawl review. No behavioural change.

- **Stale `LoadModel` XML docs (the one outright-wrong item).** `source/Sailfish/Trawl/LoadModel.cs` still described a pre-Phase-2 world: `ClosedModel` was "the default and **the only model honored by the initial Trawl execution engine**", and `OpenModel` would be "honored **once the arrival-rate scheduler ships in a later release**." The open arrival-rate model shipped in Phase 2 (#276) and is dispatched today (`TrawlExecutionEngine`), so these comments contradicted both the running code and the user-facing docs (`trawl.md`). Rewritten to match reality, including the coordinated-omission note and the `VirtualUsers`-as-in-flight-cap behaviour.
- **`TrawlResult.VirtualUsers` doc.** Said "(closed model)", but the value is reused as the open-model in-flight cap. Clarified.
- **`trawl.md` thread-safety section.** Added a note that closed-model virtual users are independent tasks, so scenarios should be `async`/non-blocking to avoid thread-pool starvation at high `VirtualUsers` counts.

## Why

Caught during the review of the merged Trawl phases (#274–#278). This is finding #1 (and the doc nits #5c/#4c).

## Testing

`dotnet build source/Sailfish/Sailfish.csproj` — clean (0 warnings, 0 errors); the new `<see cref>` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify the `VirtualUsers` property behavior across closed and open load models, and improved descriptions of load model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->