### PR TITLE
feat(saildiff): default to box plot, redesigned as a real 3-row box

### DIFF
--- a/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailfishConsoleWindowFormatter.cs
+++ b/source/Sailfish.TestAdapter/Display/TestOutputWindow/SailfishConsoleWindowFormatter.cs
@@ -151,7 +151,7 @@ internal class SailfishConsoleWindowFormatter : ISailfishConsoleWindowFormatter
                     results.Median,
                     results.UpperOutliers.Concat(results.LowerOutliers).ToArray())
             };
-            var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+            var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.BoxPlot;
             var plot = DistributionPlotRenderer.Render(series, unit, style);
             if (!string.IsNullOrEmpty(plot))
             {

--- a/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
+++ b/source/Sailfish/Analysis/SailDiff/Formatting/DistributionPlotFormatter.cs
@@ -100,7 +100,7 @@ public class DistributionPlotFormatter : IDistributionPlotFormatter
         if (drawable.Count == 0) return string.Empty;
 
         var unit = DurationFormatter.SelectUnit(drawable.SelectMany(s => s.Samples));
-        var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+        var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.BoxPlot;
         return DistributionPlotRenderer.Render(drawable, unit, style, PlotWidth);
     }
 

--- a/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
+++ b/source/Sailfish/Contracts.Public/Models/IRunSettings.cs
@@ -56,7 +56,7 @@ public interface IRunSettings
     // Inline Unicode distribution plots in IDE / Markdown output (default: true)
     bool EnableDistributionPlots { get; }
 
-    // Which inline distribution plot to render — histogram (default) or box-and-whisker
+    // Which inline distribution plot to render — box-and-whisker (default) or histogram
     Sailfish.Presentation.DistributionPlotStyle DistributionPlotStyle { get; }
 
     // Emit a standalone SVG distribution HTML report alongside the run output (default: false)

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -517,7 +517,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             if (series.Count == 0) return;
 
             var unit = DurationFormatter.SelectUnit(series.SelectMany(s => s.Samples));
-            var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+            var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.BoxPlot;
             var plot = DistributionPlotRenderer.Render(series, unit, style);
             if (string.IsNullOrEmpty(plot)) return;
 

--- a/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
+++ b/source/Sailfish/Presentation/AsciiBoxPlotRenderer.cs
@@ -10,7 +10,10 @@ namespace Sailfish.Presentation;
 /// single shared axis. Output is plain monospace text, so it lines up in IDE test-output windows and
 /// inside fenced code blocks in Markdown. No external dependencies.
 /// <para>
-/// Glyphs: <c>┣━┫</c> whisker (min–max), <c>▒</c> IQR box, <c>┃</c> median, <c>◆</c> mean.
+/// Glyphs: <c>├─┤</c> whisker (min–max); a three-row rectangle (<c>┌─┐</c> / <c>└─┘</c>) for the IQR
+/// box, with the whisker centre line running straight through the box sides (<c>┼</c>); a heavy
+/// vertical (<c>┿</c>) for the median; and <c>×</c> for the mean. Each series spans three rows so the
+/// IQR reads as a real box rather than a flat bar.
 /// The axis is scaled to the <em>cleaned</em> min–max so the distribution shape stays legible; any
 /// outliers Sailfish removed are reported as a count beside the lane rather than stretching the axis
 /// (their exact values are listed in the surrounding text). The axis unit (ns/µs/ms/s) is chosen by
