### PR TITLE
fix(saildiff): correct inverted baseline verdicts in comparison output

### DIFF
--- a/docs/diagnosis/baseline-verdict-inversion.md
+++ b/docs/diagnosis/baseline-verdict-inversion.md
@@ -1,0 +1,286 @@
+# Diagnosis: inverted baseline verdicts in the IDE comparison / SailDiff output
+
+**Surfaced on:** Sailfish.TestAdapter 4.0.136
+**Status:** **FIXED in this PR.** Root cause below; the regression test (which failed against the
+pre-fix code) now passes, and the fix is verified end-to-end with a real RELEASE run (§6).
+
+---
+
+## 1. Summary
+
+When a `[SailfishMethod(ComparisonGroup = "…", IsBaseline = true)]` comparison group is run
+through the **TestAdapter**, the IDE "IMPACT" verdict lines (and the detailed table, console
+table, CSV, and distribution-plot caption built from the same data) come out wrong in two ways:
+
+1. **Wrong baseline identity.** The method flagged `IsBaseline = true` is *not* used as the
+   baseline. The IDE comparison path never reads `IsBaseline` at all — it emits an
+   order-dependent N×N matrix and labels one side of each pair "baseline."
+2. **Inverted / transposed verdict.** For half the emitted lines the named method and its printed
+   mean are transposed, so the slowest method is reported as the fastest.
+
+Both are reproduced deterministically (no real timing) by
+[`MethodComparisonBatchProcessor_BaselineInversionTests`](../../source/Tests.TestAdapter/Queue/MethodComparisonBatchProcessor_BaselineInversionTests.cs),
+which drives the **real** formatter through the production `MethodComparisonBatchProcessor` and
+**fails** against current code. A live (disabled-by-default) benchmark repro is at
+[`BaselineVerdictInversionRepro`](../../source/PerformanceTests/ExamplePerformanceTests/BaselineVerdictInversionRepro.cs).
+
+### Captured evidence (from the failing test, synthetic means)
+
+Ground truth fed in: `WithPlus` (the `IsBaseline` method) is the **slowest**
+(`N:100 → 8 ms`, `N:10000 → 240 ms`); `WithStringBuilder` is the **fastest**
+(`N:100 → 1 ms`, `N:10000 → 4 ms`).
+
+`WithStringBuilder`'s test row prints (WRONG — the reported symptom):
+
+```
+🟢 IMPACT: WithPlus(N: 10000) is 99.6% faster than baseline WithStringBuilder(N: 100) (IMPROVED)
+   P-Value: 0.000000 | Mean: 240.000 ms → 1.000 ms
+```
+
+`240 ms` is `WithPlus`'s mean but is printed on the `baseline WithStringBuilder` side; `1 ms` is
+`WithStringBuilder`'s mean but printed as the `WithPlus` value. `WithPlus` is reported "faster"
+when it is ~160× **slower**. This is identical in shape to the field report
+(`WithPlus(N: 1000) is 99.4% faster than baseline WithStringBuilder(N: 100) | Mean: 178.815 µs → 1.102 µs`).
+
+`WithPlus`'s own test row prints the *same* pair correctly:
+
+```
+🟢 IMPACT: WithStringBuilder(N: 100) is 87.5% faster than baseline WithPlus(N: 100) (IMPROVED)
+   P-Value: 0.000000 | Mean: 8.000 ms → 1.000 ms
+```
+
+The "only rows whose **candidate** is the baseline-flagged method invert" pattern from the field
+report is confirmed and explained in §3.3.
+
+### Real-timing confirmation (RELEASE run through the live TestAdapter)
+
+The same defect reproduces with genuine measurements. Running
+[`BaselineVerdictInversionRepro`](../../source/PerformanceTests/ExamplePerformanceTests/BaselineVerdictInversionRepro.cs)
+in `-c Release` through the TestAdapter, `WithStringBuilder(N: 100)`'s row prints:
+
+```
+🟢 IMPACT: WithPlus(N: 10000) is 100.0% faster than baseline WithStringBuilder(N: 100) (IMPROVED)
+   P-Value: 0.000000 | Mean: 18.966 ms → 0.001 ms
+```
+
+`18.966 ms` is `WithPlus(N: 10000)`'s real O(n²) mean, printed on the `baseline WithStringBuilder`
+side; `0.001 ms` (StringBuilder) is printed as the `WithPlus` value. The slowest method is reported
+"faster" — the exact field symptom, just at different N/magnitude. The correct counterpart on
+`WithPlus`'s own row reads `WithStringBuilder(N: 100) is 80.7% faster than baseline WithPlus(N: 100)`.
+The run also emitted cross-N rows such as
+`WithPlus(N: 100) is 850.2% slower than baseline WithStringBuilder(N: 10000)` (see §5.3).
+
+---
+
+## 2. The two responsible mechanisms
+
+### 2.1 Symptom 2 (inversion/transposition): a dead perspective-swap guard
+
+There is exactly **one** producer of perspective-based comparison data:
+`MethodComparisonBatchProcessor.FormatComparisonResults`
+([`MethodComparisonBatchProcessor.cs:454-475`](../../source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs)).
+For one SailDiff pair (`before = methodA`, `after = methodB`) it builds **two**
+`SailDiffComparisonData` objects, one per "perspective":
+
+```csharp
+var result = comparisonResult.SailDiffResults.First();
+var isBeforePerspective = perspectiveMethodName == beforeMethodName;
+var primaryMethod  = ExtractMethodName(perspectiveMethodName);                                 // leaf name
+var comparedMethod = ExtractMethodName(isBeforePerspective ? afterMethodName : beforeMethodName);
+
+var comparisonData = new SailDiffComparisonData
+{
+    GroupName            = groupName,
+    PrimaryMethodName    = primaryMethod,     // the perspective method is ALWAYS named the "baseline"
+    ComparedMethodName   = comparedMethod,
+    Statistics           = result.TestResultsWithOutlierAnalysis.StatisticalTestResult, // MeanBefore=mean(A), MeanAfter=mean(B)
+    …
+    IsPerspectiveBased   = true,
+    PerspectiveMethodName = perspectiveMethodName    // a FULLY-QUALIFIED TestCaseId ("Ns.Class.M(N: x)")
+};
+```
+
+Every consumer then decides whether to swap before/after with the **same predicate**:
+
+```csharp
+// ImpactSummaryFormatter.AnalyzeComparison (lines 55-60) — the IMPACT verdict line
+var primaryTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
+    ? display.MeanAfter
+    : display.MeanBefore;
+var comparedTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
+    ? display.MeanBefore
+    : display.MeanAfter;
+```
+
+The guard `PerspectiveMethodName == ComparedMethodName` is **dead** — it can never be true — for
+two independent reasons:
+
+- **(D1) Wrong role.** The producer always assigns the perspective method to `PrimaryMethodName`
+  (`primaryMethod = ExtractMethodName(perspectiveMethodName)`). The perspective method is therefore
+  **never** the `ComparedMethodName`. The intent was "swap when this row is rendered from the
+  *after* method's perspective," i.e. `perspectiveMethodName == afterMethodName` — but the code
+  compares against the *compared* method instead.
+- **(D2) Key/format mismatch.** `PerspectiveMethodName` is a **fully-qualified** TestCaseId
+  (`"SailfishBugRepro.BaselineVerdictInversionRepro.WithStringBuilder(N: 100)"`), while
+  `ComparedMethodName` is the **leaf** name produced by `ExtractMethodName`
+  (`"WithPlus(N: 100)"`). A full-id-vs-leaf compare cannot match even if D1 were fixed. This is the
+  "TestCaseId not fully qualified on both sides" keying collision hypothesized in the brief: the
+  branch that *should* realign the operands is silently skipped, so the after-perspective operands
+  stay transposed relative to the labels.
+
+Because the guard is always false, **every** consumer uses `primaryTime = MeanBefore`,
+`comparedTime = MeanAfter` regardless of perspective:
+
+| Perspective | Verdict baseline (`PrimaryMethodName`) | `primaryTime` used | Correct? |
+|---|---|---|---|
+| before (methodA's row) | A | `MeanBefore` = mean(A) | ✅ name ↔ mean aligned |
+| after  (methodB's row) | B | `MeanBefore` = mean(A) | ❌ baseline named **B** but shows mean(**A**) |
+
+The after-perspective row is exactly the symptom: baseline named B carries A's mean, candidate
+named A carries B's mean, and the direction (`(comparedTime-primaryTime)/primaryTime`) is computed
+on the still-A/B times, so it points the wrong way relative to the swapped names.
+
+### 2.2 Symptom 1 (wrong baseline identity): `IsBaseline` is never consulted
+
+The TestAdapter comparison path contains **zero** references to `IsBaseline`
+(`grep -r IsBaseline source/Sailfish.TestAdapter` → no hits). Pairing is a pure, order-dependent
+N×N over every case in the batch
+([`MethodComparisonBatchProcessor.cs:145-162`](../../source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs)):
+
+```csharp
+for (var i = 0; i < testCases.Count; i++)
+for (var j = i + 1; j < testCases.Count; j++)
+{
+    var methodA = testCases[i];   // treated as "before"
+    var methodB = testCases[j];   // treated as "after"
+    …
+    await PerformMethodComparison(methodA, methodB, groupName, cancellationToken);
+}
+```
+
+The word "baseline" in the IDE output is therefore just the `PrimaryMethodName` = the perspective
+method of whichever row you're reading — never the `IsBaseline`-flagged method. In the captured run
+`WithStringBuilder`'s rows even label `WithStringBuilder` as the baseline.
+
+> Contrast: the **markdown** path (`MethodComparisonTestRunCompletedHandler.CreateBaselineComparisonTable`,
+> [lines 348-372 / 616-689](../../source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs))
+> *does* resolve the baseline from `IsBaseline` and keys the baseline case with `ReferenceEquals`
+> (no name collision). That path is correct for the single-baseline case and is **not** affected by
+> this bug — which is why the regression only shows up in the IDE / TestAdapter output.
+
+---
+
+## 3. Confirmation that this is the path (not a hash collision)
+
+### 3.1 The IDE `🟢 IMPACT … | Mean: A → B` format is `ImpactSummaryFormatter.CreateIdeImpactSummary`
+
+`ImpactSummaryFormatter.BuildVerdict`
+([ImpactSummaryFormatter.cs:154-160](../../source/Sailfish/Analysis/SailDiff/Formatting/ImpactSummaryFormatter.cs))
+emits `"{ComparedMethodName} is {pct}% {faster|slower} than baseline {PrimaryMethodName} ({SIG})"`,
+and `CreateIdeImpactSummary` appends `"   P-Value: … | Mean: {primaryTime} → {comparedTime}"`. This
+matches the field report byte-for-byte.
+
+### 3.2 Operand mapping is faithful
+
+`AdapterSailDiff.ComputeTestCaseDiff`
+([AdapterSailDiff.cs:88-106](../../source/Sailfish.TestAdapter/Execution/AdapterSailDiff.cs)) sets
+`before = preloadedLastRun` (= `methodA`) and `after = the summary result` (= `methodB`), so
+`MeanBefore = mean(methodA)`, `MeanAfter = mean(methodB)`. The regression test's fake
+`IAdapterSailDiff` mirrors this exactly, so the means the real formatter sees are production-faithful.
+
+### 3.3 Why "only candidate == baseline-method rows invert"
+
+Discovery emits a comparison group's cases method-by-method, so all `WithPlus` cases precede all
+`WithStringBuilder` cases in the batch. With the `i < j` loop, **every mixed pair has the baseline
+method (`WithPlus`) as `methodA` (= before)**. Hence:
+
+- the **before** perspective (a `WithPlus` row) is correct: baseline = `WithPlus`, candidate = `WithStringBuilder`;
+- the **after** perspective (a `WithStringBuilder` row) is the transposed one, and its
+  `ComparedMethodName` is the before method = `WithPlus`.
+
+So every inverted mixed line has **candidate == the baseline-flagged method** — exactly the
+field-report correlation. It is a side-effect of ordering + the dead guard, not an explicit (mis)lookup.
+
+---
+
+## 4. Blast radius
+
+The dead guard `IsPerspectiveBased && PerspectiveMethodName == ComparedMethodName` is duplicated
+across **five** formatter files (every surface that renders a perspective comparison transposes the
+after-perspective identically):
+
+| File | Lines | Surface |
+|---|---|---|
+| `ImpactSummaryFormatter.cs` | 55, 58 | IDE/console/markdown IMPACT verdict + `Mean: A → B` |
+| `SailDiffUnifiedFormatter.cs` | 163, 166 | `SailDiffFormattedOutput.PercentageChange` / significance |
+| `DetailedTableFormatter.cs` | 97, 165, 215, 240, 243, 246, 249 | IDE / Markdown / Console / CSV detail tables |
+| `DistributionPlotFormatter.cs` | 87 | distribution-plot mean/median caption |
+
+The single producer is `MethodComparisonBatchProcessor.FormatComparisonResults`
+(`IsPerspectiveBased = true` at line 473). Any caller that constructs `SailDiffComparisonData` with
+`IsPerspectiveBased = false` (e.g. `SailDiffDataExtensions.ToComparisonData`) is unaffected — the
+guard short-circuits on `IsPerspectiveBased`.
+
+---
+
+## 5. The fix (applied in this PR)
+
+### 5.1 Operand assignment + keying (symptom 2)
+
+The producer now **pre-orients** the statistics. `MethodComparisonBatchProcessor.FormatOriented`
+(replacing `FormatComparisonResults`) hands the formatters a `StatisticalTestResult` whose
+before/after sides are swapped (via `OrientStatistics`) whenever the named baseline was the SailDiff
+"after" operand — so `MeanBefore`/`RawDataBefore` **always** describe `PrimaryMethodName`. The
+dead `IsPerspectiveBased && PerspectiveMethodName == ComparedMethodName` guard is removed from all
+five consumer files (`ImpactSummaryFormatter`, `SailDiffUnifiedFormatter`, `DetailedTableFormatter`,
+`DistributionPlotFormatter`); they now use `primary = MeanBefore`, `compared = MeanAfter`
+unconditionally. The fragile full-id-vs-leaf-name compare is gone.
+
+### 5.2 Honor `IsBaseline` (symptom 1)
+
+`IsBaseline` is now plumbed through discovery: `DiscoveryAnalysisMethods.ExtractIsBaseline` detects
+the attribute argument, `MethodMetaData.IsBaseline` carries it, and `TestCaseItemCreator` sets the
+existing `SailfishComparisonRoleProperty = "Baseline"` (the message mappers already forward it to
+`metadata["ComparisonRole"]`). `MethodComparisonBatchProcessor` reads that role and, when a cohort
+has exactly one baseline, compares every contender **against it** (baseline-vs-contender), so the
+flagged method is always named the baseline. With no flagged baseline it falls back to N×N — now
+internally consistent thanks to §5.1.
+
+### 5.3 Cross-N grouping
+
+`ProcessComparisonGroup` partitions each comparison group by **variable set** (`ExtractVariableSection`)
+before pairing, so contenders are only compared to the baseline **at the same N**. The markdown path
+(`MethodComparisonTestRunCompletedHandler`) does the same via `RenderComparisonCohort` +
+`GetVariableSection`, which also lets a scaled baseline resolve to exactly one case per size instead
+of tripping the old ">1 baseline" N×N fallback. Single-variable-set groups render exactly as before.
+
+---
+
+## 6. Regression test + verification
+
+[`source/Tests.TestAdapter/Queue/MethodComparisonBatchProcessor_BaselineInversionTests.cs`](../../source/Tests.TestAdapter/Queue/MethodComparisonBatchProcessor_BaselineInversionTests.cs)
+
+- **`IdeComparisonOutput_DoesNotInvertOrMislabelTheBaseline`** — drives the production
+  `MethodComparisonBatchProcessor.ProcessBatch` with the **real** `SailDiffUnifiedFormatter` and a
+  faithful fake `IAdapterSailDiff`. Feeds synthetic per-case stats (baseline = large mean,
+  candidate = small mean) across **two** `SailfishVariable` values, captures the published IDE
+  output, and asserts on every parsed verdict line: (a) for mixed pairs the baseline named is the
+  `IsBaseline` method (`WithPlus`); (b) the smaller-mean method is reported "faster"; (c) no line
+  pairs a case against itself or transposes the printed means.
+- **`ImpactSummary_RendersPreOrientedComparison_WithoutTransposing`** — locks the post-fix formatter
+  contract: the formatter renders pre-oriented data verbatim (baseline carries MeanBefore) and never
+  re-derives or swaps. A regression here would resurrect the inverted verdict.
+
+Both **failed** against the pre-fix code (symptom output captured in §1); both **pass** now.
+
+**End-to-end RELEASE verification.** Running the (normally `Disabled`) benchmark
+[`BaselineVerdictInversionRepro`](../../source/PerformanceTests/ExamplePerformanceTests/BaselineVerdictInversionRepro.cs)
+through the live TestAdapter with the fix emits only correct, same-N verdicts:
+
+```
+🟢 IMPACT: WithStringBuilder(N: 100)   is 79.2% faster than baseline WithPlus(N: 100)   (IMPROVED)
+🟢 IMPACT: WithStringBuilder(N: 10000) is 99.8% faster than baseline WithPlus(N: 10000) (IMPROVED)
+```
+
+— baseline correctly resolved to the `IsBaseline` method `WithPlus` (validating the discovery→role
+plumbing), correct direction, and no cross-N rows (compare with the 12 inverted/cross-N lines in §1).

--- a/source/PerformanceTests/ExamplePerformanceTests/BaselineVerdictInversionRepro.cs
+++ b/source/PerformanceTests/ExamplePerformanceTests/BaselineVerdictInversionRepro.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using System.Text;
+using Sailfish.Attributes;
+
+namespace PerformanceTests.ExamplePerformanceTests;
+
+/// <summary>
+/// Demonstration/repro for the inverted-baseline reporting bug in the IDE comparison / SailDiff
+/// output (originally surfaced on Sailfish.TestAdapter 4.0.136, now FIXED).
+///
+/// <para>
+/// Ground truth: <see cref="WithPlus"/> is ~quadratic and the SLOWEST method; it is deliberately
+/// flagged <c>IsBaseline = true</c>. <see cref="WithStringBuilder"/> is ~linear and the FASTEST.
+/// A correct report must say WithStringBuilder is FASTER than the WithPlus baseline.
+/// </para>
+///
+/// <para>
+/// Before the fix, the IDE "IMPACT" lines inverted: rows whose CANDIDATE was the baseline-flagged
+/// method came out as e.g. <c>"🟢 IMPACT: WithPlus(N: …) is 99.x% faster than baseline
+/// WithStringBuilder(N: …)"</c> with the means transposed, and the report compared across different
+/// N. The fix now reports each contender against the WithPlus baseline at the same N, e.g.
+/// <c>"🟢 IMPACT: WithStringBuilder(N: 100) is 79.x% faster than baseline WithPlus(N: 100)"</c>.
+/// See the deterministic reproduction in
+/// <c>Tests.TestAdapter/Queue/MethodComparisonBatchProcessor_BaselineInversionTests.cs</c> and the
+/// write-up in <c>docs/diagnosis/baseline-verdict-inversion.md</c>.
+/// </para>
+///
+/// <para>
+/// Kept <c>Disabled = true</c> so it never burdens CI with a multi-second O(n²) run. To exercise it
+/// live, set <c>Disabled = false</c> and run in RELEASE so timings are clean (Debug inflates and adds
+/// noise).
+/// </para>
+/// </summary>
+[Sailfish(NumWarmupIterations = 3, SampleSize = 30, Disabled = true)]
+public class BaselineVerdictInversionRepro
+{
+    [SailfishVariable(100, 10_000)]
+    public int N { get; set; }
+
+    private string[] _parts = [];
+
+    [SailfishMethodSetup]
+    public void Setup() => _parts = Enumerable.Range(0, N).Select(i => i.ToString()).ToArray();
+
+    // SLOW: O(n^2) string concatenation. Deliberately flagged as the baseline.
+    [SailfishMethod(ComparisonGroup = "Concat", IsBaseline = true)]
+    public string WithPlus()
+    {
+        var result = string.Empty;
+        for (var i = 0; i < _parts.Length; i++) result += _parts[i];
+        return result;
+    }
+
+    // FAST: O(n) StringBuilder. A candidate.
+    [SailfishMethod(ComparisonGroup = "Concat")]
+    public string WithStringBuilder()
+    {
+        var sb = new StringBuilder(_parts.Length * 4);
+        for (var i = 0; i < _parts.Length; i++) _ = sb.Append(_parts[i]);
+        return sb.ToString();
+    }
+}

--- a/source/Sailfish.TestAdapter/Discovery/DiscoveryAnalysisMethods.cs
+++ b/source/Sailfish.TestAdapter/Discovery/DiscoveryAnalysisMethods.cs
@@ -107,10 +107,12 @@ public static class DiscoveryAnalysisMethods
                             let lineSpan = syntaxTree.GetLineSpan(methodDeclaration.Span)
                             let lineNumber = lineSpan.StartLinePosition.Line + 1
                             let comparisonGroup = IsTrawlMethod(methodDeclaration) ? null : ExtractComparisonInfo(methodDeclaration, classFullName, classDisablesComparison)
+                            let isBaseline = comparisonGroup != null && ExtractIsBaseline(methodDeclaration)
                             select new MethodMetaData(
                                 methodDeclaration.Identifier.ValueText,
                                 lineNumber,
-                                comparisonGroup))
+                                comparisonGroup,
+                                isBaseline))
                         .ToArray(),
                         syntaxTree: syntaxTree);
 
