### PR TITLE
Trawl: efficient baseline lookup + opt-in record retention

### DIFF
--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -102,6 +102,7 @@ public static class AdapterRunSettingsLoader
         if (parsed.MaxDurationSecondsOverride is not null) mapped.MaxDurationSecondsOverride = parsed.MaxDurationSecondsOverride.Value;
         if (parsed.WarmupSecondsOverride is not null) mapped.WarmupSecondsOverride = parsed.WarmupSecondsOverride.Value;
         if (parsed.FailOnRegression is not null) mapped.FailOnRegression = parsed.FailOnRegression.Value;
+        if (parsed.MaxRetainedRunsPerScenario is not null) mapped.MaxRetainedRunsPerScenario = parsed.MaxRetainedRunsPerScenario.Value;
         return mapped;
     }
 

--- a/source/Sailfish.TestAdapter/TestSettingsParser/TrawlSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/TrawlSettings.cs
@@ -28,4 +28,8 @@ public class TrawlSettings
     /// <summary>Fail a scenario's test case when it regresses significantly vs its prior run (CI gate).</summary>
     [JsonPropertyName("FailOnRegression")]
     public bool? FailOnRegression { get; set; }
+
+    /// <summary>Keep at most this many persisted runs per scenario (0/absent = keep all).</summary>
+    [JsonPropertyName("MaxRetainedRunsPerScenario")]
+    public int? MaxRetainedRunsPerScenario { get; set; }
 }

--- a/source/Sailfish/Execution/TrawlBaselineProvider.cs
+++ b/source/Sailfish/Execution/TrawlBaselineProvider.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using Sailfish.Contracts.Public.Models;
 
@@ -16,8 +18,20 @@ internal sealed class TrawlBaselineProvider
         var dir = TrawlResultWriter.TrawlDirectory(outputDirectory);
         if (!Directory.Exists(dir)) return null;
 
-        TrawlRunRecord? latest = null;
-        foreach (var file in Directory.EnumerateFiles(dir, "*.json"))
+        // Records are named "{Sanitize(displayName)}_{sortable-UTC-timestamp}.json", and the embedded
+        // timestamp equals the record's TimestampUtc, so the lexically-greatest matching filename is the most
+        // recent run. Filter to this scenario's candidates by name prefix (a cheap directory listing, no
+        // reads), sort newest-first, then deserialize lazily and return the first exact DisplayName match —
+        // touching at most a handful of files instead of deserializing every record in the directory.
+        //
+        // The prefix can still over-match a sibling whose sanitized name shares it (e.g. distinct names that
+        // sanitize identically), which is why we verify DisplayName after deserializing.
+        var prefix = TrawlResultWriter.Sanitize(displayName) + "_";
+        var candidates = Directory.EnumerateFiles(dir, "*.json")
+            .Where(path => Path.GetFileName(path).StartsWith(prefix, StringComparison.Ordinal))
+            .OrderByDescending(Path.GetFileName, StringComparer.Ordinal);
+
+        foreach (var file in candidates)
         {
             TrawlRunRecord? record;
             try
@@ -30,9 +44,9 @@ internal sealed class TrawlBaselineProvider
             }
 
             if (record is null || record.Result.DisplayName != displayName) continue;
-            if (latest is null || record.TimestampUtc > latest.TimestampUtc) latest = record;
+            return record;
         }
 
-        return latest;
+        return null;
     }
 }

--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -231,6 +231,7 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
             var outputDirectory = _runSettings.LocalOutputDirectory;
             writer.PersistRecord(result, timestamp, outputDirectory);
             writer.WriteReport(report, result, timestamp, outputDirectory);
+            writer.PruneOldRecords(result, outputDirectory, _runSettings.TrawlSettings.MaxRetainedRunsPerScenario);
         }
         catch (Exception ex)
         {

--- a/source/Sailfish/Execution/TrawlResultWriter.cs
+++ b/source/Sailfish/Execution/TrawlResultWriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Sailfish.Contracts.Public.Models;
@@ -31,6 +32,46 @@ internal sealed class TrawlResultWriter
         return path;
     }
 