@@ -21,7 +24,6 @@ public static class AsciiBoxPlotRenderer
 {
     private const int DefaultWidth = 54;
     private const int MinWidth = 24;
-    private const int MaxLabelWidth = 28;
 
     // Fraction of the data range to pad onto each side of the axis. 0.25 each side leaves the data
     // spanning the central 2/3 of the lane, so whiskers sit around 1/6 and 5/6 of the width.
@@ -31,9 +33,23 @@ public static class AsciiBoxPlotRenderer
     private const char WhiskerLine = '─';
     private const char WhiskerCapLow = '├';
     private const char WhiskerCapHigh = '┤';
-    private const char BoxFill = '▓';
-    private const char MedianMark = '┃';
-    private const char MeanMark = '◆';
+
+    // The IQR box is a real rectangle drawn across three rows (top edge, whisker row, bottom edge).
+    // The corners and the middle-row sides are connecting box-drawing glyphs, so the whisker line
+    // flows straight into the box with no gap.
+    private const char BoxTopLeft = '┌';
+    private const char BoxTopRight = '┐';
+    private const char BoxBottomLeft = '└';
+    private const char BoxBottomRight = '┘';
+    private const char BoxSide = '┼';  // Q1/Q3 sides on the whisker row — the whisker line runs through
+
+    // Median: a heavy vertical through the box that the whisker centre line passes through (┿), capped
+    // with light tees where it meets the box edges. Mean: a single glyph on the centre line.
+    private const char MedianTop = '┬';
+    private const char MedianLine = '┿';
+    private const char MedianBottom = '┴';
+    private const char MeanMark = '×';
+
     private const char RulerLine = '─';
     private const char RulerTick = '┬';
     private const char RulerCornerLow = '└';
@@ -44,7 +60,7 @@ public static class AsciiBoxPlotRenderer
     /// </summary>
     /// <param name="series">Series to draw on a shared axis (1 = single box, 2 = comparison, N = group).</param>
     /// <param name="unit">Display unit for the axis (typically <see cref="DurationFormatter.SelectUnit(System.Collections.Generic.IEnumerable{double})"/>).</param>
-    /// <param name="width">Plot width in characters (the drawable lane, excluding the label column).</param>
+    /// <param name="width">Plot width in characters. Captions sit above each box, so no line exceeds this.</param>
     public static string Render(IReadOnlyList<BoxPlotSeries> series, DurationUnit unit, int width = DefaultWidth)
     {
         if (series is null) return string.Empty;
@@ -80,75 +96,121 @@ public static class AsciiBoxPlotRenderer
             return Math.Clamp(col, 0, width - 1);
         }
 
-        var labelWidth = Math.Clamp(drawable.Max(s => (s.Label ?? string.Empty).Length), 0, MaxLabelWidth);
-        var labelPad = new string(Space, labelWidth);
         var decimals = AxisDecimals(spanU);
 
         var sb = new StringBuilder();
 
-        // Header: unit, right-aligned over the lane.
-        var unitHeader = $"Time ({DurationFormatter.UnitLabel(unit)})";
-        sb.Append(labelPad).Append("  ").AppendLine(PadCentreOrRight(unitHeader, width));
+        // Header: unit label, right-aligned over the plot.
+        sb.AppendLine(PadCentreOrRight($"Time ({DurationFormatter.UnitLabel(unit)})", width));
+        sb.AppendLine();
 
-        // One lane per series.
+        // Each series: a caption line (method name + sample count) ABOVE its box, with the box and the
+        // shared axis all left-aligned at column 0. There is no label column, so a rendered line is never
+        // wider than the plot itself — it won't wrap on a narrower terminal window.
         foreach (var s in drawable)
         {
-            sb.Append(TruncatePad(s.Label ?? string.Empty, labelWidth)).Append("  ");
-            sb.Append(Lane(s, width, Col));
-            sb.Append("  n=").Append(s.N);
-            if (s.OutlierCount > 0) sb.Append(" (+").Append(s.OutlierCount).Append(" outliers)");
+            var (top, mid, bottom) = BuildBox(s, width, Col);
+
+            sb.AppendLine(Caption(s.Label ?? string.Empty, CountLabel(s), width));
+            sb.AppendLine(top.TrimEnd());
+            sb.AppendLine(mid.TrimEnd());
+            sb.AppendLine(bottom.TrimEnd());
             sb.AppendLine();
         }
 
         // Shared axis ruler + tick labels.
-        sb.Append(labelPad).Append("  ").AppendLine(Ruler(width, spanU));
-        sb.Append(labelPad).Append("  ").AppendLine(TickLabels(width, axisMinMs, axisMaxMs, unit, decimals, spanU));
+        sb.AppendLine(Ruler(width, spanU));
+        sb.AppendLine(TickLabels(width, axisMinMs, axisMaxMs, unit, decimals, spanU));
+        sb.AppendLine();
 
         // Legend.
-        sb.Append("  ").Append(MedianMark).Append(" median  ")
+        sb.Append(MedianLine).Append(" median  ")
             .Append(MeanMark).Append(" mean  ")
-            .Append(BoxFill).Append(" IQR box  ")
+            .Append(BoxTopLeft).Append(WhiskerLine).Append(BoxTopRight).Append(" IQR box  ")
             .Append(WhiskerCapLow).Append(WhiskerLine).Append(WhiskerCapHigh).Append(" min–max");
         sb.AppendLine();
 
         return sb.ToString();
     }
 
