### PR TITLE
Trawl: bound scheduler waits (no infinite hang on a stuck SUT)

### DIFF
--- a/source/Sailfish/Execution/ArrivalRateScheduler.cs
+++ b/source/Sailfish/Execution/ArrivalRateScheduler.cs
@@ -23,13 +23,21 @@ namespace Sailfish.Execution;
 /// </summary>
 internal sealed class ArrivalRateScheduler
 {
+    /// <summary>
+    ///     How long the post-run drain waits for in-flight requests to finish before abandoning them. A
+    ///     scenario that hangs and ignores cancellation must not hang the whole run forever; this bounds the
+    ///     worst case to (run duration + this grace).
+    /// </summary>
+    private static readonly TimeSpan DefaultDrainGrace = TimeSpan.FromSeconds(30);
+
     public async Task<LoadRunData> RunAsync(
         Func<CancellationToken, ValueTask> invoke,
         double requestsPerSecond,
         TimeSpan duration,
         int maxInFlight,
         bool record,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? drainTimeout = null)
     {
         if (invoke is null) throw new ArgumentNullException(nameof(invoke));
         if (requestsPerSecond <= 0) requestsPerSecond = 1;
@@ -59,14 +67,23 @@ internal sealed class ArrivalRateScheduler
             await PaceUntilAsync(scheduledTimestamp, frequency, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) break;
 
+            // Acquire an in-flight slot, but bound the wait by the time left until the deadline: under
+            // sustained overload every slot can be occupied, and an unbounded wait here would block dispatch
+            // (and the whole run) past the run duration — indefinitely if a request hangs. If no slot frees
+            // before the deadline, the run is over, so stop dispatching.
+            var remainingToDeadline = TimeSpan.FromSeconds((deadlineTimestamp - Stopwatch.GetTimestamp()) / frequency);
+            if (remainingToDeadline <= TimeSpan.Zero) break;
+            bool acquiredSlot;
             try
             {
-                await inFlight.WaitAsync(cancellationToken).ConfigureAwait(false);
+                acquiredSlot = await inFlight.WaitAsync(remainingToDeadline, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 break;
             }
+
+            if (!acquiredSlot) break; // deadline reached while saturated
 
             var scheduled = scheduledTimestamp;
             _ = Task.Run(async () =>
@@ -96,9 +113,23 @@ internal sealed class ArrivalRateScheduler
             index++;
         }
 
-        // Drain: acquiring every permit can only succeed once all in-flight requests have released theirs.
-        for (var i = 0; i < maxInFlight; i++)
-            await inFlight.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        // Drain (bounded): acquiring every permit can only succeed once all in-flight requests have released
+        // theirs. A SUT that hangs and ignores cancellation must not hang the whole run forever, so we wait at
+        // most the drain grace and then abandon any stragglers. We dispose the semaphore only after a *full*
+        // drain — if we abandoned stragglers, one may still Release() it later, so disposing would risk an
+        // ObjectDisposedException on that abandoned task.
+        var grace = drainTimeout ?? DefaultDrainGrace;
+        var graceDeadline = Stopwatch.GetTimestamp() + (long)(Math.Max(0, grace.TotalSeconds) * frequency);
+        var acquired = 0;
+        while (acquired < maxInFlight)
+        {
+            var remaining = TimeSpan.FromSeconds((graceDeadline - Stopwatch.GetTimestamp()) / frequency);
+            if (remaining <= TimeSpan.Zero) break;
+            if (!await inFlight.WaitAsync(remaining, CancellationToken.None).ConfigureAwait(false)) break;
+            acquired++;
+        }
+
+        if (acquired == maxInFlight) inFlight.Dispose();
 
         var elapsedTimestamp = Stopwatch.GetTimestamp() - runStartTimestamp;
         var elapsed = TimeSpan.FromSeconds((double)elapsedTimestamp / frequency);

--- a/source/Sailfish/Execution/ClosedModelScheduler.cs
+++ b/source/Sailfish/Execution/ClosedModelScheduler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -63,12 +64,20 @@ internal sealed class LoadRunData
 /// </summary>
 internal sealed class ClosedModelScheduler
 {
+    /// <summary>
+    ///     How long to wait, beyond the run duration, for workers to finish before abandoning them. A scenario
+    ///     invocation that hangs (ignoring cancellation) would otherwise block the whole run forever; this
+    ///     bounds the worst case to (run duration + this grace).
+    /// </summary>
+    private static readonly TimeSpan DefaultDrainGrace = TimeSpan.FromSeconds(30);
+
     public async Task<LoadRunData> RunAsync(
         Func<CancellationToken, ValueTask> invoke,
         int virtualUsers,
         TimeSpan duration,
         bool record,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? drainTimeout = null)
     {
         if (invoke is null) throw new ArgumentNullException(nameof(invoke));
         if (virtualUsers < 1) virtualUsers = 1;
@@ -84,7 +93,7 @@ internal sealed class ClosedModelScheduler
             workers[i] = Task.Run(() => RunWorkerAsync(invoke, deadlineTimestamp, record, cancellationToken), CancellationToken.None);
         }
 
-        var workerResults = await Task.WhenAll(workers).ConfigureAwait(false);
+        var workerResults = await DrainWorkersAsync(workers, duration, drainTimeout ?? DefaultDrainGrace).ConfigureAwait(false);
 
         var elapsedTimestamp = Stopwatch.GetTimestamp() - runStartTimestamp;
         var elapsed = TimeSpan.FromSeconds((double)elapsedTimestamp / Stopwatch.Frequency);
@@ -141,6 +150,30 @@ internal sealed class ClosedModelScheduler
         }
 
         return new WorkerResult(samples ?? (IReadOnlyList<RequestSample>)Array.Empty<RequestSample>(), success, errors);
+    }
+
+    /// <summary>
+    ///     Awaits the virtual-user workers, but only up to the run duration plus a drain grace. Workers
+    ///     normally self-terminate at the deadline, so this completes promptly; if a scenario invocation hangs
+    ///     (ignoring cancellation) the budget elapses and we return the results of the workers that finished,
+    ///     abandoning the stuck ones rather than blocking the whole run forever.
+    /// </summary>
+    private static async Task<WorkerResult[]> DrainWorkersAsync(Task<WorkerResult>[] workers, TimeSpan duration, TimeSpan grace)
+    {
+        var all = Task.WhenAll(workers);
+        var budget = (duration > TimeSpan.Zero ? duration : TimeSpan.Zero) + grace;
+
+        using var graceCts = new CancellationTokenSource();
+        var finished = await Task.WhenAny(all, Task.Delay(budget, graceCts.Token)).ConfigureAwait(false);
+        if (finished == all)
+        {
+            graceCts.Cancel(); // release the pending timer
+            return await all.ConfigureAwait(false);
+        }
+
+        // Grace elapsed with workers still running — collect what completed, abandon the rest. RunWorkerAsync
+        // never throws, so a still-running worker is genuinely stuck rather than faulted.
+        return workers.Where(w => w.IsCompletedSuccessfully).Select(w => w.Result).ToArray();
     }
 
     private readonly struct WorkerResult

--- a/source/Tests.Library/Trawl/ArrivalRateSchedulerTests.cs
+++ b/source/Tests.Library/Trawl/ArrivalRateSchedulerTests.cs
@@ -66,4 +66,21 @@ public class ArrivalRateSchedulerTests
         sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
         data.ShouldNotBeNull();
     }
+
+    [Fact]
+    public async Task HungScenario_IsAbandonedAfterDrainGrace_RatherThanBlockingForever()
+    {
+        var scheduler = new ArrivalRateScheduler();
+        // Each request ignores cancellation and runs far longer than the run window + drain grace; once
+        // maxInFlight requests are stuck the drain must give up after the grace instead of waiting on them.
+        Func<CancellationToken, ValueTask> invoke = async _ => await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        var sw = Stopwatch.StartNew();
+        var data = await scheduler.RunAsync(invoke, requestsPerSecond: 50, TimeSpan.FromMilliseconds(150),
+            maxInFlight: 4, record: true, CancellationToken.None, drainTimeout: TimeSpan.FromMilliseconds(300));
+        sw.Stop();
+
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
+        data.ShouldNotBeNull();
+    }
 }

