### PR TITLE
docs(trawl): ship XML docs to consumers; complete Trawl API docs

### DIFF
--- a/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
+++ b/source/Sailfish.TestAdapter/Sailfish.TestAdapter.csproj
@@ -11,6 +11,11 @@
         <RootNamespace>Sailfish.TestAdapter</RootNamespace>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
+        <!-- Ship XML docs in the package so public members surface in consumer IntelliSense; CS1591 is
+             suppressed repo-wide (documented incrementally, build not gated on full coverage). Mirrors
+             the Sailfish library. -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/source/Sailfish/Analysis/SailDiff/Statistics/EffectSizes.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/EffectSizes.cs
@@ -16,8 +16,8 @@ namespace Sailfish.Analysis.SailDiff.Statistics;
 /// both the significance decision <em>and</em> the magnitude band the user sees.
 /// </para>
 /// <para>
-/// References: Hedges & Olkin (1985) for Hedges' g; Cliff (1993) and Romano et al. (2006)
-/// for Cliff's delta variance; Hollander, Wolfe & Chicken §4.2 for the Hodges-Lehmann
+/// References: Hedges &amp; Olkin (1985) for Hedges' g; Cliff (1993) and Romano et al. (2006)
+/// for Cliff's delta variance; Hollander, Wolfe &amp; Chicken §4.2 for the Hodges-Lehmann
 /// estimator and its distribution-free CI.
 /// </para>
 /// </remarks>
@@ -120,7 +120,7 @@ internal static class EffectSizes
     /// </summary>
     /// <remarks>
     /// CI uses the distribution-free formula based on the rank-sum critical value
-    /// (Hollander, Wolfe & Chicken §4.2, "Estimation Associated with the Wilcoxon Rank Sum
+    /// (Hollander, Wolfe &amp; Chicken §4.2, "Estimation Associated with the Wilcoxon Rank Sum
     /// Test"): the kth and (n1·n2 − k + 1)th smallest pairwise differences, where k is
     /// chosen so the CI's coverage is at least <c>1 − alpha</c>. The exact k comes from
     /// the rank-sum critical value at α/2.

--- a/source/Sailfish/Analysis/SailDiff/Statistics/MultipleComparisons.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/MultipleComparisons.cs
@@ -82,7 +82,7 @@ namespace Sailfish.Analysis.SailDiff.Statistics
         /// <summary>
         /// Compute a ratio-based effect size and CI using a log-normal (delta-method) approximation.
         /// ratio = meanB / meanA. CI computed on log scale using SEs, then exponentiated.