@@ -217,6 +219,33 @@ public static class DiscoveryAnalysisMethods
             Debug.WriteLine($"[Sailfish.TestAdapter] Failed to access comparison attribute expression: {ex.Message}");
             return null;
         }
+    }
+
+    /// <summary>
+    /// Returns true when the method's <c>[SailfishMethod]</c> attribute sets <c>IsBaseline = true</c>.
+    /// Carried downstream as ComparisonRole="Baseline" so the comparison reporter can name the
+    /// baseline-flagged method as the reference for every other method in its group.
+    /// </summary>
+    private static bool ExtractIsBaseline(MethodDeclarationSyntax methodDeclaration)
+    {
+        var sailfishMethodAttr = methodDeclaration.AttributeLists
+            .SelectMany(attrList => attrList.Attributes)
+            .FirstOrDefault(attr =>
+                attr.Name.ToString() == "SailfishMethod" ||
+                attr.Name.ToString() == "SailfishMethodAttribute");
+
+        if (sailfishMethodAttr?.ArgumentList?.Arguments == null) return false;
+
+        foreach (var arg in sailfishMethodAttr.ArgumentList.Arguments)
+        {
+            if (arg.NameEquals?.Name.Identifier.ValueText != "IsBaseline") continue;
+            if (arg.Expression is LiteralExpressionSyntax lit && lit.Token.IsKind(SyntaxKind.TrueKeyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/source/Sailfish.TestAdapter/Discovery/MethodMetaData.cs
+++ b/source/Sailfish.TestAdapter/Discovery/MethodMetaData.cs
@@ -9,10 +9,16 @@ public sealed class MethodMetaData
     }
 
     public MethodMetaData(string methodName, int lineNumber, string? comparisonGroup)
+        : this(methodName, lineNumber, comparisonGroup, isBaseline: false)
+    {
+    }
+
+    public MethodMetaData(string methodName, int lineNumber, string? comparisonGroup, bool isBaseline)
     {
         MethodName = methodName;
         LineNumber = lineNumber;
         ComparisonGroup = comparisonGroup;
+        IsBaseline = isBaseline;
     }
 
     public string MethodName { get; set; }
@@ -23,4 +29,11 @@ public sealed class MethodMetaData
     /// Methods with the same comparison group will be compared against each other.
     /// </summary>
     public string? ComparisonGroup { get; set; }
+
+    /// <summary>
+    /// True when this method is the comparison group's baseline
+    /// (<c>[SailfishMethod(IsBaseline = true)]</c>). Every other method in the group is reported
+    /// relative to it.
+    /// </summary>
+    public bool IsBaseline { get; set; }
 }

--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -31,6 +31,7 @@ internal static class TestCaseItemCreator
                     propertyNames,
                     propertyValues,
                     methodMetaData.ComparisonGroup,
+                    methodMetaData.IsBaseline,
                     hashAlgorithm);
             }
         }
