### PR TITLE
Trawl: add WithTrawlWarmup + WithTrawlFailOnRegression builder methods

### DIFF
--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -186,6 +186,23 @@ public class RunSettingsBuilder
         return this;
     }
 
+    /// <summary>Overrides the warmup duration in seconds for every Trawl scenario (traffic generated but not measured).</summary>
+    public RunSettingsBuilder WithTrawlWarmup(double seconds)
+    {
+        (_trawlSettings ??= new TrawlSettings()).WarmupSecondsOverride = seconds;
+        return this;
+    }
+
+    /// <summary>
+    ///     Turns the Trawl regression gate on or off: when enabled, a scenario that has regressed
+    ///     significantly against its most recent prior run (per SailDiff) fails its test case.
+    /// </summary>
+    public RunSettingsBuilder WithTrawlFailOnRegression(bool failOnRegression = true)
+    {
+        (_trawlSettings ??= new TrawlSettings()).FailOnRegression = failOnRegression;
+        return this;
+    }
+
 
     /// <summary>
     ///     Provide a string array of class names to execute. This will run all test cases in a class decorated with the

--- a/source/Tests.Library/Trawl/TrawlSettingsWiringTests.cs
+++ b/source/Tests.Library/Trawl/TrawlSettingsWiringTests.cs
@@ -43,11 +43,25 @@ public class TrawlSettingsWiringTests
         var settings = RunSettingsBuilder.CreateBuilder()
             .WithTrawlVirtualUsers(16)
             .WithTrawlMaxDuration(45)
+            .WithTrawlWarmup(7)
+            .WithTrawlFailOnRegression()
             .DisableTrawl()
             .Build();
 
         settings.TrawlSettings.VirtualUsersOverride.ShouldBe(16);
         settings.TrawlSettings.MaxDurationSecondsOverride.ShouldBe(45.0);
+        settings.TrawlSettings.WarmupSecondsOverride.ShouldBe(7.0);
+        settings.TrawlSettings.FailOnRegression.ShouldBeTrue();
         settings.TrawlSettings.Disabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Builder_WithTrawlFailOnRegression_CanDisableExplicitly()
+    {
+        var settings = RunSettingsBuilder.CreateBuilder()
+            .WithTrawlFailOnRegression(false)
+            .Build();
+
+        settings.TrawlSettings.FailOnRegression.ShouldBeFalse();
     }
 }


### PR DESCRIPTION
## What

Fill the gap in the fluent `RunSettingsBuilder` Trawl surface. It already had `WithTrawlVirtualUsers`, `WithTrawlMaxDuration`, and `DisableTrawl`, but not:

- `WithTrawlWarmup(double seconds)` → `TrawlSettings.WarmupSecondsOverride`
- `WithTrawlFailOnRegression(bool failOnRegression = true)` → `TrawlSettings.FailOnRegression`

Both are first-class on `TrawlSettings` and already mapped from `.sailfish.json`, so they were reachable only via `WithTrawl(new TrawlSettings { ... })`. Notably the CI regression gate — arguably the headline Trawl feature — had no dedicated builder method.

## Why

Finding #3b from the post-merge Trawl review (builder API asymmetry).

## Testing

`Tests.Library` Trawl filter **34 passed** (net9.0 + net10.0); extended the granular-helpers wiring test and added one for explicitly disabling the gate.

> Note: `MaxRetainedRunsPerScenario` (added in #281) will get its own `WithTrawlRetention` helper as a small follow-up once that lands, to keep this PR independent of #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)