+    /// <summary>
+    ///     Prunes a scenario's persisted runs (the <c>.json</c> record and its matching <c>.md</c> report) down
+    ///     to the <paramref name="maxRetained" /> most recent, by filename timestamp. A value &lt;= 0 (the
+    ///     default) keeps every run — no pruning. Best-effort: a file that can't be deleted is skipped, never
+    ///     thrown. Records are matched by the same sanitized-name prefix used to write them, so two display
+    ///     names that sanitize to an identical stem share one retention pool.
+    /// </summary>
+    public void PruneOldRecords(TrawlResult result, string outputDirectory, int maxRetained)
+    {
+        if (maxRetained <= 0) return;
+
+        var dir = TrawlDirectory(outputDirectory);
+        if (!Directory.Exists(dir)) return;
+
+        var prefix = Sanitize(result.DisplayName) + "_";
+        var stale = Directory.EnumerateFiles(dir, "*.json")
+            .Where(path => Path.GetFileName(path).StartsWith(prefix, StringComparison.Ordinal))
+            .OrderByDescending(Path.GetFileName, StringComparer.Ordinal) // newest first (timestamp stem sorts lexically)
+            .Skip(maxRetained)
+            .ToList();
+
+        foreach (var json in stale)
+        {
+            TryDelete(json);
+            TryDelete(Path.ChangeExtension(json, ".md"));
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch
+        {
+            // Best-effort cleanup — a locked/removed artifact must never fail the run.
+        }
+    }
+
     private static string EnsureDirectory(string outputDirectory)
     {
         var dir = TrawlDirectory(outputDirectory);
@@ -41,7 +82,12 @@ internal sealed class TrawlResultWriter
     private static string Stem(TrawlResult result, DateTime timestampUtc)
         => $"{Sanitize(result.DisplayName)}_{timestampUtc:yyyy-MM-ddTHH-mm-ss-fffZ}";
 
-    private static string Sanitize(string name)
+    /// <summary>
+    ///     Maps a display name to the filename stem prefix used for its persisted records: invalid filename
+    ///     characters and spaces become <c>_</c>. Shared with <see cref="TrawlBaselineProvider" /> so baseline
+    ///     lookup can enumerate only a scenario's own candidate files.
+    /// </summary>
+    internal static string Sanitize(string name)
     {
         var invalid = Path.GetInvalidFileNameChars();
         var sb = new StringBuilder(name.Length);

--- a/source/Sailfish/Trawl/TrawlSettings.cs
+++ b/source/Sailfish/Trawl/TrawlSettings.cs
@@ -43,6 +43,14 @@ public class TrawlSettings
     /// </summary>
     public bool FailOnRegression { get; set; }
 
+    /// <summary>
+    ///     Maximum number of persisted run records to keep <i>per scenario</i> under
+    ///     <c>&lt;output&gt;/trawl/</c>. After persisting a new run, the oldest records (and their Markdown
+    ///     reports) beyond this count are pruned. <c>0</c> (default) keeps every run — no pruning. The most
+    ///     recent run is always retained, so baseline comparison is unaffected by any positive value.
+    /// </summary>
+    public int MaxRetainedRunsPerScenario { get; set; }
+
     /// <summary>A fresh instance with all-default (no-override) values.</summary>
     public static TrawlSettings Default => new();
 }

--- a/source/Tests.Library/Trawl/TrawlBaselineProviderTests.cs
+++ b/source/Tests.Library/Trawl/TrawlBaselineProviderTests.cs
@@ -45,4 +45,29 @@ public class TrawlBaselineProviderTests
             try { Directory.Delete(dir, true); } catch { /* ignore */ }
         }
     }
+
+    [Fact]
+    public void DoesNotConfuse_ScenariosThatShareANamePrefix()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_baseline_prefix_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var writer = new TrawlResultWriter();
+            // "Checkout" is a string-prefix of "CheckoutFast"; the "_" separator in the filename stem must
+            // keep their baselines distinct even though prefix-filtering drives the (efficient) lookup. The
+            // CheckoutFast record is newer, so a naive prefix match would wrongly return it for "Checkout".
+            writer.PersistRecord(new TrawlResult { DisplayName = "Checkout", RequestsPerSecond = 1, LatencySamplesMs = new[] { 1.0 } }, DateTime.UtcNow.AddMinutes(-5), dir);
+            writer.PersistRecord(new TrawlResult { DisplayName = "CheckoutFast", RequestsPerSecond = 999, LatencySamplesMs = new[] { 2.0 } }, DateTime.UtcNow, dir);
+
+            var baseline = new TrawlBaselineProvider().GetLatestBaseline("Checkout", dir);
+
+            baseline.ShouldNotBeNull();
+            baseline!.Result.DisplayName.ShouldBe("Checkout");
+            baseline.Result.RequestsPerSecond.ShouldBe(1); // not the newer CheckoutFast record
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
 }

--- a/source/Tests.Library/Trawl/TrawlResultWriterTests.cs
+++ b/source/Tests.Library/Trawl/TrawlResultWriterTests.cs
@@ -62,4 +62,62 @@ public class TrawlResultWriterTests
             try { Directory.Delete(dir, true); } catch { /* ignore */ }
         }
     }