@@ -45,6 +46,7 @@ internal static class TestCaseItemCreator
         IEnumerable<string> propertyNames,
         IEnumerable<object> propertyValues,
         string? comparisonGroup,
+        bool isBaseline,
         IHashAlgorithm hasher)
     {
         var testCaseId = DisplayNameHelper.CreateTestCaseId(testType, methodName, propertyNames.ToArray(), propertyValues.ToArray());
@@ -87,6 +89,13 @@ internal static class TestCaseItemCreator
         if (!string.IsNullOrEmpty(comparisonGroup))
         {
             testCase.SetPropertyValue(SailfishManagedProperty.SailfishComparisonGroupProperty, comparisonGroup);
+
+            // Carry the baseline flag so the comparison reporter names this method the baseline for
+            // every other method in its group. Only the baseline role is set; contenders are left unset.
+            if (isBaseline)
+            {
+                testCase.SetPropertyValue(SailfishManagedProperty.SailfishComparisonRoleProperty, "Baseline");
+            }
         }
 
         return testCase;

--- a/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs
+++ b/source/Sailfish.TestAdapter/Queue/Processors/MethodComparison/MethodComparisonBatchProcessor.cs
@@ -138,25 +138,53 @@ internal class MethodComparisonBatchProcessor
             return;
         }
 
-        // Note: Already logged in ProcessBatch, no need to log again here
+        // Compare only WITHIN the same variable set (same problem size). Pairing across different
+        // SailfishVariable values — e.g. (N: 100) vs (N: 10000) — mixes problem sizes and is
+        // meaningless, so each distinct variable set forms its own comparison cohort.
+        var cohorts = testCases
+            .GroupBy(tc => ExtractVariableSection(tc.TestCaseId), StringComparer.Ordinal)
+            .ToList();
 
-        // For true N×N comparison, each method needs to be compared with every other method
-        // We need to ensure each method gets its own perspective on all other methods
-        var allPairs = new HashSet<(string, string)>();
-
-        // Generate all unique pairs for SailDiff comparison (avoid duplicate SailDiff calls)
-        for (var i = 0; i < testCases.Count; i++)
+        foreach (var cohort in cohorts)
         {
-            for (var j = i + 1; j < testCases.Count; j++)
+            var members = cohort.ToList();
+            if (members.Count < 2)
             {
-                var methodA = testCases[i];
-                var methodB = testCases[j];
-                var pairKey = (methodA.TestCaseId, methodB.TestCaseId);
+                _logger.Log(LogLevel.Debug,
+                    "Comparison cohort '{0}' in group '{1}' has fewer than 2 methods ({2}); nothing to compare",
+                    cohort.Key, groupName, members.Count);
+                continue;
+            }
 
-                if (allPairs.Add(pairKey))
+            // A method flagged [SailfishMethod(IsBaseline = true)] is carried as ComparisonRole="Baseline"
+            // (set during discovery in TestCaseItemCreator and forwarded through the message mappers).
+            var baselines = members.Where(IsBaselineRole).ToList();
+
+            if (baselines.Count == 1)
+            {
+                // Baseline-vs-contender: every other method is reported relative to the single baseline,
+                // and the baseline-flagged method is always the one named "baseline".
+                var baseline = baselines[0];
+                foreach (var contender in members.Where(m => !ReferenceEquals(m, baseline)))
                 {
-                    // Perform comparison between the two methods (this will generate perspective-specific output for both)
-                    await PerformMethodComparison(methodA, methodB, groupName, cancellationToken);
+                    CompareBaselineToContender(baseline, contender, groupName);
+                }
+            }
+            else
+            {
+                if (baselines.Count > 1)
+                {
+                    _logger.Log(LogLevel.Warning,
+                        "Comparison cohort '{0}' in group '{1}' has {2} methods marked IsBaseline=true; expected at most one. " +
+                        "Falling back to N×N. The SF1301 analyzer should catch this at build time.",
+                        cohort.Key, groupName, baselines.Count);
+                }
+
+                // No designated baseline → full N×N, each method reported from its own perspective.
+                for (var i = 0; i < members.Count; i++)
+                for (var j = i + 1; j < members.Count; j++)
+                {
+                    CompareNxNPair(members[i], members[j], groupName);
                 }
             }
         }
@@ -187,91 +215,125 @@ internal class MethodComparisonBatchProcessor
     }
 
     /// <summary>
-    /// Performs SailDiff comparison between a Before and After method.
+    /// True when the message is the comparison group's designated baseline
+    /// (a <c>[SailfishMethod(IsBaseline = true)]</c> method, carried as ComparisonRole="Baseline").
     /// </summary>