-        /// If inputs are degenerate (means <= 0 or SEs not available), returns ratio with null CI.
+        /// If inputs are degenerate (means &lt;= 0 or SEs not available), returns ratio with null CI.
         /// </summary>
         public static (double Ratio, double? Lower, double? Upper) ComputeRatioCi(
             double meanA, double seA, int nA,

--- a/source/Sailfish/Analysis/SailDiff/Statistics/StatsCore/Distributions/WilcoxonDistribution.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/StatsCore/Distributions/WilcoxonDistribution.cs
@@ -19,7 +19,7 @@ namespace Sailfish.Analysis.SailDiff.Statistics.StatsCore.Distributions;
 /// </para>
 /// <para>
 /// <strong>Discrete CDF convention.</strong> Both
-/// <see cref="DistributionFunction"/> and <see cref="ComplementaryDistributionFunction"/>
+/// <c>DistributionFunction</c> and <c>ComplementaryDistributionFunction</c>
 /// include the queried point: <c>F(w) = P(W+ ≤ w)</c> and <c>F_c(w) = P(W+ ≥ w)</c>.
 /// Together they sum to <c>1 + P(W+ = w)</c>, not 1 — the same convention used by
 /// <see cref="MannWhitneyDistribution"/> so the signed-rank wrapper's two-tailed p-value

--- a/source/Sailfish/Attributes/SailfishMethodAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishMethodAttribute.cs
@@ -22,8 +22,6 @@ public sealed class SailfishMethodAttribute : Attribute
     /// <summary>
     ///     Initializes a new instance of the <see cref="SailfishMethodAttribute" /> class.
     /// </summary>
-    /// <param name="disabled">Whether or not to ignore the given test method</param>
-    /// <param name="disableComplexity">Whether or not to disable complexity analysis for this method</param>
     public SailfishMethodAttribute()
     {
     }

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -23,7 +23,11 @@ public interface IRunSettings
     ScaleFishSettings ScaleFishSettings { get; }
     AiAnalysisSettings AiAnalysisSettings { get; }
 
-    // Trawl (load testing) global settings/overrides for [Trawl] load scenarios
+    /// <summary>
+    ///     Run-wide Trawl (load testing) settings and overrides applied to every <c>[Trawl]</c> load
+    ///     scenario in the run (kill switch, virtual-user / duration / warmup overrides, the regression
+    ///     gate, and run retention). See <see cref="Sailfish.Trawl.TrawlSettings" />.
+    /// </summary>
     TrawlSettings TrawlSettings { get; }
     IEnumerable<Type> TestLocationAnchors { get; }
     IEnumerable<Type> RegistrationProviderAnchors { get; }

--- a/source/Sailfish/Contracts.Public/Models/TrawlRegressionVerdict.cs
+++ b/source/Sailfish/Contracts.Public/Models/TrawlRegressionVerdict.cs
@@ -22,6 +22,7 @@ public enum TrawlRegressionOutcome
 /// </summary>
 public sealed record TrawlRegressionVerdict
 {
+    /// <summary>The categorical outcome of the comparison (improved / regressed / not significant / inconclusive).</summary>
     public TrawlRegressionOutcome Outcome { get; init; }
 
     /// <summary>Percentage change in mean latency vs baseline; positive means slower (a regression).</summary>

--- a/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
+++ b/source/Sailfish/Contracts.Public/Models/TrawlResult.cs
@@ -99,6 +99,7 @@ public sealed record TrawlTimeSeries
     /// <summary>p99 latency (ms) within each one-second bucket.</summary>
     public double[] P99Ms { get; init; } = Array.Empty<double>();
 
+    /// <summary>An empty instance (all arrays zero-length), used when no time series was captured.</summary>
     public static TrawlTimeSeries Empty => new();
 }
 
@@ -108,6 +109,9 @@ public sealed record TrawlTimeSeries
 /// </summary>
 public sealed record TrawlRunRecord
 {
+    /// <summary>UTC wall-clock time at which this run was captured and persisted.</summary>
     public DateTime TimestampUtc { get; init; }
+
+    /// <summary>The captured run summary.</summary>
     public TrawlResult Result { get; init; } = new();
 }

--- a/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
@@ -42,7 +42,7 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
 
     /// <summary>
     /// Preferred constructor: takes the optional <see cref="IRunSettings"/> so the BH-FDR
-    /// q-value threshold honours the user-configured <see cref="SailDiffSettings.Alpha"/>
+    /// q-value threshold honours the user-configured <c>SailDiffSettings.Alpha</c>
     /// instead of defaulting to 0.05. The DI container selects this overload when all
     /// dependencies are available (multiple ctors → MediatR picks the longest match).
     /// </summary>

--- a/source/Sailfish/Execution/CompiledInvoker.cs
+++ b/source/Sailfish/Execution/CompiledInvoker.cs
@@ -9,7 +9,7 @@ namespace Sailfish.Execution;
 
 /// <summary>
 ///     Builds a compiled, allocation-free delegate that invokes a Sailfish benchmark method
-///     <b>directly</b> — no <see cref="MethodInfo.Invoke" /> per call — normalizing every supported
+///     <b>directly</b> — no <c>MethodInfo.Invoke</c> per call — normalizing every supported
 ///     return shape (<c>void</c>, <see cref="Task" />, <c>Task&lt;T&gt;</c>, <see cref="ValueTask" />,
 ///     <c>ValueTask&lt;T&gt;</c>) to a single <see cref="Func{CancellationToken, ValueTask}" /> shape.
 ///     <para>

--- a/source/Sailfish/Execution/TrawlTimeSeriesCalculator.cs
+++ b/source/Sailfish/Execution/TrawlTimeSeriesCalculator.cs
@@ -11,6 +11,9 @@ namespace Sailfish.Execution;
 /// </summary>
 internal static class TrawlTimeSeriesCalculator
 {
+    /// <param name="samples">The per-request latency samples captured during the measured window.</param>
+    /// <param name="runStartTimestamp">Stopwatch timestamp marking the start of the measured window.</param>
+    /// <param name="frequency">Stopwatch tick frequency (ticks per second), used to convert raw timestamps to seconds.</param>
     /// <param name="measuredSeconds">
     ///     The measured window's total duration in seconds. When provided (&gt; 0) and the run's final whole
     ///     second is a partial second, that last bucket's count is scaled up to a per-second rate so the

--- a/source/Sailfish/Presentation/AsciiHistogramRenderer.cs
+++ b/source/Sailfish/Presentation/AsciiHistogramRenderer.cs
@@ -38,6 +38,7 @@ public static class AsciiHistogramRenderer
     /// <param name="unit">Display unit; samples (ms) are converted to it for the axis and labels.</param>
     /// <param name="measure">Axis title prefix, e.g. "Time" → "Time (ms)".</param>
     /// <param name="plotWidth">Width of the plot area in characters.</param>
+    /// <param name="bins">Number of histogram bins the value range is divided into.</param>
     public static string Render(IReadOnlyList<DistributionData> distributions, DurationUnit unit, string measure = "Time", int plotWidth = DefaultPlotWidth, int bins = 12)
     {
         if (distributions is null) return string.Empty;

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -133,6 +133,7 @@ internal class RunSettings : IRunSettings
     public bool EnableDistributionPlots { get; }
     public bool EmitDistributionHtmlReport { get; }
     public DistributionPlotStyle DistributionPlotStyle { get; }
+    /// <inheritdoc />
     public TrawlSettings TrawlSettings { get; }
 
     public LogLevel MinimumLogLevel { get; }

--- a/source/Sailfish/Sailfish.csproj
+++ b/source/Sailfish/Sailfish.csproj
@@ -11,6 +11,14 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
+        <!-- Emit the XML documentation file and pack it alongside the DLL so the /// summaries on our
+             public API (Trawl attributes/settings, the RunSettings builder, the public contracts, ...)
+             surface in consumers' IntelliSense. Without this, none of those comments ever reach a package
+             consumer. CS1591 ("missing XML comment for publicly visible type or member") is suppressed
+             repo-wide: we document the public surface incrementally and do not gate the build on full
+             coverage. The XML still ships docs for every member that IS documented. -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
         <IsPackable>true</IsPackable>
         <DebugSymbols>True</DebugSymbols>
         <DebugType>Embedded</DebugType>


### PR DESCRIPTION
## Why

`VirtualUsers` — and most of the Trawl API — showed **no docs in IntelliSense** for package consumers. The cause wasn't missing comments: the Trawl surface was already ~90% documented in source. **`GenerateDocumentationFile` was set nowhere in the repo**, so the compiler never emitted `Sailfish.xml` and NuGet never packed it. Consumers therefore saw zero XML docs no matter how many `///` comments existed. (In-solution project references still surface them from source, which masked the gap.)

## What

**Ship the docs (the actual fix)**
- Enable `GenerateDocumentationFile` + `<NoWarn>$(NoWarn);CS1591</NoWarn>` in the two packable libraries — `Sailfish` and `Sailfish.TestAdapter`. CS1591 ("missing XML comment") is suppressed repo-wide so we document incrementally rather than gating the build on full coverage; the XML still ships docs for every member that has them. (`Sailfish.Analyzers` left alone — it ships as a Roslyn analyzer DLL, not a callable API.)

**Complete the Trawl public surface**
- Documented the last bare public members: `IRunSettings.TrawlSettings`, `RunSettings.TrawlSettings`, `TrawlRunRecord.{TimestampUtc,Result}`, `TrawlTimeSeries.Empty`, `TrawlRegressionVerdict.Outcome`, and the missing `<param>` tags on `TrawlTimeSeriesCalculator.Compute`.

**Fix latent doc bugs surfaced by doc-gen**
- Turning on doc-gen made the compiler validate existing comments, exposing ~11 pre-existing defects in non-Trawl files: unescaped `&`/`<` corrupting XML (`EffectSizes`, `MultipleComparisons`), broken `<see cref>` links (`WilcoxonDistribution`, `CompiledInvoker`, `CsvTestRunCompletedHandler`), and stale/missing `<param>` tags (`SailfishMethodAttribute`, `AsciiHistogramRenderer`). Fixed rather than suppressed — they were real bugs.

## Verification
- `Sailfish`: **0 warnings, 0 errors**
- `Sailfish.TestAdapter`: 0 errors (2 pre-existing unrelated `CS0618`)
- Full solution: **0 errors** (remaining warnings are pre-existing, all in test projects)
- `Sailfish.xml` now generates for `net9.0` + `net10.0` and contains the full Trawl surface. `VirtualUsers` now ships *"Number of concurrent virtual users (closed model). Default 10."* to consumer IntelliSense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced XML documentation comments across analysis, attribute, and model files for improved clarity
  * Updated documentation formatting and added missing parameter descriptions
  * Fixed XML escape sequences in documentation comments

* **Chores**
  * Configured projects to generate and include XML documentation files in package outputs
  * Suppressed documentation-related compiler warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->