### PR TITLE
Trawl: remove unused ITrawlExecutionEngine interface

### DIFF
--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -11,11 +11,6 @@ using Sailfish.Trawl;
 
 namespace Sailfish.Execution;
 
-internal interface ITrawlExecutionEngine
-{
-    Task<TestCaseExecutionResult> RunAsync(TestInstanceContainer container, TrawlAttribute attribute, CancellationToken cancellationToken);
-}
-
 /// <summary>
 ///     Runs a <c>[Trawl]</c> method as a concurrent load scenario instead of a sequential microbenchmark.
 ///     <para>
@@ -29,7 +24,7 @@ internal interface ITrawlExecutionEngine
 ///         its latency distribution through the normal pipeline.
 ///     </para>
 /// </summary>
-internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
+internal sealed class TrawlExecutionEngine
 {
     /// <summary>
     ///     Upper bound on the number of latency samples injected into the shared <see cref="PerformanceTimer" />.


### PR DESCRIPTION
## What

Delete the `ITrawlExecutionEngine` interface. It was declared and implemented by `TrawlExecutionEngine`, but never used:

- `TrawlExecutionEngine` is constructed directly with `new` in `TestCaseIterator` and called on the concrete type.
- It is not registered in DI, and nothing resolves `ITrawlExecutionEngine`.

So the interface was pure abstraction surface with no consumer. Removing it (the interface block + the `: ITrawlExecutionEngine` on the class) is a no-op.

## Why

Finding #2 from the post-merge Trawl review. If a DI seam is wanted later, it should be reintroduced alongside an actual registration and injection point.

## Testing

`dotnet build source/Sailfish/Sailfish.csproj` — clean (0/0). No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)