-    private static string Lane(BoxPlotSeries s, int width, Func<double, int> col)
+    // Builds the three rows of one series' box-and-whisker: the box top edge, the whisker row (with the
+    // box sides, the median line and the mean glyph), and the box bottom edge. All three share the same
+    // column mapping, so they stack into a real rectangle on the shared axis.
+    private static (string Top, string Mid, string Bottom) BuildBox(BoxPlotSeries s, int width, Func<double, int> col)
     {
-        var buf = new char[width];
-        for (var i = 0; i < width; i++) buf[i] = Space;
+        var top = new char[width];
+        var mid = new char[width];
+        var bottom = new char[width];
+        Array.Fill(top, Space);
+        Array.Fill(mid, Space);
+        Array.Fill(bottom, Space);
 
         if (s.HasNoSpread)
         {
-            buf[col(s.Median)] = MeanMark;
-            return new string(buf);
+            // A single value (or an all-equal sample) has no box; just mark the point on the whisker row.
+            mid[col(s.Median)] = MeanMark;
+            return (new string(top), new string(mid), new string(bottom));
         }
 
         var minC = col(s.Min);
         var maxC = col(s.Max);
         var q1C = col(s.Q1);
         var q3C = col(s.Q3);
+        var medianC = col(s.Median);
+        var meanC = col(s.Mean);
 
-        // Layers, painted low-to-high precedence (later overwrites earlier). The shaded run itself is
-        // the IQR box — set against the thin whisker line it reads as a crisp block with no need for
-        // bracket edges that could be mistaken for whisker caps.
+        // Whisker line spans the cleaned min–max on the middle row, and runs straight through the box
+        // interior (the box is an outline, not a fill — but its centre line stays connected, no gap).
         for (var i = minC; i <= maxC; i++)
+            if (mid[i] == Space) mid[i] = WhiskerLine;
+
+        if (minC < q1C) mid[minC] = WhiskerCapLow;
+        if (maxC > q3C) mid[maxC] = WhiskerCapHigh;
+
+        if (q3C > q1C)
         {
-            if (buf[i] == Space) buf[i] = WhiskerLine;
+            // Box outline: top and bottom edges spanning the quartiles, with corners; on the whisker row
+            // the sides are crossings (┼) so the centre line passes through them with no gap.
+            for (var i = q1C; i <= q3C; i++)
+            {
+                top[i] = WhiskerLine;
+                bottom[i] = WhiskerLine;
+            }
+
+            top[q1C] = BoxTopLeft;
+            top[q3C] = BoxTopRight;
+            bottom[q1C] = BoxBottomLeft;
+            bottom[q3C] = BoxBottomRight;
+            mid[q1C] = BoxSide;
+            mid[q3C] = BoxSide;
+
+            // Mean: a single glyph on the centre line (anywhere between the whiskers). Never let it
+            // clobber a box side.
+            if (meanC >= 0 && meanC < width && meanC != q1C && meanC != q3C)
+                mid[meanC] = MeanMark;
+
+            // Median: a heavy vertical through the box, crossing the centre line (┿) and capped with
+            // light tees on the box edges.
+            if (medianC > q1C && medianC < q3C)
+            {
+                top[medianC] = MedianTop;
+                mid[medianC] = MedianLine;
+                bottom[medianC] = MedianBottom;
+            }
+            else if (medianC >= 0 && medianC < width)
+            {
+                mid[medianC] = MedianLine;
+            }
+        }
+        else
+        {
+            // Degenerate IQR (quartiles land on a single column): no room for a box, so draw just the
+            // median plus the mean glyph on the whisker line.
+            if (meanC >= 0 && meanC < width && meanC != medianC) mid[meanC] = MeanMark;
+            if (medianC >= 0 && medianC < width) mid[medianC] = MedianLine;
         }
 
-        if (minC < q1C) buf[minC] = WhiskerCapLow;
-        if (maxC > q3C) buf[maxC] = WhiskerCapHigh;
-
-        for (var i = q1C; i <= q3C; i++) buf[i] = BoxFill;
-
-        var meanC = col(s.Mean);
-        if (meanC >= 0 && meanC < width) buf[meanC] = MeanMark;
-
-        buf[col(s.Median)] = MedianMark; // highest precedence
-
-        return new string(buf);
+        return (new string(top), new string(mid), new string(bottom));
     }
 
     private static string Ruler(int width, double spanU)
