### PR TITLE
Trawl: report polish — p75 column, tail-second throughput, shared stride

### DIFF
--- a/source/Sailfish/Execution/TrawlExecutionEngine.cs
+++ b/source/Sailfish/Execution/TrawlExecutionEngine.cs
@@ -169,7 +169,7 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
         var stats = LatencyStatsCalculator.Compute(latenciesMs);
         var throughput = runData.Elapsed.TotalSeconds > 0 ? totalRequests / runData.Elapsed.TotalSeconds : 0;
         var errorRate = totalRequests > 0 ? (double)runData.ErrorCount / totalRequests : 0;
-        var timeSeries = TrawlTimeSeriesCalculator.Compute(runData.Samples, runData.RunStartTimestamp, frequency);
+        var timeSeries = TrawlTimeSeriesCalculator.Compute(runData.Samples, runData.RunStartTimestamp, frequency, runData.Elapsed.TotalSeconds);
 
         var trawlResult = new TrawlResult
         {
@@ -238,13 +238,21 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
         }
     }
 
+    /// <summary>
+    ///     Uniform down-sampling stride so that at most <see cref="MaxInjectedSamples" /> items survive.
+    ///     Shared by <see cref="Downsample" /> and <see cref="InjectSamples" /> so the persisted/plotted sample
+    ///     set and the timer-injected set stay in lockstep.
+    /// </summary>
+    private static int DownsampleStride(int count)
+        => count > MaxInjectedSamples ? (int)Math.Ceiling(count / (double)MaxInjectedSamples) : 1;
+
     /// <summary>Caps the latency sample array for plotting/persistence via uniform stride down-sampling.</summary>
     private static double[] Downsample(double[] all)
     {
         var count = all.Length;
         if (count <= MaxInjectedSamples) return all;
 
-        var stride = (int)Math.Ceiling(count / (double)MaxInjectedSamples);
+        var stride = DownsampleStride(count);
         var size = (count + stride - 1) / stride;
         var result = new double[size];
         var j = 0;
@@ -264,7 +272,7 @@ internal sealed class TrawlExecutionEngine : ITrawlExecutionEngine
         var count = samples.Count;
         if (count == 0) return;
 
-        var stride = count > MaxInjectedSamples ? (int)Math.Ceiling(count / (double)MaxInjectedSamples) : 1;
+        var stride = DownsampleStride(count);
         for (var i = 0; i < count; i += stride)
         {
             var sample = samples[i];

--- a/source/Sailfish/Execution/TrawlReportRenderer.cs
+++ b/source/Sailfish/Execution/TrawlReportRenderer.cs
@@ -24,9 +24,9 @@ internal static class TrawlReportRenderer
         sb.AppendLine($"- Model: **{result.Model}** | Virtual users: **{result.VirtualUsers}** | Duration: **{result.Duration.TotalSeconds:0.##}s**");
         sb.AppendLine($"- Throughput: **{result.RequestsPerSecond:0.#} req/s** | Requests: **{result.TotalRequests}** | Errors: **{result.TotalErrors}** ({result.ErrorRate:0.##%})");
         sb.AppendLine();
-        sb.AppendLine("| latency (ms) | p50 | p90 | p95 | p99 | max | mean | min |");
-        sb.AppendLine("|---|----:|----:|----:|----:|----:|-----:|----:|");
-        sb.AppendLine($"| | {latency.P50:0.##} | {latency.P90:0.##} | {latency.P95:0.##} | {latency.P99:0.##} | {latency.Max:0.##} | {latency.Mean:0.##} | {latency.Min:0.##} |");
+        sb.AppendLine("| latency (ms) | p50 | p75 | p90 | p95 | p99 | max | mean | min |");
+        sb.AppendLine("|---|----:|----:|----:|----:|----:|----:|-----:|----:|");
+        sb.AppendLine($"| | {latency.P50:0.##} | {latency.P75:0.##} | {latency.P90:0.##} | {latency.P95:0.##} | {latency.P99:0.##} | {latency.Max:0.##} | {latency.Mean:0.##} | {latency.Min:0.##} |");
         sb.AppendLine();
 
         if (result.LatencySamplesMs.Length > 0)

--- a/source/Sailfish/Execution/TrawlTimeSeriesCalculator.cs
+++ b/source/Sailfish/Execution/TrawlTimeSeriesCalculator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Sailfish.Contracts.Public.Models;
 
@@ -10,7 +11,12 @@ namespace Sailfish.Execution;
 /// </summary>
 internal static class TrawlTimeSeriesCalculator
 {
-    public static TrawlTimeSeries Compute(IReadOnlyList<RequestSample> samples, long runStartTimestamp, long frequency)
+    /// <param name="measuredSeconds">
+    ///     The measured window's total duration in seconds. When provided (&gt; 0) and the run's final whole
+    ///     second is a partial second, that last bucket's count is scaled up to a per-second rate so the
+    ///     throughput series doesn't show a misleading dip at the tail. Pass 0 to bucket by raw counts only.
+    /// </param>
+    public static TrawlTimeSeries Compute(IReadOnlyList<RequestSample> samples, long runStartTimestamp, long frequency, double measuredSeconds = 0)
     {
         if (samples is null || samples.Count == 0 || frequency <= 0) return TrawlTimeSeries.Empty;
 
@@ -40,6 +46,18 @@ internal static class TrawlTimeSeriesCalculator
             rps[i] = bucket.Value.Count; // a one-second bucket, so the count is requests/second
             p99[i] = LatencyStatsCalculator.Compute(bucket.Value).P99;
             i++;
+        }
+
+        // The run's final whole second is usually only partially elapsed, so its raw count understates the
+        // rate — a misleading dip at the tail, which in a load test is exactly where degradation shows. When
+        // the measured duration is known and its last whole second is the final populated bucket, scale that
+        // bucket up to a per-second rate by the fraction of a second it actually spans.
+        if (measuredSeconds > 0)
+        {
+            var last = count - 1;
+            var fraction = measuredSeconds - offsets[last];
+            if (offsets[last] == Math.Floor(measuredSeconds) && fraction > 1e-6 && fraction < 1.0)
+                rps[last] /= fraction;
         }
 
         return new TrawlTimeSeries { SecondOffsets = offsets, RequestsPerSecond = rps, P99Ms = p99 };

--- a/source/Tests.Library/Trawl/TrawlReportRendererTests.cs
+++ b/source/Tests.Library/Trawl/TrawlReportRendererTests.cs
@@ -20,7 +20,7 @@ public class TrawlReportRendererTests
         TotalErrors = 6,
         RequestsPerSecond = 100,
         ErrorRate = 0.02,
-        Latency = new LatencyStats { Min = 1, Mean = 6, P50 = 5, P90 = 12, P95 = 18, P99 = 40, Max = 80 },
+        Latency = new LatencyStats { Min = 1, Mean = 6, P50 = 5, P75 = 8, P90 = 12, P95 = 18, P99 = 40, Max = 80 },
         LatencySamplesMs = new[] { 1.0, 2, 3, 5, 8, 12, 18, 40, 80 },
         TimeSeries = new TrawlTimeSeries
         {
@@ -37,6 +37,7 @@ public class TrawlReportRendererTests
 
         report.ShouldContain("Trawl — My.Load(scenario: 1)");
         report.ShouldContain("req/s");
+        report.ShouldContain("p75"); // the p75 percentile is now surfaced in the table
         report.ShouldContain("p99");
         report.ShouldContain("Throughput/s");
     }

--- a/source/Tests.Library/Trawl/TrawlTimeSeriesCalculatorTests.cs
+++ b/source/Tests.Library/Trawl/TrawlTimeSeriesCalculatorTests.cs
@@ -41,4 +41,25 @@ public class TrawlTimeSeriesCalculatorTests
         ts.P99Ms[0].ShouldBe(30, 0.5); // nearest-rank p99 of {10,20,30}
         ts.P99Ms[1].ShouldBe(50, 0.5);
     }
+
+    [Fact]
+    public void NormalizesTrailingPartialSecond_WhenMeasuredDurationProvided()
+    {
+        const long runStart = 5_000_000;
+        var samples = new List<RequestSample>
+        {
+            // second 0: three requests (a full second)
+            new(At(0.1, runStart), Ms(10)),
+            new(At(0.5, runStart), Ms(10)),
+            new(At(0.9, runStart), Ms(10)),
+            // second 1: two requests, but the run only ran 0.4s into this second
+            new(At(1.1, runStart), Ms(20)),
+            new(At(1.3, runStart), Ms(20)),
+        };
+
+        var ts = TrawlTimeSeriesCalculator.Compute(samples, runStart, Freq, measuredSeconds: 1.4);
+
+        ts.RequestsPerSecond[0].ShouldBe(3);       // full second — left as the raw count
+        ts.RequestsPerSecond[1].ShouldBe(5, 0.01); // 2 requests / 0.4s ≈ 5 req/s, not a misleading "2"
+    }
 }


### PR DESCRIPTION
## What

Three small reporting fixes from the post-merge Trawl review.

- **Show p75 (#5a).** `LatencyStats` computed `P75` but `TrawlReportRenderer` never displayed it. Added the `p75` column (and its separator) so the surfaced percentiles match what's calculated.

- **Fix the misleading tail-second throughput (#5b).** The run's final whole-second bucket is usually only partially elapsed, so its raw request count understated the rate — a dip at the tail, which in a load test is exactly where degradation shows. `TrawlTimeSeriesCalculator.Compute` now takes the measured duration and scales that last partial second up to a proper per-second rate (keeping the data rather than dropping the bucket). The parameter is optional, so the raw-count behaviour — and the existing test — are preserved when it isn't supplied.

- **Share the down-sample stride (#3c).** `Downsample` and `InjectSamples` each inlined the same `ceil(count / MaxInjectedSamples)` stride. Extracted `DownsampleStride` so the persisted/plotted sample set and the timer-injected set can't drift apart.

## Why

Findings #5a, #5b, #3c from the post-merge Trawl review.

## Testing

`Tests.Library` Trawl filter **34 passed** (net9.0 + net10.0): p75 now appears in the rendered table, and the trailing partial second is normalized (2 requests over 0.4s reads as ~5 req/s, not a misleading 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)