-    private Task PerformMethodComparison(
-        TestCompletionQueueMessage beforeMethod,
-        TestCompletionQueueMessage afterMethod,
-        string groupName,
-        CancellationToken cancellationToken)
+    private bool IsBaselineRole(TestCompletionQueueMessage message)
+        => string.Equals(ExtractComparisonRole(message), "Baseline", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The variable-set section of a TestCaseId (e.g. <c>"(N: 100)"</c>), or <c>""</c> when the method
+    /// is not parameterized. Comparisons are scoped to a single variable set so different problem sizes
+    /// are never compared against each other.
+    /// </summary>
+    private static string ExtractVariableSection(string testCaseId)
+    {
+        var idx = testCaseId.IndexOf('(');
+        return idx >= 0 ? testCaseId.Substring(idx) : string.Empty;
+    }
+
+    /// <summary>
+    /// Compares a single contender against the group's baseline and accumulates one baseline-oriented
+    /// verdict (the baseline is always named "baseline") onto BOTH the contender's and the baseline's rows.
+    /// </summary>
+    private void CompareBaselineToContender(
+        TestCompletionQueueMessage baseline,
+        TestCompletionQueueMessage contender,
+        string groupName)
     {
         try
         {
-            // Extract performance data from messages
-            var beforeData = CreatePerformanceRunResultFromMessage(beforeMethod);
-            var afterData = CreatePerformanceRunResultFromMessage(afterMethod);
+            // before = baseline, after = contender ⇒ MeanBefore is the baseline's mean (no swap needed).
+            var comparisonResult = ComputeDiff(baseline, contender, groupName);
+            StorePairwisePValue(baseline, contender, comparisonResult);
 
-            // Create combined class execution summary from both methods
-            var classExecutionSummary = CreateCombinedClassExecutionSummary(beforeMethod, afterMethod);
+            var output = FormatOriented(comparisonResult, groupName, primary: baseline, compared: contender, swap: false);
 
-            // Debug: Log class execution summary contents
-            _logger.Log(LogLevel.Debug,
-                "Class execution summary contains {0} compiled test case results",
-                classExecutionSummary.CompiledTestCaseResults.Count());
-
-            foreach (var result in classExecutionSummary.CompiledTestCaseResults)
-            {
-                _logger.Log(LogLevel.Debug,
-                    "Compiled result: DisplayName='{0}', HasPerformanceResult={1}",
-                    result.PerformanceRunResult?.DisplayName ?? "null", result.PerformanceRunResult != null);
-            }
-
-            // Perform SailDiff comparison using the comparison group name as a common test case ID
-            // This allows SailDiff to compare different methods by treating them as before/after versions
-            var commonTestCaseId = $"Comparison_{groupName}";
-
-            _logger.Log(LogLevel.Debug,
-                "Calling SailDiff.ComputeTestCaseDiff for group '{0}' with before: '{1}', after: '{2}', using common ID: '{3}'",
-                groupName, beforeMethod.TestCaseId, afterMethod.TestCaseId, commonTestCaseId);
-
-            var comparisonResult = _sailDiff.ComputeTestCaseDiff(
-                [commonTestCaseId],
-                [commonTestCaseId],
-                commonTestCaseId,
-                CreateModifiedClassExecutionSummary(classExecutionSummary, beforeMethod, afterMethod, commonTestCaseId),
-                CreateModifiedPerformanceResult(beforeData, commonTestCaseId));
-
-            _logger.Log(LogLevel.Debug,
-                "SailDiff comparison completed for group '{0}'. Results count: {1}",
-                groupName, comparisonResult?.SailDiffResults?.Count ?? 0);
-
-            // Store pairwise p-value for NxN FDR adjustment later. Also store the alpha used
-            // for the comparison so downstream formatters apply the user-configured threshold
-            // when labelling matrix cells, rather than the previously hardcoded 0.05.
-            var pNullable = comparisonResult?.SailDiffResults?.FirstOrDefault()?.TestResultsWithOutlierAnalysis?.StatisticalTestResult?.PValue;
-            if (pNullable.HasValue)
-            {
-                var fdrAlpha = comparisonResult?.TestSettings?.Alpha
-                               ?? Sailfish.Analysis.SailDiff.Statistics.SailDiffSignificance.FallbackAlpha;
-                UpdatePairwisePValueMetadata(beforeMethod, afterMethod, pNullable.Value, fdrAlpha);
-            }
-
-            // Format comparison results from each method's perspective
-            var beforeMethodOutput = FormatComparisonResults(comparisonResult, groupName, beforeMethod.TestCaseId,
-                afterMethod.TestCaseId, beforeMethod.TestCaseId);
-            var afterMethodOutput = FormatComparisonResults(comparisonResult, groupName, beforeMethod.TestCaseId,
-                afterMethod.TestCaseId, afterMethod.TestCaseId);
-
-            // Enhance test output messages with perspective-specific results
-            EnhanceTestOutputWithComparison(beforeMethod, afterMethod, beforeMethodOutput, afterMethodOutput,
-                cancellationToken);
-
-            // Note: We don't remove suppression flags or republish here
-            // This will be done after ALL comparisons in the group are complete
+            // The same baseline-oriented line is correct from either row's point of view.
+            EnhanceTestOutputWithComparison(baseline, contender, output, output, CancellationToken.None);
 
             _logger.Log(LogLevel.Information,
-                "Completed comparison for group '{0}': {1} vs {2}",
-                groupName, beforeMethod.TestCaseId, afterMethod.TestCaseId);
-
-            return Task.CompletedTask;
+                "Completed baseline comparison for group '{0}': {1} vs baseline {2}",
+                groupName, contender.TestCaseId, baseline.TestCaseId);
         }
         catch (Exception ex)
         {
             _logger.Log(LogLevel.Error, ex,
-                "Failed to perform comparison for group '{0}': {1}",
-                groupName, ex.Message);
-            return Task.CompletedTask;
+                "Failed baseline comparison for group '{0}': {1}", groupName, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Compares two methods with no designated baseline (N×N). Each method's row shows the pair from
+    /// its own perspective, with the statistics oriented so the named baseline always carries its own mean.
+    /// </summary>
+    private void CompareNxNPair(
+        TestCompletionQueueMessage methodA,
+        TestCompletionQueueMessage methodB,
+        string groupName)
+    {
+        try
+        {
+            // before = A, after = B ⇒ MeanBefore is A's mean.
+            var comparisonResult = ComputeDiff(methodA, methodB, groupName);
+            StorePairwisePValue(methodA, methodB, comparisonResult);
+
+            // A's row: A is the reference (no swap). B's row: B is the reference (swap before/after).
+            var outputA = FormatOriented(comparisonResult, groupName, primary: methodA, compared: methodB, swap: false);
+            var outputB = FormatOriented(comparisonResult, groupName, primary: methodB, compared: methodA, swap: true);
+
+            EnhanceTestOutputWithComparison(methodA, methodB, outputA, outputB, CancellationToken.None);
+
+            _logger.Log(LogLevel.Information,
+                "Completed comparison for group '{0}': {1} vs {2}",
+                groupName, methodA.TestCaseId, methodB.TestCaseId);
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(LogLevel.Error, ex,
+                "Failed to perform comparison for group '{0}': {1}", groupName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Runs the SailDiff comparison for an ordered (before, after) pair. The result's
+    /// MeanBefore/RawDataBefore describe <paramref name="beforeMethod"/>.
+    /// </summary>
+    private TestCaseSailDiffResult ComputeDiff(
+        TestCompletionQueueMessage beforeMethod,
+        TestCompletionQueueMessage afterMethod,
+        string groupName)
+    {
+        var beforeData = CreatePerformanceRunResultFromMessage(beforeMethod);
+        var classExecutionSummary = CreateCombinedClassExecutionSummary(beforeMethod, afterMethod);
+
+        // A common test case ID lets SailDiff treat the two distinct methods as before/after versions.
+        var commonTestCaseId = $"Comparison_{groupName}";
+
+        _logger.Log(LogLevel.Debug,
+            "Calling SailDiff.ComputeTestCaseDiff for group '{0}' with before: '{1}', after: '{2}', using common ID: '{3}'",
+            groupName, beforeMethod.TestCaseId, afterMethod.TestCaseId, commonTestCaseId);
+
+        return _sailDiff.ComputeTestCaseDiff(
+            [commonTestCaseId],
+            [commonTestCaseId],
+            commonTestCaseId,
+            CreateModifiedClassExecutionSummary(classExecutionSummary, beforeMethod, afterMethod, commonTestCaseId),
+            CreateModifiedPerformanceResult(beforeData, commonTestCaseId));
+    }
+
+    /// <summary>
+    /// Stores the pairwise p-value (and the configured alpha) on both messages for the later
+    /// BH-FDR adjustment of the N×N matrix.
+    /// </summary>
+    private void StorePairwisePValue(TestCompletionQueueMessage a, TestCompletionQueueMessage b, TestCaseSailDiffResult? comparisonResult)
+    {
+        var pNullable = comparisonResult?.SailDiffResults?.FirstOrDefault()?.TestResultsWithOutlierAnalysis?.StatisticalTestResult?.PValue;
+        if (!pNullable.HasValue) return;
+
+        var fdrAlpha = comparisonResult?.TestSettings?.Alpha
+                       ?? Sailfish.Analysis.SailDiff.Statistics.SailDiffSignificance.FallbackAlpha;
+        UpdatePairwisePValueMetadata(a, b, pNullable.Value, fdrAlpha);
     }
 
     /// <summary>
@@ -435,53 +497,86 @@ internal class MethodComparisonBatchProcessor
     }
 
     /// <summary>
-    /// Formats SailDiff comparison results for display from a specific method's perspective using the unified formatter.
+    /// Formats a comparison for display with <paramref name="primary"/> named the baseline and
+    /// <paramref name="compared"/> the contender. The statistics are oriented (see
+    /// <see cref="OrientStatistics"/>) so MeanBefore/RawDataBefore always describe
+    /// <paramref name="primary"/> — the named baseline therefore always carries its own mean, which is
+    /// what makes the verdict direction correct. <paramref name="swap"/> is true when
+    /// <paramref name="primary"/> was the SailDiff "after" operand.
     /// </summary>
-    private string FormatComparisonResults(TestCaseSailDiffResult? comparisonResult, string groupName,
-        string beforeMethodName, string afterMethodName, string perspectiveMethodName)
+    private string FormatOriented(
+        TestCaseSailDiffResult? comparisonResult,
+        string groupName,
+        TestCompletionQueueMessage primary,
+        TestCompletionQueueMessage compared,
+        bool swap)
     {
-        _logger.Log(LogLevel.Debug,
-            "Formatting comparison results for group '{0}' from perspective '{1}'. ComparisonResult is null: {2}, SailDiffResults count: {3}",
-            groupName, ExtractMethodName(perspectiveMethodName), comparisonResult == null,
-            comparisonResult?.SailDiffResults?.Count() ?? 0);
-
         if (comparisonResult?.SailDiffResults?.Any() != true)
         {
             return "\n❌ No comparison results available\n";
         }
 
-        // Convert SailDiff result to unified comparison data
         var result = comparisonResult.SailDiffResults.First();
-        var isBeforePerspective = perspectiveMethodName == beforeMethodName;
-        var primaryMethod = ExtractMethodName(perspectiveMethodName);
-        var comparedMethod = ExtractMethodName(isBeforePerspective ? afterMethodName : beforeMethodName);
+        var statistics = OrientStatistics(result.TestResultsWithOutlierAnalysis.StatisticalTestResult, swap);
+        var primaryMethod = ExtractMethodName(primary.TestCaseId);
+        var comparedMethod = ExtractMethodName(compared.TestCaseId);
 
         var comparisonData = new SailDiffComparisonData
         {
             GroupName = groupName,
             PrimaryMethodName = primaryMethod,
             ComparedMethodName = comparedMethod,
-            Statistics = result.TestResultsWithOutlierAnalysis.StatisticalTestResult,
+            Statistics = statistics,
             Metadata = new ComparisonMetadata
             {
-                SampleSize = result.TestResultsWithOutlierAnalysis.StatisticalTestResult.SampleSizeBefore,
+                SampleSize = statistics.SampleSizeBefore,
                 AlphaLevel = comparisonResult.TestSettings.Alpha,
                 TestType = GetTestTypeDisplayName(comparisonResult.TestSettings.TestType),
                 OutliersRemoved = (result.TestResultsWithOutlierAnalysis.Sample1?.TotalNumOutliers ?? 0) +
                                   (result.TestResultsWithOutlierAnalysis.Sample2?.TotalNumOutliers ?? 0)
             },
-            IsPerspectiveBased = true,
-            PerspectiveMethodName = perspectiveMethodName
+            // Statistics are pre-oriented to match the named methods, so no perspective swap is needed
+            // downstream (the historical perspective heuristic in the formatters is a no-op).
+            IsPerspectiveBased = false
         };
 
-        // Format using unified formatter for IDE context
         var formattedOutput = _unifiedFormatter.Format(comparisonData, OutputContext.Ide);
 
         _logger.Log(LogLevel.Debug,
-            "Unified formatter generated output for '{0}' vs '{1}'. Significance: {2}, Change: {3:F1}%",
+            "Unified formatter generated output for baseline '{0}' vs contender '{1}'. Significance: {2}, Change: {3:F1}%",
             primaryMethod, comparedMethod, formattedOutput.Significance, formattedOutput.PercentageChange);
 
         return formattedOutput.FullOutput;
+    }
+
+    /// <summary>
+    /// Returns the test result oriented so MeanBefore/MedianBefore/RawDataBefore describe the method
+    /// being named the baseline. When <paramref name="swap"/> is true the before/after sides are
+    /// exchanged. The p-value and "No Change" detection are orientation-symmetric and preserved as-is.
+    /// </summary>
+    private static StatisticalTestResult OrientStatistics(StatisticalTestResult s, bool swap)
+    {
+        if (!swap) return s;
+
+        return new StatisticalTestResult(
+            meanBefore: s.MeanAfter,
+            meanAfter: s.MeanBefore,
+            medianBefore: s.MedianAfter,
+            medianAfter: s.MedianBefore,
+            testStatistic: s.TestStatistic,
+            pValue: s.PValue,
+            changeDescription: s.ChangeDescription,
+            sampleSizeBefore: s.SampleSizeAfter,
+            sampleSizeAfter: s.SampleSizeBefore,
+            rawDataBefore: s.RawDataAfter,
+            rawDataAfter: s.RawDataBefore,
+            additionalResults: s.AdditionalResults)
+        {
+            EffectSize = s.EffectSize,
+            Difference = s.Difference,
+            QValue = s.QValue,
+            MinimumDetectableEffectPercent = s.MinimumDetectableEffectPercent
+        };
     }
 
     /// <summary>

--- a/source/Sailfish/Analysis/SailDiff/Formatting/DetailedTableFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/DetailedTableFormatter.cs
@@ -94,9 +94,9 @@ public class DetailedTableFormatter : IDetailedTableFormatter
         {
             var stats = data.Statistics;
             var display = SailDiffDisplayStatistics.From(stats);
-            var swap = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName;
-            var primaryTime = swap ? display.MeanAfter : display.MeanBefore;
-            var comparedTime = swap ? display.MeanBefore : display.MeanAfter;
+            // Statistics are pre-oriented: MeanBefore/MedianBefore describe the baseline (primary).
+            var primaryTime = display.MeanBefore;
+            var comparedTime = display.MeanAfter;
 
             var percentChange = primaryTime > 0 ? ((comparedTime - primaryTime) / primaryTime) * 100 : 0;
             var changeText = percentChange >= 0 ? $"+{percentChange:F1}%" : $"{percentChange:F1}%";
@@ -109,8 +109,8 @@ public class DetailedTableFormatter : IDetailedTableFormatter
 
             rows.Add(new[] { $"Mean ({unitLabel})", DurationFormatter.Format(primaryTime, unit, Decimals), DurationFormatter.Format(comparedTime, unit, Decimals), changeText, $"{stats.PValue:F6}" });
 
-            var primaryMedian = swap ? display.MedianAfter : display.MedianBefore;
-            var comparedMedian = swap ? display.MedianBefore : display.MedianAfter;
+            var primaryMedian = display.MedianBefore;
+            var comparedMedian = display.MedianAfter;
 
             var medianChange = primaryMedian > 0 ? ((comparedMedian - primaryMedian) / primaryMedian) * 100 : 0;
             var medianChangeText = medianChange >= 0 ? $"+{medianChange:F1}%" : $"{medianChange:F1}%";
@@ -162,9 +162,9 @@ public class DetailedTableFormatter : IDetailedTableFormatter
         {
             var stats = data.Statistics;
             var display = SailDiffDisplayStatistics.From(stats);
-            var swap = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName;
-            var primaryTime = swap ? display.MeanAfter : display.MeanBefore;
-            var comparedTime = swap ? display.MeanBefore : display.MeanAfter;
+            // Statistics are pre-oriented: MeanBefore/MedianBefore describe the baseline (primary).
+            var primaryTime = display.MeanBefore;
+            var comparedTime = display.MeanAfter;
 
             var percentChange = primaryTime > 0 ? ((comparedTime - primaryTime) / primaryTime) * 100 : 0;
             var changeText = percentChange >= 0 ? $"+{percentChange:F1}%" : $"{percentChange:F1}%";
@@ -174,8 +174,8 @@ public class DetailedTableFormatter : IDetailedTableFormatter
             sb.AppendLine("|--------|------------|-------------|--------|---------|");
             sb.AppendLine($"| Mean ({unitLabel}) | {DurationFormatter.Format(primaryTime, unit, Decimals)} | {DurationFormatter.Format(comparedTime, unit, Decimals)} | {changeText} | {stats.PValue:F6} |");
 
-            var primaryMedian = swap ? display.MedianAfter : display.MedianBefore;
-            var comparedMedian = swap ? display.MedianBefore : display.MedianAfter;
+            var primaryMedian = display.MedianBefore;
+            var comparedMedian = display.MedianAfter;
 
             var medianChange = primaryMedian > 0 ? ((comparedMedian - primaryMedian) / primaryMedian) * 100 : 0;
             var medianChangeText = medianChange >= 0 ? $"+{medianChange:F1}%" : $"{medianChange:F1}%";
@@ -212,9 +212,9 @@ public class DetailedTableFormatter : IDetailedTableFormatter
                 sb.AppendLine(new string('-', 40));
             }
 
-            var swap = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName;
-            var primaryTime = swap ? display.MeanAfter : display.MeanBefore;
-            var comparedTime = swap ? display.MeanBefore : display.MeanAfter;
+            // Statistics are pre-oriented: MeanBefore/MedianBefore describe the baseline (primary).
+            var primaryTime = display.MeanBefore;
+            var comparedTime = display.MeanAfter;
 
             sb.AppendLine($"Mean:     {DurationFormatter.FormatWithUnit(primaryTime, unit, Decimals)} -> {DurationFormatter.FormatWithUnit(comparedTime, unit, Decimals)}");
             sb.AppendLine($"P-Value:  {stats.PValue:F6}");
@@ -237,18 +237,11 @@ public class DetailedTableFormatter : IDetailedTableFormatter
         foreach (var data in comparisons)
         {
             var stats = data.Statistics;
-            var primaryTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
-                ? stats.MeanAfter
-                : stats.MeanBefore;
-            var comparedTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
-                ? stats.MeanBefore
-                : stats.MeanAfter;
-            var primaryMedian = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
-                ? stats.MedianAfter
-                : stats.MedianBefore;
-            var comparedMedian = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
-                ? stats.MedianBefore
-                : stats.MedianAfter;
+            // Statistics are pre-oriented: Before describes the baseline (primary), After the contender.
+            var primaryTime = stats.MeanBefore;
+            var comparedTime = stats.MeanAfter;
+            var primaryMedian = stats.MedianBefore;
+            var comparedMedian = stats.MedianAfter;
 
             sb.AppendLine($"{data.PrimaryMethodName},{data.ComparedMethodName}," +
                          $"{primaryTime:F3},{comparedTime:F3}," +

--- a/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
@@ -80,14 +80,11 @@ public class DistributionPlotFormatter : IDistributionPlotFormatter
         return Wrap(RenderSeries(series), context);
     }
 
-    // Honors the perspective swap the other SailDiff formatters apply: when the comparison is viewed
-    // from the compared method's perspective, before/after are exchanged.
+    // Comparison data arrives pre-oriented from the producer: RawDataBefore describes the baseline
+    // (primary) and RawDataAfter the contender, so no perspective swap is applied here.
     private static (double[]? Primary, double[]? Compared) OrientedSamples(SailDiffComparisonData data)
     {
-        var swap = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName;
-        return swap
-            ? (data.Statistics.RawDataAfter, data.Statistics.RawDataBefore)
-            : (data.Statistics.RawDataBefore, data.Statistics.RawDataAfter);
+        return (data.Statistics.RawDataBefore, data.Statistics.RawDataAfter);
     }
 
     private static void AddDistinct(List<DistributionPlotRenderer.Series> series, HashSet<string> seen, string label, double[]? data)

--- a/source/Sailfish/Analysis/SailDiff/Formatting/ImpactSummaryFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/ImpactSummaryFormatter.cs
@@ -51,13 +51,11 @@ public class ImpactSummaryFormatter : IImpactSummaryFormatter
         // aren't lost to the pre-rounded scalar statistics (keeps the %Δ meaningful for fast methods).
         var display = SailDiffDisplayStatistics.From(stats);
 
-        // Calculate percentage change
-        var primaryTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
-            ? display.MeanAfter
-            : display.MeanBefore;
-        var comparedTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName
-            ? display.MeanBefore
-            : display.MeanAfter;
+        // Calculate percentage change. Comparison data arrives pre-oriented: MeanBefore is the
+        // baseline (PrimaryMethodName) and MeanAfter the contender (ComparedMethodName), so the named
+        // baseline always carries its own mean and the direction can never be misread.
+        var primaryTime = display.MeanBefore;
+        var comparedTime = display.MeanAfter;
 
         var percentChange = primaryTime > 0 ? ((comparedTime - primaryTime) / primaryTime) * 100 : 0;
         

--- a/source/Sailfish/Analysis/SailDiff/Formatting/SailDiffUnifiedFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/SailDiffUnifiedFormatter.cs
@@ -158,14 +158,10 @@ public class SailDiffUnifiedFormatter : ISailDiffUnifiedFormatter
     private static double CalculatePercentageChange(SailDiffComparisonData data)
     {
         var stats = data.Statistics;
-        
-        // Handle perspective-based comparisons
-        var primaryTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName 
-            ? stats.MeanAfter 
-            : stats.MeanBefore;
-        var comparedTime = data.IsPerspectiveBased && data.PerspectiveMethodName == data.ComparedMethodName 
-            ? stats.MeanBefore 
-            : stats.MeanAfter;
+
+        // Comparison data arrives pre-oriented: MeanBefore is the baseline, MeanAfter the contender.
+        var primaryTime = stats.MeanBefore;
+        var comparedTime = stats.MeanAfter;
 
         return primaryTime > 0 ? ((comparedTime - primaryTime) / primaryTime) * 100 : 0;
     }

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -345,61 +345,36 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                     continue;
                 }
 
-                // Determine baselines (zero, one, or — incorrectly — many).
-                var baselines = members
-                    .Where(m => GetComparisonInfoForResult(m.TestResult, m.TestClass).IsBaseline)
-                    .Select(m => m.TestResult)
+                // Compare only WITHIN the same variable set (same problem size). Pairing across different
+                // SailfishVariable values mixes problem sizes and is meaningless, so each distinct variable
+                // set is rendered as its own comparison block — which also lets a scaled baseline resolve
+                // to exactly one case per size instead of tripping the ">1 baseline" N×N fallback.
+                // A single-variable-set group (the common case) renders exactly one block, unchanged.
+                var testClass = group.Key.TestClass;
+                var cohorts = methods
+                    .GroupBy(m => GetVariableSection(m.TestCaseId?.DisplayName ?? string.Empty), StringComparer.Ordinal)
+                    .OrderBy(c => c.Key, StringComparer.Ordinal)
                     .ToList();
 
-                string comparisonContent;
-                string sectionHeader;
-                if (baselines.Count == 1)
+                if (cohorts.Count <= 1)
                 {
-                    sectionHeader = "### Baseline Comparison";
-                    comparisonContent = CreateBaselineComparisonTable(baselines[0], methods);
+                    RenderComparisonCohort(methods, testClass, displayGroupName, sb);
                 }
                 else
                 {
-                    if (baselines.Count > 1)
+                    foreach (var cohort in cohorts)
                     {
-                        _logger.Log(LogLevel.Warning,
-                            "Comparison group {0} in class '{1}' has {2} methods marked IsBaseline=true; expected at most one. " +
-                            "Falling back to N×N comparison. The SF1301 analyzer should catch this at build time.",
-                            displayGroupName, className, baselines.Count);
+                        var cohortMethods = cohort.ToList();
+                        if (cohortMethods.Count < 2)
+                        {
+                            continue; // a lone case at this problem size has nothing to compare against
+                        }
+
+                        sb.AppendLine($"### Variables: {(string.IsNullOrEmpty(cohort.Key) ? "(none)" : cohort.Key)}");
+                        sb.AppendLine();
+                        RenderComparisonCohort(cohortMethods, testClass, displayGroupName, sb);
                     }
-                    sectionHeader = "### Performance Comparison Matrix";
-                    comparisonContent = CreateNxNComparisonMatrix(methods);
                 }
-
-                if (!string.IsNullOrEmpty(comparisonContent))
-                {
-                    sb.AppendLine(sectionHeader);
-                    sb.AppendLine();
-                    sb.AppendLine(comparisonContent);
-                    sb.AppendLine();
-                }
-
-                // Add detailed results table
-                sb.AppendLine("### Detailed Results");
-                sb.AppendLine();
-                var detailUnit = DurationFormatter.SelectUnit(methods.SelectMany(m => new[] { m.PerformanceRunResult?.Mean ?? 0, m.PerformanceRunResult?.Median ?? 0 }));
-                var detailUnitLabel = DurationFormatter.UnitLabel(detailUnit);
-                sb.AppendLine($"| Method | Mean Time ({detailUnitLabel}) | Median Time ({detailUnitLabel}) | Sample Size | Status |");
-                sb.AppendLine("|--------|-----------|-------------|-------------|--------|");
-
-                foreach (var method in methods.OrderBy(m => m.PerformanceRunResult?.Mean ?? double.MaxValue))
-                {
-                    var meanTime = method.PerformanceRunResult?.Mean ?? 0;
-                    var medianTime = method.PerformanceRunResult?.Median ?? 0;
-                    var sampleSize = method.PerformanceRunResult?.SampleSize ?? 0;
-                    var status = method.Exception == null ? "✅ Success" : "❌ Failed";
-
-                    sb.AppendLine($"| {method.TestCaseId?.DisplayName ?? "Unknown"} | {DurationFormatter.Format(meanTime, detailUnit, 3)} | {DurationFormatter.Format(medianTime, detailUnit, 3)} | {sampleSize} | {status} |");
-                }
-                sb.AppendLine();
-
-                // Box-and-whisker plot of every method in the group on a shared axis
-                AppendComparisonDistributionPlot(methods, sb);
             }
         }
 
@@ -431,6 +406,83 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Renders one comparison cohort (a single variable set) into <paramref name="sb"/>: a
+    /// baseline-vs-contender table when exactly one method is the baseline, otherwise an N×N matrix,
+    /// followed by the detailed-results table and the distribution plot.
+    /// </summary>
+    private void RenderComparisonCohort(
+        List<CompiledTestCaseResultTrackingFormat> methods,
+        Type testClass,
+        string displayGroupName,
+        StringBuilder sb)
+    {
+        // Determine baselines (zero, one, or — incorrectly — many) within this variable set.
+        var baselines = methods
+            .Where(m => GetComparisonInfoForResult(m, testClass).IsBaseline)
+            .ToList();
+
+        string comparisonContent;
+        string sectionHeader;
+        if (baselines.Count == 1)
+        {
+            sectionHeader = "### Baseline Comparison";
+            comparisonContent = CreateBaselineComparisonTable(baselines[0], methods);
+        }
+        else
+        {
+            if (baselines.Count > 1)
+            {
+                _logger.Log(LogLevel.Warning,
+                    "Comparison group {0} in class '{1}' has {2} methods marked IsBaseline=true within one variable set; " +
+                    "expected at most one. Falling back to N×N comparison. The SF1301 analyzer should catch this at build time.",
+                    displayGroupName, testClass.Name, baselines.Count);
+            }
+            sectionHeader = "### Performance Comparison Matrix";
+            comparisonContent = CreateNxNComparisonMatrix(methods);
+        }
+
+        if (!string.IsNullOrEmpty(comparisonContent))
+        {
+            sb.AppendLine(sectionHeader);
+            sb.AppendLine();
+            sb.AppendLine(comparisonContent);
+            sb.AppendLine();
+        }
+
+        // Add detailed results table
+        sb.AppendLine("### Detailed Results");
+        sb.AppendLine();
+        var detailUnit = DurationFormatter.SelectUnit(methods.SelectMany(m => new[] { m.PerformanceRunResult?.Mean ?? 0, m.PerformanceRunResult?.Median ?? 0 }));
+        var detailUnitLabel = DurationFormatter.UnitLabel(detailUnit);
+        sb.AppendLine($"| Method | Mean Time ({detailUnitLabel}) | Median Time ({detailUnitLabel}) | Sample Size | Status |");
+        sb.AppendLine("|--------|-----------|-------------|-------------|--------|");
+
+        foreach (var method in methods.OrderBy(m => m.PerformanceRunResult?.Mean ?? double.MaxValue))
+        {
+            var meanTime = method.PerformanceRunResult?.Mean ?? 0;
+            var medianTime = method.PerformanceRunResult?.Median ?? 0;
+            var sampleSize = method.PerformanceRunResult?.SampleSize ?? 0;
+            var status = method.Exception == null ? "✅ Success" : "❌ Failed";
+
+            sb.AppendLine($"| {method.TestCaseId?.DisplayName ?? "Unknown"} | {DurationFormatter.Format(meanTime, detailUnit, 3)} | {DurationFormatter.Format(medianTime, detailUnit, 3)} | {sampleSize} | {status} |");
+        }
+        sb.AppendLine();
+
+        // Box-and-whisker plot of every method in the cohort on a shared axis
+        AppendComparisonDistributionPlot(methods, sb);
+    }
+
+    /// <summary>
+    /// The variable-set section of a test case display name (e.g. <c>"(N: 100)"</c>), or <c>""</c>
+    /// when the method is not parameterized. Used to keep comparisons within a single problem size.
+    /// </summary>
+    private static string GetVariableSection(string displayName)
+    {
+        var idx = displayName.IndexOf('(');
+        return idx >= 0 ? displayName.Substring(idx) : string.Empty;
     }
 
     /// <summary>

--- a/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
@@ -28,6 +28,12 @@ public class MethodComparisonTestRunCompletedHandlerTests
     private readonly IMediator _mockMediator;
     private readonly MethodComparisonTestRunCompletedHandler _handler;
 
+    // Methods in a comparison group always share the same SailfishVariable set in real runs, so every
+    // built test case uses the same variable section. (TestCaseIdBuilder otherwise defaults to a random
+    // per-call variable, which would scatter a group's methods across distinct same-size cohorts.)
+    private static readonly global::Sailfish.Contracts.Public.Models.TestCaseVariable[] SharedComparisonVariables =
+        { new("N", 100) };
+
     public MethodComparisonTestRunCompletedHandlerTests()
     {
         _mockLogger = Substitute.For<ILogger>();
@@ -377,7 +383,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("TestMethod1").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("TestMethod1").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.5)
                     .WithMedian(10.0)
@@ -393,7 +399,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithoutWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("TestMethod1").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("TestMethod1").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create().Build()))
             .Build();
 
@@ -405,14 +411,14 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var summary1 = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("TestMethod1").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("TestMethod1").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create().Build()))
             .Build();
 
         var summary2 = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithoutWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("TestMethod2").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("TestMethod2").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create().Build()))
             .Build();
 