@@ -224,15 +286,17 @@ public static class AsciiBoxPlotRenderer
         return 3;
     }
 
-    private static string TruncatePad(string label, int labelWidth)
-    {
-        if (labelWidth == 0) return string.Empty;
-        if (label.Length > labelWidth)
-        {
-            return labelWidth <= 1 ? label[..labelWidth] : label[..(labelWidth - 1)] + "…";
-        }
+    private static string CountLabel(BoxPlotSeries s)
+        => s.OutlierCount > 0 ? $"n={s.N} (+{s.OutlierCount} outliers)" : $"n={s.N}";
 
-        return label.PadRight(labelWidth);
+    // "<label>  <count>" caption sitting above a box, trimmed so it never exceeds the plot width: the
+    // count is kept whole and an over-long method name is ellipsized (or dropped if there's no room).
+    private static string Caption(string label, string count, int width)
+    {
+        var maxLabel = width - 2 - count.Length;
+        if (label.Length > maxLabel)
+            label = maxLabel <= 1 ? string.Empty : label[..(maxLabel - 1)] + "…";
+        return label.Length == 0 ? count : label + "  " + count;
     }
 
     private static string PadCentreOrRight(string text, int width)

--- a/source/Sailfish/Presentation/DistributionPlotRenderer.cs
+++ b/source/Sailfish/Presentation/DistributionPlotRenderer.cs
@@ -8,10 +8,10 @@ namespace Sailfish.Presentation;
 /// </summary>
 public enum DistributionPlotStyle
 {
-    /// <summary>Compact shared-axis histograms (default).</summary>
+    /// <summary>Compact shared-axis histograms.</summary>
     Histogram = 0,
 
-    /// <summary>Horizontal box-and-whisker plots.</summary>
+    /// <summary>Horizontal box-and-whisker plots (default).</summary>
     BoxPlot = 1
 }
 

--- a/source/Sailfish/Presentation/MarkdownTableConverter.cs
+++ b/source/Sailfish/Presentation/MarkdownTableConverter.cs
@@ -287,7 +287,7 @@ public class MarkdownTableConverter : IMarkdownTableConverter
             })
             .ToList();
 
-        var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.Histogram;
+        var style = _runSettings?.DistributionPlotStyle ?? DistributionPlotStyle.BoxPlot;
         var plot = DistributionPlotRenderer.Render(series, unit, style);
         if (string.IsNullOrEmpty(plot)) return;
 

--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -52,7 +52,7 @@ internal class RunSettings : IRunSettings
         AiAnalysisSettings? aiAnalysisSettings = null,
         bool enableDistributionPlots = true,
         bool emitDistributionHtmlReport = false,
-        DistributionPlotStyle distributionPlotStyle = DistributionPlotStyle.Histogram,
+        DistributionPlotStyle distributionPlotStyle = DistributionPlotStyle.BoxPlot,
         TrawlSettings? trawlSettings = null)
     {
         TestNames = testNames;

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -45,7 +45,7 @@ public class RunSettingsBuilder
 
     private bool _enableDistributionPlots = true;
     private bool _emitDistributionHtmlReport;
-    private DistributionPlotStyle _distributionPlotStyle = DistributionPlotStyle.Histogram;
+    private DistributionPlotStyle _distributionPlotStyle = DistributionPlotStyle.BoxPlot;
     private TrawlSettings? _trawlSettings;
 
 
@@ -145,8 +145,8 @@ public class RunSettingsBuilder
     }
 
     /// <summary>