+
+    [Fact]
+    public void PruneOldRecords_KeepsNewest_DeletesOlderPairs_AndLeavesOtherScenariosAlone()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_prune_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var writer = new TrawlResultWriter();
+            var baseTime = DateTime.UtcNow;
+
+            // Five runs of one scenario (json + md each), plus one run of an unrelated scenario.
+            for (var i = 0; i < 5; i++)
+            {
+                var t = baseTime.AddSeconds(i);
+                var r = new TrawlResult { DisplayName = "Svc.Run", RequestsPerSecond = i, LatencySamplesMs = new[] { 1.0 } };
+                writer.PersistRecord(r, t, dir);
+                writer.WriteReport($"# run {i}", r, t, dir);
+            }
+            var other = new TrawlResult { DisplayName = "Other.Run", LatencySamplesMs = new[] { 1.0 } };
+            writer.PersistRecord(other, baseTime, dir);
+            writer.WriteReport("# other", other, baseTime, dir);
+
+            writer.PruneOldRecords(new TrawlResult { DisplayName = "Svc.Run" }, dir, maxRetained: 2);
+
+            var trawlDir = TrawlResultWriter.TrawlDirectory(dir);
+            Directory.GetFiles(trawlDir, "Svc.Run_*.json").Length.ShouldBe(2); // newest two kept
+            Directory.GetFiles(trawlDir, "Svc.Run_*.md").Length.ShouldBe(2);   // matching reports pruned too
+            Directory.GetFiles(trawlDir, "Other.Run_*.json").Length.ShouldBe(1); // unrelated scenario untouched
+
+            // The most recent record (i = 4) must survive, so baseline comparison is unaffected.
+            new TrawlBaselineProvider().GetLatestBaseline("Svc.Run", dir)!.Result.RequestsPerSecond.ShouldBe(4);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public void PruneOldRecords_WithNonPositiveCap_KeepsEverything()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "trawl_prune_zero_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var writer = new TrawlResultWriter();
+            var baseTime = DateTime.UtcNow;
+            for (var i = 0; i < 3; i++)
+                writer.PersistRecord(new TrawlResult { DisplayName = "Svc.Run", LatencySamplesMs = new[] { 1.0 } }, baseTime.AddSeconds(i), dir);
+
+            writer.PruneOldRecords(new TrawlResult { DisplayName = "Svc.Run" }, dir, maxRetained: 0);
+
+            Directory.GetFiles(TrawlResultWriter.TrawlDirectory(dir), "Svc.Run_*.json").Length.ShouldBe(3);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* ignore */ }
+        }
+    }
 }


### PR DESCRIPTION
## What

Two related fixes to the persisted-run handling under `<output>/trawl/`.

### 1. Efficient baseline lookup (the perf fix)

`TrawlBaselineProvider.GetLatestBaseline` used to deserialize **every** `*.json` record in the directory — each carrying up to 10k latency doubles plus the per-second time-series — then filter by `DisplayName` in memory. That's O(runs × samples) per scenario per run and grows unbounded; bad for a tool designed to run repeatedly in CI.

Now it exploits the filename layout (`{Sanitize(displayName)}_{sortable-UTC-timestamp}.json`, where the embedded timestamp equals the record's `TimestampUtc`):

1. prefix-filter to the scenario's own candidates via a cheap directory listing (no file reads),
2. sort newest-first (the timestamp stem sorts lexically),
3. deserialize lazily and return the first **exact** `DisplayName` match.

So it touches a handful of files instead of all of them. The `_` separator keeps prefix-sharing scenarios distinct (`Checkout` vs `CheckoutFast`), and the exact-`DisplayName` check guards the rare case of two names sanitizing to the same stem. `Sanitize` is promoted to `internal` and shared from `TrawlResultWriter` so the two stay in lockstep.

### 2. Opt-in retention (the unbounded-growth fix)

New `TrawlSettings.MaxRetainedRunsPerScenario` (default `0` = keep everything, no pruning). After a run is persisted, `TrawlResultWriter.PruneOldRecords` trims the oldest `.json`/`.md` pairs for that scenario beyond the cap. **The most recent run is always retained**, so baseline comparison is never affected by a positive value. Pruning is opt-in by design — silently deleting a user's artifacts shouldn't be the default. Wired through the `.sailfish.json` DTO + `AdapterRunSettingsLoader` like every other Trawl setting:

```jsonc
{ "TrawlSettings": { "MaxRetainedRunsPerScenario": 50 } }
```

## Why

Finding #3a from the post-merge Trawl review.

## Testing

- New: baseline lookup is not confused by a shared name prefix; prune keeps the newest N, deletes older `.json`+`.md` pairs, leaves other scenarios untouched, and no-ops when the cap is `<= 0`.
- `dotnet build` (solution) clean; `Tests.Library` Trawl filter **36 passed** (was 33) on net9.0 + net10.0; `Tests.TestAdapter` Trawl **3 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)