@@ -424,14 +430,14 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithComparison))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Method1").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Method1").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0)
                     .WithMedian(9.5)
                     .WithSampleSize(100)
                     .Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Method2").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Method2").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0)
                     .WithMedian(19.5)
@@ -447,14 +453,14 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithBaselineComparison))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Baseline").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0)
                     .WithMedian(9.5)
                     .WithSampleSize(100)
                     .Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Contender").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0)
                     .WithMedian(19.5)
@@ -470,11 +476,11 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classA = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithBaselineComparison))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Baseline").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0).WithMedian(9.5).WithSampleSize(100).Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Contender").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0).WithMedian(19.5).WithSampleSize(100).Build()))
             .Build();
@@ -482,11 +488,11 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classB = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(OtherTestClassWithBaselineComparison))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Baseline").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Baseline").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(30.0).WithMedian(29.5).WithSampleSize(100).Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Contender").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Contender").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(40.0).WithMedian(39.5).WithSampleSize(100).Build()))
             .Build();
@@ -499,11 +505,11 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithImplicitGroup))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("MethodA").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("MethodA").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0).WithMedian(9.5).WithSampleSize(100).Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("MethodB").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("MethodB").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0).WithMedian(19.5).WithSampleSize(100).Build()))
             .Build();
@@ -516,11 +522,11 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithImplicitGroupAndBaseline))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Reference").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Reference").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0).WithMedian(9.5).WithSampleSize(100).Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Alternative").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Alternative").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0).WithMedian(19.5).WithSampleSize(100).Build()))
             .Build();