-    ///     Selects the inline distribution plot style — <see cref="DistributionPlotStyle.Histogram"/>
-    ///     (default) or <see cref="DistributionPlotStyle.BoxPlot"/>.
+    ///     Selects the inline distribution plot style — <see cref="DistributionPlotStyle.BoxPlot"/>
+    ///     (default) or <see cref="DistributionPlotStyle.Histogram"/>.
     /// </summary>
     public RunSettingsBuilder WithDistributionPlotStyle(DistributionPlotStyle style)
     {

--- a/source/Tests.Library/Analysis/SailDiff/Formatting/DistributionPlotFormatterTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Formatting/DistributionPlotFormatterTests.cs
@@ -37,13 +37,12 @@ public class DistributionPlotFormatterTests
     }
 
     [Fact]
-    public void CreatePlot_Ide_IncludesPlotHeaderHistogramAndBothMethods()
+    public void CreatePlot_Ide_IncludesPlotHeaderBoxPlotAndBothMethods()
     {
         var output = _formatter.CreatePlot(CreateComparison(), OutputContext.Ide);
 
         output.ShouldContain("📊 DISTRIBUTION");
-        output.ShouldContain("█");                 // histogram block glyph
-        output.ShouldContain("count per bin");      // legend
+        output.ShouldContain("IQR box");            // box-plot legend (the default style)
         output.ShouldContain("Primary");
         output.ShouldContain("Compared");
     }
@@ -104,8 +103,8 @@ public class DistributionPlotFormatterTests
         output.ShouldContain("Tracked");
         output.ShouldContain("NoTracking");
         output.ShouldContain("Projected");
-        // "Tracked" is shared across both comparisons but de-duplicated to a single summary row.
-        output.Split('\n').Count(l => l.Contains("Tracked") && l.Contains("n=")).ShouldBe(1);
+        // "Tracked" is shared across both comparisons but de-duplicated to a single labelled row.
+        output.Split('\n').Count(l => l.Contains("Tracked")).ShouldBe(1);
     }
 
     [Fact]

--- a/source/Tests.Library/Presentation/AsciiHistogramRendererTests.cs
+++ b/source/Tests.Library/Presentation/AsciiHistogramRendererTests.cs
@@ -23,10 +23,10 @@ public class AsciiHistogramRendererTests
 
         output.IndexOfAny("▁▂▃▄▅▆▇█".ToCharArray()).ShouldBeGreaterThanOrEqualTo(0); // histogram glyphs present
         output.ShouldContain("count per bin");
-        // Old inline box-plot glyphs must be gone.
-        output.ShouldNotContain("◆");
-        output.ShouldNotContain("┃");
-        output.ShouldNotContain("▓");
+        // Box-plot glyphs must not leak into the histogram.
+        output.ShouldNotContain("×");   // box-plot mean
+        output.ShouldNotContain("┿");   // box-plot median
+        output.ShouldNotContain("┌");   // box-plot corner
     }
 
     [Fact]

--- a/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
+++ b/source/Tests.Library/Presentation/BoxPlotRendererTests.cs
@@ -71,9 +71,9 @@ public class BoxPlotRendererTests
         var series = BoxPlotData.FromSamples("Method", Ramp(20), mean: 10.5);
         var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds);
 
-        output.ShouldContain("┃");   // median
-        output.ShouldContain("◆");   // mean
-        output.ShouldContain("▓");   // IQR box
+        output.ShouldContain("┿");   // median (heavy vertical crossing the centre line)
+        output.ShouldContain("×");   // mean
+        output.ShouldContain("┌");   // IQR box corner (hollow rectangle)
         output.ShouldContain("Time (ms)");
         output.ShouldContain("median"); // legend
         output.ShouldContain("n=20");
@@ -87,14 +87,13 @@ public class BoxPlotRendererTests
 
         var output = AsciiBoxPlotRenderer.Render(new[] { primary, compared }, DurationUnit.Milliseconds);
 
-        var laneLines = output
-            .Split('\n')
-            .Where(l => l.Contains("n=")) // series lanes are suffixed with the sample count
-            .ToList();
+        // Each series prints its sample count on its box-bottom row.
+        var countLines = output.Split('\n').Where(l => l.Contains("n=")).ToList();
+        countLines.Count.ShouldBe(2);
 