--- a/source/Tests.Library/Trawl/ClosedModelSchedulerTests.cs
+++ b/source/Tests.Library/Trawl/ClosedModelSchedulerTests.cs
@@ -93,4 +93,21 @@ public class ClosedModelSchedulerTests
         sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
         data.ShouldNotBeNull();
     }
+
+    [Fact]
+    public async Task HungScenario_IsAbandonedAfterDrainGrace_RatherThanBlockingForever()
+    {
+        var scheduler = new ClosedModelScheduler();
+        // Ignores cancellation and runs far longer than the run window + drain grace.
+        Func<CancellationToken, ValueTask> invoke = async _ => await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        var sw = Stopwatch.StartNew();
+        var data = await scheduler.RunAsync(invoke, virtualUsers: 3, TimeSpan.FromMilliseconds(150),
+            record: true, CancellationToken.None, drainTimeout: TimeSpan.FromMilliseconds(300));
+        sw.Stop();
+
+        // run window (~150ms) + drain grace (~300ms) + slack — nowhere near the 30s hung invocation.
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
+        data.ShouldNotBeNull();
+    }
 }


### PR DESCRIPTION
## What

Give both load schedulers a hard ceiling so a system under test that hangs and ignores its cancellation token can't hang the whole run forever.

### `ArrivalRateScheduler`

- **Dispatch loop (the real bug).** The in-flight permit was acquired with an **unbounded** `WaitAsync(cancellationToken)`. Under sustained overload every slot is occupied, so dispatch — and the whole run — blocked *past the run duration*, and **indefinitely** if a request hung. Now the wait is bounded by the time remaining until the deadline; if no slot frees by then, the run is over and we stop dispatching. This also makes the deadline authoritative under saturation. (My initial change only bounded the drain — the open-model hung test then waited the full 30s, which is exactly what surfaced this latent dispatch-side hang.)
- **Drain.** Waits at most a grace period for in-flight requests to finish, then abandons stragglers.

### `ClosedModelScheduler`

- Workers self-terminate at the deadline, but a hung invocation would block `Task.WhenAll` forever. `DrainWorkersAsync` waits at most `(duration + grace)`, then returns the results of the workers that finished and abandons the stuck ones.

### Semaphore disposal (#5d, done safely)

The open-model semaphore is now disposed — but **only after a full drain**. If we abandoned stragglers, one may still `Release()` it later, so disposing unconditionally (a plain `using`) would throw `ObjectDisposedException` on an abandoned task. The conditional dispose closes the "never disposed" nit without that hazard.

Default grace is 30s; both `RunAsync` methods take an optional `drainTimeout` so tests can drive it fast. The engine call sites are unchanged (new param is optional).

## Why

Findings #4a (no hard ceiling on a hung scenario) and #5d (semaphore disposal) from the post-merge Trawl review — plus the dispatch-side hang the hung-scenario test then exposed.

## Testing

New hung-scenario test per scheduler (invocation ignores cancellation and runs 30s; the run must return within ~3s). `Tests.Library` Trawl filter **35 passed** on net9.0 + net10.0 — and total suite time dropped from ~31s (pre-fix, waiting on the hang) back to ~1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)