@@ -533,11 +539,11 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithComparisonDisabled))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("OperationA").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("OperationA").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0).WithMedian(9.5).WithSampleSize(100).Build()))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("OperationB").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("OperationB").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0).WithMedian(19.5).WithSampleSize(100).Build()))
             .Build();
@@ -550,7 +556,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var classExecutionSummary = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("RegularMethod").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("RegularMethod").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(15.0)
                     .WithMedian(14.5)
@@ -575,7 +581,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var summary1 = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(TestClassWithWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("TestMethod1").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("TestMethod1").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(10.0)
                     .Build()))
@@ -584,7 +590,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var summary2 = ClassExecutionSummaryTrackingFormatBuilder.Create()
             .WithTestClass(typeof(AnotherTestClassWithWriteToMarkdown))
             .WithCompiledTestCaseResult(b => b
-                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("TestMethod2").Build())
+                .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("TestMethod2").Build())
                 .WithPerformanceRunResult(PerformanceRunResultTrackingFormatBuilder.Create()
                     .WithMean(20.0)
                     .Build()))
@@ -797,7 +803,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
             var methods = new List<CompiledTestCaseResultTrackingFormat>
             {
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
-                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Alpha").Build())
+                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Alpha").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
                             .WithMean(10.0)
@@ -807,7 +813,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
                             .Build())
                     .Build(),
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
-                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Beta").Build())
+                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Beta").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
                             .WithMean(10.5)
@@ -839,7 +845,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
             var methods = new List<CompiledTestCaseResultTrackingFormat>
             {
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
-                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Alpha").Build())
+                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Alpha").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
                             .WithMean(10.0)
@@ -849,7 +855,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
                             .Build())
                     .Build(),
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
-                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseName("Beta").Build())
+                    .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Beta").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
                             .WithMean(20.0)