-        laneLines.Count.ShouldBe(2);
-        // Lanes share the same total width (labels are padded to equal length).
-        laneLines.Select(l => l.Length).Distinct().Count().ShouldBe(1);
+        // Exactly one shared axis ruler underlies both series (the only line carrying both a └ corner
+        // and the ┬ ticks; box tops have ┬ but no └, box bottoms have └ but no ┬).
+        output.Split('\n').Count(l => l.Contains('┬') && l.Contains('└')).ShouldBe(1);
     }
 
     [Fact]
@@ -115,7 +114,7 @@ public class BoxPlotRendererTests
         var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds);
 
         output.ShouldNotBeNullOrEmpty();
-        output.ShouldContain("◆");
+        output.ShouldContain("×");
     }
 
     [Fact]
@@ -146,12 +145,15 @@ public class BoxPlotRendererTests
         var series = BoxPlotData.FromSamples("M", Ramp(40), mean: 20.5);
         var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds, width: 60);
 
-        var rulerLine = output.Split('\n').First(l => l.Contains('└'));
-        var laneLine = output.Split('\n').First(l => l.Contains('├'));
+        // The ruler is the LAST line carrying a └ (every series' box bottom also has └, but the ruler
+        // comes after them; the tick-labels and legend below it have none). The whisker caps live on the
+        // whisker row, which carries the median ┿ (the count is on the box-bottom row, not here).
+        var rulerLine = output.Split('\n').Last(l => l.Contains('└'));
+        var laneLine = output.Split('\n').First(l => l.Contains('┿'));
 
-        // The axis ruler (└────┘) spans the full width; the data whiskers (├──┤) must sit inside it.
+        // The axis ruler (└────┘) spans the full width; the data whisker caps (├ … ┤) must sit inside it.
         laneLine.IndexOf('├').ShouldBeGreaterThan(rulerLine.IndexOf('└'));
-        laneLine.IndexOf('┤').ShouldBeLessThan(rulerLine.IndexOf('┘'));
+        laneLine.LastIndexOf('┤').ShouldBeLessThan(rulerLine.LastIndexOf('┘'));
     }
 
     [Fact]
@@ -160,10 +162,11 @@ public class BoxPlotRendererTests
         var series = BoxPlotData.FromSamples("x", Ramp(20), mean: 10.5);
         var output = AsciiBoxPlotRenderer.Render(new[] { series }, DurationUnit.Milliseconds, width: 30);
 
-        var laneLine = output.Split('\n').First(l => l.Contains("n=20"));
-        // label("x"=>1) + 2 spaces + 30 lane + "  n=20"
-        laneLine.ShouldContain(new string('▓', 1)); // some box drawn
-        laneLine.Length.ShouldBeGreaterThan(30);
+        output.ShouldContain("┿"); // a box with a median was drawn
+        // With captions above the boxes there is no label column, so the axis ruler is exactly the
+        // requested plot width (nothing widens the line).
+        var rulerLine = output.Split('\n').Last(l => l.Contains('└'));
+        rulerLine.Length.ShouldBe(30);
     }
 
     #endregion

--- a/source/Tests.Library/Presentation/DistributionPlotRendererTests.cs
+++ b/source/Tests.Library/Presentation/DistributionPlotRendererTests.cs
@@ -30,7 +30,7 @@ public class DistributionPlotRendererTests
         var output = DistributionPlotRenderer.Render(new[] { Series() }, DurationUnit.Milliseconds, DistributionPlotStyle.BoxPlot);
 
         output.ShouldContain("IQR box");          // box-plot legend
-        output.ShouldContain("▓");                 // IQR box fill
+        output.ShouldContain("┌");                 // IQR box corner (hollow rectangle outline)
         output.ShouldNotContain("count per bin");  // not the histogram legend
     }
 

--- a/source/Tests.Library/Presentation/MarkdownTableConverterTests.cs
+++ b/source/Tests.Library/Presentation/MarkdownTableConverterTests.cs
@@ -534,10 +534,10 @@ public class MarkdownTableConverterTests
             // Act
             var result = _markdownTableConverter.ConvertToEnhancedMarkdownTableString(new List<IClassExecutionSummary> { summary });
 