--- a/source/Tests.TestAdapter/Queue/MethodComparisonBatchProcessor_BaselineInversionTests.cs
+++ b/source/Tests.TestAdapter/Queue/MethodComparisonBatchProcessor_BaselineInversionTests.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NSubstitute;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff.Formatting;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Sailfish.TestAdapter.Execution;
+using Sailfish.TestAdapter.Handlers.FrameworkHandlers;
+using Sailfish.TestAdapter.Queue.Contracts;
+using Sailfish.TestAdapter.Queue.Processors.MethodComparison;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.TestAdapter.Queue;
+
+/// <summary>
+/// Regression coverage for the inverted-baseline reporting bug in the IDE method-comparison
+/// output (surfaced on Sailfish.TestAdapter 4.0.136).
+///
+/// <para>
+/// Ground truth fed in synthetically (NO real timing): the method flagged
+/// <c>IsBaseline = true</c> (<c>WithPlus</c>) is the SLOWEST at every variable value, and the
+/// candidate (<c>WithStringBuilder</c>) is the FASTEST. WithPlus's smallest mean (8 ms) is still
+/// larger than WithStringBuilder's largest mean (4 ms), so for any pairing of the two methods —
+/// even across different N — WithPlus is unambiguously slower.
+/// </para>
+///
+/// <para>
+/// A correct comparison report must therefore say WithStringBuilder is FASTER than the WithPlus
+/// baseline, and must name WithPlus (the only <c>IsBaseline</c> method) as the baseline. These
+/// tests drive the real <see cref="SailDiffUnifiedFormatter"/> / <see cref="ImpactSummaryFormatter"/>
+/// through the production <see cref="MethodComparisonBatchProcessor"/> and assert exactly that.
+/// They FAIL against current code, demonstrating the bug.
+/// </para>
+/// </summary>
+public class MethodComparisonBatchProcessorBaselineInversionTests
+{
+    private const string ClassName = "SailfishBugRepro.BaselineVerdictInversionRepro";
+    private const string Group = "Concat";
+
+    // The single IsBaseline = true method, and its (deliberately slow) per-case means in ms.
+    private const string BaselineMethod = "WithPlus";
+
+    // name (as printed by ExtractMethodName) -> true mean in ms.
+    private static readonly Dictionary<string, double> TrueMeanMs = new(StringComparer.Ordinal)
+    {
+        ["WithPlus(N: 100)"] = 8.0,     // baseline, slow
+        ["WithPlus(N: 10000)"] = 240.0, // baseline, slow
+        ["WithStringBuilder(N: 100)"] = 1.0,    // candidate, fast
+        ["WithStringBuilder(N: 10000)"] = 4.0,  // candidate, fast
+    };
+
+    private readonly ITestOutputHelper _output;
+    private readonly IAdapterSailDiff _sailDiff = Substitute.For<IAdapterSailDiff>();
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+
+    // The REAL unified formatter — the bug lives in the formatting/operand path, so a mocked
+    // formatter (as in the sibling Accumulate tests) would hide it.
+    private readonly ISailDiffUnifiedFormatter _formatter = SailDiffUnifiedFormatterFactory.Create();
+
+    public MethodComparisonBatchProcessorBaselineInversionTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task IdeComparisonOutput_DoesNotInvertOrMislabelTheBaseline()
+    {
+        // Arrange: a faithful fake of AdapterSailDiff. It maps operands the same way the real one
+        // does (before = preloaded run, after = the summary result under the common id), so the
+        // before/after means are exactly what the production code would feed the formatter.
+        _sailDiff.ComputeTestCaseDiff(default!, default!, default!, default!, default!)
+            .ReturnsForAnyArgs(ci =>
+            {
+                var currentId = ci.ArgAt<string>(2);
+                var summary = ci.ArgAt<IClassExecutionSummary>(3);
+                var preloadedBefore = ci.ArgAt<PerformanceRunResult>(4);
+
+                var beforeMean = preloadedBefore.Mean;
+                var afterMean = summary.CompiledTestCaseResults
+                    .First(x => x.PerformanceRunResult is not null
+                                && x.PerformanceRunResult.DisplayName == currentId)
+                    .PerformanceRunResult!.Mean;
+
+                return BuildDiff(beforeMean, afterMean);
+            });
+
+        var published = new List<FrameworkTestCaseEndNotification>();
+        _mediator
+            .When(m => m.Publish(Arg.Any<FrameworkTestCaseEndNotification>(), Arg.Any<CancellationToken>()))
+            .Do(ci => published.Add(ci.Arg<FrameworkTestCaseEndNotification>()));
+
+        // Two methods across two SailfishVariable values => 4 cases. Baseline (WithPlus) = large mean.
+        var p100 = CreateMessage("WithPlus(N: 100)", TrueMeanMs["WithPlus(N: 100)"], isBaseline: true);
+        var p10000 = CreateMessage("WithPlus(N: 10000)", TrueMeanMs["WithPlus(N: 10000)"], isBaseline: true);
+        var sb100 = CreateMessage("WithStringBuilder(N: 100)", TrueMeanMs["WithStringBuilder(N: 100)"], isBaseline: false);
+        var sb10000 = CreateMessage("WithStringBuilder(N: 10000)", TrueMeanMs["WithStringBuilder(N: 10000)"], isBaseline: false);
+
+        var all = new[] { p100, p10000, sb100, sb10000 };
+        AttachClassExecutionSummary(all);
+
+        var batch = new TestCaseBatch
+        {
+            BatchId = $"Comparison_{ClassName}_{Group}",
+            TestCases = all.ToList(),
+            Status = BatchStatus.Complete,
+            CreatedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow,
+        };
+
+        var sut = new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _formatter);
+
+        // Act
+        await sut.ProcessBatch(batch, CancellationToken.None);
+
+        // Collect every IMPACT verdict line the user would see, from every method's row.
+        var verdicts = published
+            .SelectMany(n => ParseVerdicts(n.TestOutputWindowMessage))
+            .ToList();
+
+        foreach (var n in published)
+        {
+            _output.WriteLine($"----- {n.TestCase.FullyQualifiedName} -----");
+            _output.WriteLine(n.TestOutputWindowMessage);
+        }
+
+        verdicts.ShouldNotBeEmpty("expected the IDE comparison output to contain '… IMPACT: …' verdict lines");
+
+        var failures = new List<string>();
+
+        foreach (var v in verdicts)
+        {
+            var comparedName = StripIcon(v.Compared);
+            var primaryName = v.Primary;
+
+            // (c) — no row may compare a case against itself.
+            if (string.Equals(comparedName, primaryName, StringComparison.Ordinal))
+                failures.Add($"SELF-PAIR: '{v.Line}'");
+
+            var haveCompared = TrueMeanMs.TryGetValue(comparedName, out var comparedTrue);
+            var havePrimary = TrueMeanMs.TryGetValue(primaryName, out var primaryTrue);
+            if (!haveCompared || !havePrimary)
+            {
+                failures.Add($"UNRECOGNIZED METHOD NAME in: '{v.Line}'");
+                continue;
+            }
+
+            // (b) — direction must match ground truth: "faster" iff the compared method's true mean
+            // is below the named baseline's true mean.
+            var expectedFaster = comparedTrue < primaryTrue;
+            var reportedFaster = v.Direction == "faster";
+            if (reportedFaster != expectedFaster)
+                failures.Add(
+                    $"INVERTED VERDICT: '{v.Line}' — reported '{v.Direction}', but {comparedName} (mean {comparedTrue}ms) " +
+                    $"vs baseline {primaryName} (mean {primaryTrue}ms) should be '{(expectedFaster ? "faster" : "slower")}'");
+
+            // (c) — printed means must not be transposed: the mean printed beside the named baseline
+            // must order the same way as that baseline's true mean relative to the compared method.
+            var printedPrimaryAbove = v.PrimaryMean > v.ComparedMean;
+            var truePrimaryAbove = primaryTrue > comparedTrue;
+            if (printedPrimaryAbove != truePrimaryAbove)
+                failures.Add(
+                    $"TRANSPOSED MEANS: '{v.Line}' — printed baseline mean {v.PrimaryMean} → compared {v.ComparedMean}, " +
+                    $"but baseline {primaryName} (true {primaryTrue}ms) vs {comparedName} (true {comparedTrue}ms) are the other way round");
+
+            // (a) — when the two methods differ, the baseline named must be the IsBaseline method.
+            var comparedIsBaseline = comparedName.StartsWith(BaselineMethod, StringComparison.Ordinal);
+            var primaryIsBaseline = primaryName.StartsWith(BaselineMethod, StringComparison.Ordinal);
+            var mixedPair = comparedIsBaseline ^ primaryIsBaseline;
+            if (mixedPair && !primaryIsBaseline)
+                failures.Add(
+                    $"WRONG BASELINE IDENTITY: '{v.Line}' — '{primaryName}' is labelled the baseline, " +
+                    $"but the only IsBaseline=true method is '{BaselineMethod}'");
+        }
+
+        // Crisp restatement of the exact reported symptom: no line may claim a WithPlus case is
+        // FASTER than a WithStringBuilder baseline (WithPlus is always the slower method here).
+        var inverted = verdicts.FirstOrDefault(v =>
+            StripIcon(v.Compared).StartsWith("WithPlus", StringComparison.Ordinal) &&
+            v.Primary.StartsWith("WithStringBuilder", StringComparison.Ordinal) &&
+            v.Direction == "faster");
+        if (inverted is not null)
+            failures.Add($"REPORTED SYMPTOM REPRODUCED: '{inverted.Line}'");
+
+        failures.ShouldBeEmpty(
+            "Baseline comparison verdicts are inverted/mislabelled:" + Environment.NewLine +
+            string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>
+    /// Locks the post-fix formatter contract: <see cref="ImpactSummaryFormatter"/> renders comparison
+    /// data verbatim — the named baseline (<c>PrimaryMethodName</c>) always carries MeanBefore and the
+    /// contender (<c>ComparedMethodName</c>) MeanAfter. The producer is now responsible for orienting
+    /// the statistics, so the formatter must NOT re-derive or swap anything (the historical
+    /// perspective heuristic is gone). A regression here would resurrect the inverted verdict.
+    /// </summary>
+    [Fact]
+    public void ImpactSummary_RendersPreOrientedComparison_WithoutTransposing()
+    {
+        const double baselineMeanMs = 200.0;   // WithPlus — slow baseline
+        const double contenderMeanMs = 2.0;    // WithStringBuilder — fast contender
+
+        // Pre-oriented by the producer: Before = baseline (WithPlus), After = contender (StringBuilder).
+        var stats = BuildStat(meanBefore: baselineMeanMs, meanAfter: contenderMeanMs);
+
+        var data = new SailDiffComparisonData
+        {
+            GroupName = Group,
+            PrimaryMethodName = "WithPlus(N: 100)",           // the baseline-flagged method
+            ComparedMethodName = "WithStringBuilder(N: 100)", // the contender
+            IsPerspectiveBased = false,
+            Statistics = stats,
+            Metadata = new ComparisonMetadata { AlphaLevel = 0.05 }
+        };
+
+        var summary = new ImpactSummaryFormatter().CreateImpactSummary(data, OutputContext.Ide);
+        _output.WriteLine(summary);
+
+        var verdict = ParseVerdicts(summary).Single();
+
+        verdict.Primary.ShouldBe("WithPlus(N: 100)", $"the baseline-flagged method must be named the baseline. Got: '{verdict.Line}'");
+        StripIcon(verdict.Compared).ShouldBe("WithStringBuilder(N: 100)");
+        verdict.Direction.ShouldBe("faster",
+            $"the contender (~{contenderMeanMs}ms) is faster than the baseline (~{baselineMeanMs}ms). Got: '{verdict.Line}'");
+        verdict.PrimaryMean.ShouldBeGreaterThan(verdict.ComparedMean,
+            $"the baseline (WithPlus, ~{baselineMeanMs}ms) must print a LARGER mean than the contender " +
+            $"(WithStringBuilder, ~{contenderMeanMs}ms); a smaller baseline mean would mean the name/mean pair was transposed. Got: '{verdict.Line}'");
+    }
+
+    // ---------- helpers ----------
+
+    private sealed record Verdict(string Line, string Compared, double Pct, string Direction, string Primary, double PrimaryMean, double ComparedMean);
+
+    private static readonly Regex VerdictRx = new(
+        @"IMPACT:\s*(?<compared>.+?)\s+is\s+(?<pct>[\d.]+)%\s+(?<dir>faster|slower)\s+than\s+baseline\s+(?<primary>.+?)\s+\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex MeanRx = new(
+        @"Mean:\s*(?<pt>[\d.]+)\s*\S+\s*→\s*(?<ct>[\d.]+)",
+        RegexOptions.Compiled);
+
+    private static IEnumerable<Verdict> ParseVerdicts(string output)
+    {
+        var lines = output.Replace("\r\n", "\n").Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var vm = VerdictRx.Match(lines[i]);
+            if (!vm.Success) continue;
+
+            double pt = double.NaN, ct = double.NaN;
+            // The "P-Value … | Mean: A → B" detail is the next non-empty line.
+            for (var j = i + 1; j < Math.Min(lines.Length, i + 3); j++)
+            {
+                var mm = MeanRx.Match(lines[j]);
+                if (mm.Success)
+                {
+                    pt = double.Parse(mm.Groups["pt"].Value, CultureInfo.InvariantCulture);
+                    ct = double.Parse(mm.Groups["ct"].Value, CultureInfo.InvariantCulture);
+                    break;
+                }
+            }
+
+            yield return new Verdict(
+                lines[i].Trim(),
+                vm.Groups["compared"].Value.Trim(),
+                double.Parse(vm.Groups["pct"].Value, CultureInfo.InvariantCulture),
+                vm.Groups["dir"].Value,
+                vm.Groups["primary"].Value.Trim(),
+                pt,
+                ct);
+        }
+    }
+
+    // The compared token includes the leading significance icon (🟢/🔴/⚪); strip it for name compares.
+    private static string StripIcon(string compared)
+    {
+        var idx = compared.IndexOf("IMPACT:", StringComparison.Ordinal);
+        var s = idx >= 0 ? compared[(idx + "IMPACT:".Length)..] : compared;
+        return s.Trim();
+    }
+
+    private TestCompletionQueueMessage CreateMessage(string methodWithVariables, double meanMs, bool isBaseline)
+    {
+        var fqn = $"{ClassName}.{methodWithVariables}";
+        var testCase = new TestCase(fqn, new Uri("executor://sailfish"), "Sailfish");
+        return new TestCompletionQueueMessage
+        {
+            TestCaseId = fqn,
+            TestResult = new TestExecutionResult { IsSuccess = true },
+            CompletedAt = DateTime.UtcNow,
+            Metadata = new Dictionary<string, object>
+            {
+                ["ComparisonGroup"] = Group,
+                ["ComparisonRole"] = isBaseline ? "Baseline" : "Comparison",
+                ["TestCase"] = testCase,
+                ["StartTime"] = DateTimeOffset.UtcNow.AddSeconds(-1),
+                ["EndTime"] = DateTimeOffset.UtcNow,
+            },
+            PerformanceMetrics = new PerformanceMetrics
+            {
+                MeanMs = meanMs,
+                MedianMs = meanMs,
+                SampleSize = 5,
+                StandardDeviation = meanMs * 0.01,
+                Variance = 1.0,
+                RawExecutionResults = new[] { meanMs, meanMs, meanMs },
+                DataWithOutliersRemoved = new[] { meanMs, meanMs, meanMs },
+                UpperOutliers = Array.Empty<double>(),
+                LowerOutliers = Array.Empty<double>(),
+                TotalNumOutliers = 0,
+                GroupingId = Group,
+                NumWarmupIterations = 0
+            }
+        };
+    }
+
+    private static StatisticalTestResult BuildStat(double meanBefore, double meanAfter)
+    {
+        // Raw arrays must carry the means: ImpactSummaryFormatter recomputes display means from them.
+        var rawBefore = new[] { meanBefore, meanBefore, meanBefore };
+        var rawAfter = new[] { meanAfter, meanAfter, meanAfter };
+        return new StatisticalTestResult(
+            meanBefore: meanBefore,
+            meanAfter: meanAfter,
+            medianBefore: meanBefore,
+            medianAfter: meanAfter,
+            testStatistic: 5.0,
+            pValue: 0.0000001,                 // strongly significant
+            changeDescription: "Significant",  // must not contain "No Change"
+            sampleSizeBefore: rawBefore.Length,
+            sampleSizeAfter: rawAfter.Length,
+            rawDataBefore: rawBefore,
+            rawDataAfter: rawAfter,
+            additionalResults: new Dictionary<string, object>());
+    }
+
+    private static TestCaseSailDiffResult BuildDiff(double meanBefore, double meanAfter)
+    {
+        var stat = BuildStat(meanBefore, meanAfter);
+        var withOutliers = new TestResultWithOutlierAnalysis(
+            stat,
+            new ProcessedStatisticalTestData(stat.RawDataBefore, stat.RawDataBefore, Array.Empty<double>(), Array.Empty<double>(), 0),
+            new ProcessedStatisticalTestData(stat.RawDataAfter, stat.RawDataAfter, Array.Empty<double>(), Array.Empty<double>(), 0));
+        var diff = new SailDiffResult(new TestCaseId("Comparison"), withOutliers);
+        return new TestCaseSailDiffResult(
+            new List<SailDiffResult> { diff },
+            new TestIds(new[] { "before" }, new[] { "after" }),
+            new Sailfish.Analysis.SailDiff.SailDiffSettings());
+    }
+
+    private static void AttachClassExecutionSummary(params TestCompletionQueueMessage[] messages)
+    {
+        var compiled = new List<ICompiledTestCaseResult>();
+        foreach (var m in messages)
+        {
+            var pm = m.PerformanceMetrics;
+            var clean = pm.DataWithOutliersRemoved ?? pm.RawExecutionResults ?? Array.Empty<double>();
+            var n = clean.Length;
+            var se = n > 1 ? pm.StandardDeviation / Math.Sqrt(n) : 0;
+            var pr = new PerformanceRunResult(
+                m.TestCaseId,
+                pm.MeanMs,
+                pm.StandardDeviation,
+                pm.Variance,
+                pm.MedianMs,
+                pm.RawExecutionResults ?? Array.Empty<double>(),
+                pm.SampleSize,
+                pm.NumWarmupIterations,
+                clean,
+                pm.UpperOutliers ?? Array.Empty<double>(),
+                pm.LowerOutliers ?? Array.Empty<double>(),
+                pm.TotalNumOutliers,
+                se,
+                0.95,
+                pm.MeanMs,
+                pm.MeanMs,
+                0.0);
+            compiled.Add(new StubCompiledResult(new TestCaseId(m.TestCaseId), pm.GroupingId ?? string.Empty, pr));
+        }
+
+        var summary = new StubClassExecutionSummary(typeof(object), new ExecutionSettings(), compiled);
+        foreach (var m in messages)
+        {
+            m.Metadata["ClassExecutionSummaries"] = summary;
+        }
+    }
+
+    private sealed class StubCompiledResult : ICompiledTestCaseResult
+    {
+        public StubCompiledResult(TestCaseId id, string grouping, PerformanceRunResult pr)
+        {
+            TestCaseId = id;
+            GroupingId = grouping;
+            PerformanceRunResult = pr;
+        }
+
+        public string? GroupingId { get; }
+        public PerformanceRunResult? PerformanceRunResult { get; }
+        public Exception? Exception { get; } = null;
+        public TestCaseId? TestCaseId { get; }
+    }
+
+    private sealed class StubClassExecutionSummary : IClassExecutionSummary
+    {
+        public StubClassExecutionSummary(Type type, IExecutionSettings settings, IEnumerable<ICompiledTestCaseResult> results)
+        {
+            TestClass = type;
+            ExecutionSettings = settings;
+            CompiledTestCaseResults = results;
+        }
+
+        public Type TestClass { get; }
+        public IExecutionSettings ExecutionSettings { get; }
+        public IEnumerable<ICompiledTestCaseResult> CompiledTestCaseResults { get; }
+        public IEnumerable<ICompiledTestCaseResult> GetSuccessfulTestCases() => CompiledTestCaseResults.Where(x => x.PerformanceRunResult is not null);
+        public IEnumerable<ICompiledTestCaseResult> GetFailedTestCases() => CompiledTestCaseResults.Where(x => x.PerformanceRunResult is null);
+        public IClassExecutionSummary FilterForSuccessfulTestCases() => new StubClassExecutionSummary(TestClass, ExecutionSettings, GetSuccessfulTestCases());
+        public IClassExecutionSummary FilterForFailureTestCases() => new StubClassExecutionSummary(TestClass, ExecutionSettings, GetFailedTestCases());
+    }
+}