-            // Assert — fenced histogram with both methods present
+            // Assert — fenced box plot (default style) with both methods present
             result.ShouldContain("**Distribution**");
             result.ShouldContain("```text");
-            result.ShouldContain("█"); // histogram block glyph
+            result.ShouldContain("IQR box"); // box-plot legend
             result.ShouldContain("AlphaMethod");
             result.ShouldContain("BetaMethod");
         }

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoaderTests.cs
@@ -57,10 +57,10 @@ public class AdapterRunSettingsLoaderTests
     }
 
     [Fact]
-    public void DistributionPlotStyle_DefaultsToHistogram_WhenUnset()
+    public void DistributionPlotStyle_DefaultsToBoxPlot_WhenUnset()
     {
         var json = "{ \"GlobalSettings\": {}, \"SailDiffSettings\": {}, \"SailfishSettings\": {}, \"ScaleFishSettings\": {} }";
-        LoadFromConfig(json).DistributionPlotStyle.ShouldBe(DistributionPlotStyle.Histogram);
+        LoadFromConfig(json).DistributionPlotStyle.ShouldBe(DistributionPlotStyle.BoxPlot);
     }
 
     [Fact]

--- a/source/Tests.TestAdapter/SailfishConsoleWindowFormatterTests.cs
+++ b/source/Tests.TestAdapter/SailfishConsoleWindowFormatterTests.cs
@@ -152,10 +152,9 @@ public class SailfishConsoleWindowFormatterTests
         // Act
         var output = _formatter.FormConsoleWindowMessageForSailfish(results);
 
-        // Assert — plots default on; a histogram and the legend are present.
+        // Assert — plots default on; the box plot (default style) and its legend are present.
         output.ShouldContain("Distribution Plot");
-        output.ShouldContain("█"); // histogram block glyph
-        output.ShouldContain("count per bin"); // legend
+        output.ShouldContain("IQR box"); // box-plot legend
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

Flips the default distribution plot back to the **box plot** (the histogram was a bit confusing to read), and redesigns the ASCII box plot from a single-row shaded bar into a **real enclosed rectangle** that reads clearly and survives narrow terminal windows.

### Box plot redesign (`AsciiBoxPlotRenderer`)
- **3-row enclosed rectangle** (`┌─┐` / `└─┘`) with the whisker centre line running straight **through** the box (sides `┼`, no empty interior — no "gap").
- **Median** `┿` (heavy vertical the line crosses), capped with light `┬`/`┴` connectors on the box edges.
- **Mean** `×` — replaces `◆`, which has line-breaking font side-bearings.
- **Caption above each box** (`method  n=<count>`, with `(+N outliers)` when present), left-aligned with the box and axis at column 0. Because there's no left label column, **no rendered line exceeds the plot width**, so it doesn't wrap on a narrower window.

```text
QuickSort  n=60
            ┌─────┬────────────┐
          ├─┼─────┿───×────────┼─────────────────┤
            └─────┴────────────┘

└──────────────┬──────────────┬─────────────┬──────────────┘
5.0           9.6           14.2          18.4          23.0

┿ median  × mean  ┌─┐ IQR box  ├─┤ min–max
```

### Default flip → `BoxPlot`
Set in all 5 places the default lives: `RunSettings` ctor param, `RunSettingsBuilder` field, and the four null-settings fallbacks (`DistributionPlotFormatter`, `MethodComparisonTestRunCompletedHandler`, `MarkdownTableConverter`, `SailfishConsoleWindowFormatter`). Enum numeric values are kept stable (so `default(enum)` / unset NSubstitute mocks are unaffected). Histogram remains available via `WithDistributionPlotStyle(Histogram)` / `.sailfish.json`. The SVG HTML report path is untouched.

## Test plan
- Updated the renderer glyph assertions, the "default behaviour" tests (now expect box-plot output), and the layout-dependent tests (ruler/caption detection).
- Full suites green: **1603** (`Tests.Library`) + **569** (`Tests.TestAdapter`); solution builds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced box-and-whisker plot rendering with improved visual layout and Unicode glyphs.

* **Documentation**
  * Updated documentation to reflect box-and-whisker plots as the default distribution visualization style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->