### PR DESCRIPTION
## Problem

The IDE method-comparison output (Sailfish.TestAdapter, surfaced on 4.0.136) reported baseline verdicts **backwards**. With a `[SailfishMethod(ComparisonGroup = "Concat", IsBaseline = true)]` slow method `WithPlus` and a fast `WithStringBuilder`, the output read:

```
🟢 IMPACT: WithPlus(N: 10000) is 100.0% faster than baseline WithStringBuilder(N: 100)
   P-Value: 0.000000 | Mean: 18.966 ms → 0.001 ms
```

The slowest method (`WithPlus`, 18.966 ms) was reported as the *fastest*, its mean printed on the **wrong side**, the wrong method labelled the baseline, and sizes compared across different `N`.

## Root causes (three, all fixed)

1. **Operand transposition.** The per-perspective swap guard `IsPerspectiveBased && PerspectiveMethodName == ComparedMethodName` was **always false** — it compared a full `TestCaseId` to an extracted leaf name, and tested the wrong field (the perspective method is always the *primary*, never the compared). So "after-perspective" rows printed the baseline's name beside the contender's mean. The producer now **pre-orients** the statistics (`FormatOriented` / `OrientStatistics`) so `MeanBefore` always describes the named baseline, and the dead guard is removed from all five formatters.

2. **`IsBaseline` ignored.** The TestAdapter comparison path never read `IsBaseline`. It is now plumbed through discovery (`ExtractIsBaseline` → `MethodMetaData.IsBaseline` → `SailfishComparisonRoleProperty = "Baseline"` → `metadata["ComparisonRole"]`), and the batch processor compares each contender **against the flagged baseline**.

3. **Cross-N pairing.** Comparisons are now partitioned by variable set, so contenders are only compared to the baseline **at the same `N`** (TestAdapter + markdown paths; the markdown change also fixes the scaled-baseline ">1 baseline" N×N fallback).

## After the fix (real RELEASE run)

```
🟢 IMPACT: WithStringBuilder(N: 100)   is 79.2% faster than baseline WithPlus(N: 100)   (IMPROVED)
🟢 IMPACT: WithStringBuilder(N: 10000) is 99.8% faster than baseline WithPlus(N: 10000) (IMPROVED)
```

Baseline correctly resolved to the `IsBaseline` method, correct direction, no cross-N rows.

## Tests & verification

- New deterministic regression test (`MethodComparisonBatchProcessor_BaselineInversionTests`) — failed against the pre-fix code, passes now; drives the real formatter through the production batch processor with synthetic stats across two variable values.
- New dormant repro benchmark (`BaselineVerdictInversionRepro`, `Disabled = true`) and a written diagnosis (`docs/diagnosis/baseline-verdict-inversion.md`).
- Full suites green: **Tests.Library 1603/1603**, **Tests.TestAdapter 569/569**; full solution builds in Release (net9.0 + net10.0); end-to-end RELEASE run confirms correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)