### PR TITLE
fix(saildiff): correct false 'Similar' verdicts and rounded change-direction in comparison output

### DIFF
--- a/source/Sailfish/Analysis/SailDiff/Statistics/MultipleComparisons.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/MultipleComparisons.cs
@@ -10,6 +10,13 @@ namespace Sailfish.Analysis.SailDiff.Statistics
     /// </summary>
     public static class MultipleComparisons
     {
+        // Smallest p-value the comparison helpers report for a genuine difference. A literal 0
+        // is indistinguishable downstream from "no comparison computed": it BH-adjusts to q = 0,
+        // which the q-value cell labels (SailDiffSignificance.IsSignificantPositive) treat as not
+        // significant. So an extreme-but-real difference must never collapse to exactly 0.
+        // See LogRatioPValue.
+        private const double MinPositivePValue = 1e-300;
+
         /// <summary>
         /// Apply Benjamini–Hochberg False Discovery Rate control to a set of p-values.
         /// Returns adjusted q-values (FDR) mapped to the same pair keys.
@@ -113,6 +120,46 @@ namespace Sailfish.Analysis.SailDiff.Statistics
             var lower = Math.Exp(logR - delta);
             var upper = Math.Exp(logR + delta);
             return (ratio, lower, upper);
+        }
+
+        /// <summary>
+        /// Two-sided p-value for H0: meanA == meanB on the log scale, using the same delta-method
+        /// standard error and conservative degrees of freedom as <see cref="ComputeRatioCi"/>.
+        /// Returns <see cref="double.NaN"/> when the test is undefined — a mean is non-positive, or
+        /// neither side has any usable variance (nothing to test against). Otherwise the result is
+        /// always strictly positive — see remarks.
+        /// </summary>
+        /// <remarks>
+        /// The tail is evaluated as <c>2·StudentT.CDF(−|t|)</c> — the lower tail, which MathNet
+        /// returns directly — rather than the algebraically-equivalent <c>2·(1 − StudentT.CDF(|t|))</c>.
+        /// The latter is catastrophic for large <c>t</c>: once the true tail drops below the ULP of
+        /// 1.0 (~1.1e-16) the CDF rounds to exactly 1.0, so <c>1 − CDF</c> becomes 0 and the *most
+        /// significant* comparisons collapse to <c>p = 0</c>. A 0 is then indistinguishable from
+        /// "no comparison computed" and is reported as not significant ("Similar") — the exact
+        /// failure where a 400×, perfectly-separated difference was labelled not significant.
+        /// Evaluating the lower tail keeps the small-but-positive value (≈1e-18); the floor
+        /// guarantees a strictly positive result even past the point where the tail itself
+        /// underflows.
+        /// </remarks>
+        public static double LogRatioPValue(double meanA, double seA, int nA, double meanB, double seB, int nB)
+        {
+            if (!(meanA > 0) || !(meanB > 0)) return double.NaN;
+
+            var logRatio = Math.Abs(Math.Log(meanB / meanA));
+            var seLog = Math.Sqrt(Square(SafeDiv(seA, meanA)) + Square(SafeDiv(seB, meanB)));
+
+            // No usable variance on either side (e.g. N = 1, or StdDev collapsed to 0): there is
+            // nothing to run a variance-based test against, so abstain. NaN routes to "not
+            // significant" downstream — the deliberate "Similar, no q-value" behaviour for cells
+            // whose standard error is unavailable. (The reported zero-variance bug is the *other*
+            // case: one side constant, the other with real spread, so seLog > 0 and the tail
+            // computation below correctly reports significance.)
+            if (seLog <= 0) return double.NaN;
+
+            var t = logRatio / seLog;
+            var dof = Math.Max(1, Math.Min(Math.Max(0, nA - 1), Math.Max(0, nB - 1)));
+            var p = 2.0 * StudentT.CDF(0, 1, dof, -t);
+            return Math.Max(p, MinPositivePValue);
         }
 
         public static (string A, string B) NormalizePair(string a, string b)

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/KolmogorovSmirnovTestSailfish/KolmogorovSmirnovTest.cs
@@ -34,8 +34,10 @@ public class KolmogorovSmirnovTest : IKolmogorovSmirnovTest
 
             var test = TwoSampleKolmogorovSmirnovFactory.Create(sample1, sample2);
 
-            var meanBefore = Math.Round(sample1.Mean(), sigDig);
-            var meanAfter = Math.Round(sample2.Mean(), sigDig);
+            var rawMeanBefore = sample1.Mean();
+            var rawMeanAfter = sample2.Mean();
+            var meanBefore = Math.Round(rawMeanBefore, sigDig);
+            var meanAfter = Math.Round(rawMeanAfter, sigDig);
 
             var medianBefore = Math.Round(sample1.Median(), sigDig);
             var medianAfter = Math.Round(sample2.Median(), sigDig);
@@ -44,7 +46,9 @@ public class KolmogorovSmirnovTest : IKolmogorovSmirnovTest
             var pVal = Math.Round(test.PValue, TestConstants.PValueSigDig);
 
             var isSignificant = test.PValue <= settings.Alpha;
-            var changeDirection = meanAfter > meanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
+            // Direction from the unrounded means — rounding for display can collapse a real
+            // sub-resolution difference to equal and flip the verdict to Improved.
+            var changeDirection = rawMeanAfter > rawMeanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
 
             var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
 

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/MWWilcoxonTestSailfish/MannWhitneyWilcoxonTest.cs
@@ -52,15 +52,20 @@ public class MannWhitneyWilcoxonTest : IMannWhitneyWilcoxonTest
 
             var test = MannWhitneyWilcoxonFactory.Create(sample1, sample2);
 
-            var meanBefore = Math.Round(sample1.Mean(), sigDig);
-            var meanAfter = Math.Round(sample2.Mean(), sigDig);
+            var rawMeanBefore = sample1.Mean();
+            var rawMeanAfter = sample2.Mean();
+            var meanBefore = Math.Round(rawMeanBefore, sigDig);
+            var meanAfter = Math.Round(rawMeanAfter, sigDig);
             var medianBefore = Math.Round(sample1.Median(), sigDig);
             var medianAfter = Math.Round(sample2.Median(), sigDig);
             var testStatistic = Math.Round(test.Statistic, sigDig);
             var pVal = Math.Round(test.PValue, TestConstants.PValueSigDig);
             var isSignificant = test.PValue <= settings.Alpha;
+            // Direction from the unrounded means. Rounding for display (settings.Round) can
+            // collapse a small-but-real difference to equal, and `meanAfter > meanBefore` would
+            // then fall through to the Improved branch — mislabelling a regression as improved.
             var description = isSignificant
-                ? meanAfter > meanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved
+                ? rawMeanAfter > rawMeanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved
                 : SailfishChangeDirection.NoChange;
             var additionalResults = new Dictionary<string, object>
             {

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/PermutationTest/PermutationTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/PermutationTest/PermutationTest.cs
@@ -116,12 +116,16 @@ public class PermutationTest : IPermutationTest
             var pVal = (1.0 + countAtLeastAsExtreme) / (1.0 + k);
             var isSignificant = pVal <= settings.Alpha;
 
-            var meanBefore = Math.Round(sample1.Mean(), sigDig);
-            var meanAfter = Math.Round(sample2.Mean(), sigDig);
+            var rawMeanBefore = sample1.Mean();
+            var rawMeanAfter = sample2.Mean();
+            var meanBefore = Math.Round(rawMeanBefore, sigDig);
+            var meanAfter = Math.Round(rawMeanAfter, sigDig);
             var medianBefore = Math.Round(sample1.Median(), sigDig);
             var medianAfter = Math.Round(sample2.Median(), sigDig);
             var testStatistic = Math.Round(observed, sigDig);
-            var changeDirection = meanAfter > meanBefore
+            // Direction from the unrounded means — rounding for display can collapse a real
+            // sub-resolution difference to equal and flip the verdict to Improved.
+            var changeDirection = rawMeanAfter > rawMeanBefore
                 ? SailfishChangeDirection.Regressed
                 : SailfishChangeDirection.Improved;
             var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TTest/TTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TTest/TTest.cs
@@ -46,15 +46,19 @@ public class Test : ITTest
 
             // Means / medians reported on the raw scale so the user sees their familiar ms
             // numbers regardless of whether the test ran on log(time).
-            var meanBefore = Math.Round(rawSample1.Mean(), sigDig);
-            var meanAfter = Math.Round(rawSample2.Mean(), sigDig);
+            var rawMeanBefore = rawSample1.Mean();
+            var rawMeanAfter = rawSample2.Mean();
+            var meanBefore = Math.Round(rawMeanBefore, sigDig);
+            var meanAfter = Math.Round(rawMeanAfter, sigDig);
             var medianBefore = Math.Round(rawSample1.Median(), sigDig);
             var medianAfter = Math.Round(rawSample2.Median(), sigDig);
             var testStatistic = Math.Round(test.Statistic, sigDig);
             var dof = Math.Round(test.DegreesOfFreedom, sigDig);
             var isSignificant = test.PValue <= settings.Alpha;
             var pVal = Math.Round(test.PValue, TestConstants.PValueSigDig);
-            var changeDirection = meanAfter > meanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
+            // Direction from the unrounded means — rounding for display can collapse a real
+            // sub-resolution difference to equal and flip the verdict to Improved.
+            var changeDirection = rawMeanAfter > rawMeanBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
             var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
             var additionalResults = new Dictionary<string, object> { { AdditionalResults.DegreesOfFreedom, dof } };
             // SampleSize* / RawData* describe the data the test actually consumed (after

--- a/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTest.cs
+++ b/source/Sailfish/Analysis/SailDiff/Statistics/Tests/TwoSampleWilcoxonSignedRankTestSailfish/TwoSampleWilcoxonSignedRankTest.cs
@@ -62,12 +62,16 @@ public class TwoSampleWilcoxonSignedRankTest : ITwoSampleWilcoxonSignedRankTest
             // different data when outlier detection was on.
             var meanBefore = Math.Round(sample1.Mean(), sigDig);
             var meanAfter = Math.Round(sample2.Mean(), sigDig);
-            var medianBefore = Math.Round(sample1.Median(), sigDig);
-            var medianAfter = Math.Round(sample2.Median(), sigDig);
+            var rawMedianBefore = sample1.Median();
+            var rawMedianAfter = sample2.Median();
+            var medianBefore = Math.Round(rawMedianBefore, sigDig);
+            var medianAfter = Math.Round(rawMedianAfter, sigDig);
             var testStatistic = Math.Round(test.Statistic, sigDig);
             var pval = test.PValue;
             var isSignificant = pval <= settings.Alpha;
-            var changeDirection = medianAfter > medianBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
+            // Direction from the unrounded median — rounding for display can collapse a real
+            // sub-resolution difference to equal and flip the verdict to Improved.
+            var changeDirection = rawMedianAfter > rawMedianBefore ? SailfishChangeDirection.Regressed : SailfishChangeDirection.Improved;
             var description = isSignificant ? changeDirection : SailfishChangeDirection.NoChange;
             var additionalResults = new Dictionary<string, object>();
             // SampleSize* / RawData* describe the data the test actually consumed (after

--- a/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
@@ -11,7 +11,6 @@ using Sailfish.Contracts.Private;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Contracts.Public.Serialization.Tracking.V1;
 using Sailfish.Logging;
-using MathNet.Numerics.Distributions;
 using Sailfish.Analysis.SailDiff.Statistics;
 using Sailfish.Contracts.Public.Models;
 
@@ -298,7 +297,7 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
                 {
                     var a = stats[i];
                     var b = stats[j];
-                    var p = ComputeLogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
+                    var p = MultipleComparisons.LogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
                     if (!double.IsNaN(p) && p > 0)
                     {
                         pMap[MultipleComparisons.NormalizePair(a.Id, b.Id)] = p;
@@ -351,19 +350,6 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
             return p.ToString("0.###");
         }
 
-        static double ComputeLogRatioPValue(double meanA, double seA, int nA, double meanB, double seB, int nB)
-        {
-            if (!(meanA > 0) || !(meanB > 0)) return double.NaN;
-            var seLog = Math.Sqrt(SafeDiv(seA, meanA) * SafeDiv(seA, meanA) + SafeDiv(seB, meanB) * SafeDiv(seB, meanB));
-            if (seLog <= 0) return double.NaN;
-            var t = Math.Abs(Math.Log(meanB / meanA)) / seLog;
-            var dof = Math.Max(1, Math.Min(Math.Max(0, nA - 1), Math.Max(0, nB - 1)));
-            var cdf = StudentT.CDF(0, 1, dof, t);
-            var p = 2 * Math.Max(0.0, 1.0 - cdf);
-            return p;
-        }
-
-        static double SafeDiv(double a, double b) => Math.Abs(b) < double.Epsilon ? 0 : a / b;
     }
 
     /// <summary>

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -15,7 +15,6 @@ using Sailfish.Diagnostics.Environment;
 using Sailfish.Logging;
 using Sailfish.Presentation;
 using Sailfish.Results;
-using MathNet.Numerics.Distributions;
 using Sailfish.Analysis.SailDiff.Statistics;
 
 using Sailfish.Execution;
@@ -577,7 +576,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                 {
                     var a = stats[i];
                     var b = stats[j];
-                    var p = ComputeLogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
+                    var p = MultipleComparisons.LogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
                     if (!double.IsNaN(p) && p > 0)
                     {
                         pMap[MultipleComparisons.NormalizePair(a.Id, b.Id)] = p;
@@ -638,20 +637,6 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                 return p.ToString("0.###");
             }
 
-            static double ComputeLogRatioPValue(double meanA, double seA, int nA, double meanB, double seB, int nB)
-            {
-                if (!(meanA > 0) || !(meanB > 0)) return double.NaN;
-                var seLog = Math.Sqrt(Square(SafeDiv(seA, meanA)) + Square(SafeDiv(seB, meanB)));
-                if (seLog <= 0) return double.NaN;
-                var t = Math.Abs(Math.Log(meanB / meanA)) / seLog;
-                var dof = Math.Max(1, Math.Min(Math.Max(0, nA - 1), Math.Max(0, nB - 1)));
-                var cdf = StudentT.CDF(0, 1, dof, t);
-                var p = 2 * Math.Max(0.0, 1.0 - cdf);
-                return p;
-            }
-
-            static double SafeDiv(double a, double b) => Math.Abs(b) < double.Epsilon ? 0 : a / b;
-            static double Square(double x) => x * x;
         }
         catch (Exception ex)
         {
@@ -707,7 +692,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             var pMap = new Dictionary<(string A, string B), double>();
             foreach (var c in contenders)
             {
-                var p = ComputeLogRatioPValue(baselineStat.Mean, baselineStat.SE, baselineStat.N, c.Mean, c.SE, c.N);
+                var p = MultipleComparisons.LogRatioPValue(baselineStat.Mean, baselineStat.SE, baselineStat.N, c.Mean, c.SE, c.N);
                 if (!double.IsNaN(p) && p > 0)
                 {
                     pMap[MultipleComparisons.NormalizePair(baselineStat.Id, c.Id)] = p;
@@ -746,20 +731,6 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                 return p.ToString("0.###");
             }
 
-            static double ComputeLogRatioPValue(double meanA, double seA, int nA, double meanB, double seB, int nB)
-            {
-                if (!(meanA > 0) || !(meanB > 0)) return double.NaN;
-                var seLog = Math.Sqrt(Square(SafeDiv(seA, meanA)) + Square(SafeDiv(seB, meanB)));
-                if (seLog <= 0) return double.NaN;
-                var t = Math.Abs(Math.Log(meanB / meanA)) / seLog;
-                var dof = Math.Max(1, Math.Min(Math.Max(0, nA - 1), Math.Max(0, nB - 1)));
-                var cdf = StudentT.CDF(0, 1, dof, t);
-                var p = 2 * Math.Max(0.0, 1.0 - cdf);
-                return p;
-            }
-
-            static double SafeDiv(double a, double b) => Math.Abs(b) < double.Epsilon ? 0 : a / b;
-            static double Square(double x) => x * x;
         }
         catch (Exception ex)
         {

--- a/source/Tests.Library/Analysis/SailDiff/ChangeDirectionRoundingTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/ChangeDirectionRoundingTests.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.MWWilcoxonTestSailfish;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.TwoSampleWilcoxonSignedRankTestSailfish;
+using Sailfish.Contracts.Public;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+/// <summary>
+/// Regression coverage for the change-direction verdict when display rounding (settings.Round,
+/// default 3 → ms with 3 decimals) collapses two genuinely-different sub-millisecond statistics
+/// to the same displayed value. The verdict must follow the <em>unrounded</em> statistic; deciding
+/// it from the rounded value sent every such case to the "Improved" branch — because
+/// <c>after &gt; before</c> is false when both round equal — mislabelling regressions as improvements.
+/// </summary>
+public class ChangeDirectionRoundingTests
+{
+    private static TestPreprocessor Preprocessor() => new(new SailfishOutlierDetector());
+
+    private static SailDiffSettings Settings(TestType testType) =>
+        new(alpha: 0.05, round: 3, useOutlierDetection: false, testType: testType);
+
+    // 10 distinct, strictly increasing sub-millisecond values; every value rounds to 0.001 ms
+    // at Round = 3, so the displayed mean/median collapses to a single value.
+    private static double[] Cluster(double centerMs) =>
+        Enumerable.Range(0, 10).Select(i => centerMs + i * 1e-6).ToArray();
+
+    [Fact]
+    public void RankSum_AfterSlightlySlower_RoundsEqual_StillReportsRegressed()
+    {
+        var before = Cluster(0.000590); // ≈ 0.59 µs
+        var after = Cluster(0.000620); // ≈ 0.62 µs, every value > every before value
+
+        var result = new MannWhitneyWilcoxonTest(Preprocessor())
+            .ExecuteTest(before, after, Settings(TestType.WilcoxonRankSumTest));
+
+        result.ExceptionMessage.ShouldBeEmpty();
+        result.StatisticalTestResult.PValue.ShouldBeLessThan(0.05); // significant
+        // Precondition: rounding has collapsed both means to the same displayed value.
+        result.StatisticalTestResult.MeanBefore.ShouldBe(result.StatisticalTestResult.MeanAfter);
+        // After is genuinely slower → must be Regressed, not Improved.
+        result.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Regressed);
+    }
+
+    [Fact]
+    public void RankSum_AfterSlightlyFaster_RoundsEqual_StillReportsImproved()
+    {
+        var before = Cluster(0.000620);
+        var after = Cluster(0.000590); // every value < every before value
+
+        var result = new MannWhitneyWilcoxonTest(Preprocessor())
+            .ExecuteTest(before, after, Settings(TestType.WilcoxonRankSumTest));
+
+        result.ExceptionMessage.ShouldBeEmpty();
+        result.StatisticalTestResult.PValue.ShouldBeLessThan(0.05);
+        result.StatisticalTestResult.MeanBefore.ShouldBe(result.StatisticalTestResult.MeanAfter);
+        result.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Improved);
+    }
+
+    [Fact]
+    public void SignedRank_MedianDirection_RoundsEqual_StillReportsRegressed()
+    {
+        // The signed-rank wrapper decides direction from the median rather than the mean; same
+        // collapse, same requirement that the unrounded value drives the verdict.
+        var before = Cluster(0.000590);
+        var after = Cluster(0.000620);
+
+        var result = new TwoSampleWilcoxonSignedRankTest(Preprocessor())
+            .ExecuteTest(before, after, Settings(TestType.TwoSampleWilcoxonSignedRankTest));
+
+        result.ExceptionMessage.ShouldBeEmpty();
+        result.StatisticalTestResult.PValue.ShouldBeLessThan(0.05);
+        result.StatisticalTestResult.MedianBefore.ShouldBe(result.StatisticalTestResult.MedianAfter);
+        result.StatisticalTestResult.ChangeDescription.ShouldBe(SailfishChangeDirection.Regressed);
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/Statistics/MultipleComparisonsLogRatioPValueTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/Statistics/MultipleComparisonsLogRatioPValueTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using MathNet.Numerics.Distributions;
+using Sailfish.Analysis.SailDiff.Statistics;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff.Statistics;
+
+/// <summary>
+/// Regression coverage for <see cref="MultipleComparisons.LogRatioPValue"/>, the parametric
+/// log-ratio test behind the method-comparison tables. The headline failure: a perfectly
+/// separated, ~400× difference where one method had (near-)zero variance was labelled
+/// "Similar" (not significant). Root cause: the p-value was computed as
+/// <c>2·(1 − StudentT.CDF(t))</c>, which collapses to exactly 0 for large t — the tail
+/// underflows the ULP of 1.0 — and a 0 p-value is dropped / BH-adjusts to q = 0, which the
+/// cell labels treat as not significant.
+/// </summary>
+public class MultipleComparisonsLogRatioPValueTests
+{
+    // The reported numbers: WithPlus baseline ≈ 16.972 ms (real spread) vs WithStringBuilder
+    // ≈ 0.039 ms with zero observed variance at measurement resolution (SE = 0).
+    private const double BaselineMean = 16.972;
+    private const double BaselineSe = 0.4; // ≈ stddev 1.2ms / sqrt(10)
+    private const double FastMean = 0.039;
+    private const double FastSe = 0.0; // zero observed variance
+    private const int N = 10;
+
+    [Fact]
+    public void NaiveOneMinusCdfForm_CollapsesToExactlyZero_DocumentingTheBug()
+    {
+        // The pre-fix computation. Asserting it really is exactly 0 anchors the regression below
+        // to the actual failure mode (a dropped p-value) rather than a hypothetical one.
+        var seLog = BaselineSe / BaselineMean; // FastSe = 0 contributes nothing
+        var t = Math.Abs(Math.Log(FastMean / BaselineMean)) / seLog;
+        var naiveP = 2.0 * Math.Max(0.0, 1.0 - StudentT.CDF(0, 1, N - 1, t));
+
+        naiveP.ShouldBe(0.0); // a maximally-significant comparison read as p = 0
+    }
+
+    [Fact]
+    public void ExtremeSeparation_WithZeroVarianceGroup_IsStrictlyPositiveAndSignificant()
+    {
+        var p = MultipleComparisons.LogRatioPValue(BaselineMean, BaselineSe, N, FastMean, FastSe, N);
+
+        double.IsNaN(p).ShouldBeFalse();
+        p.ShouldBeGreaterThan(0.0); // never the dropped-as-0 value again
+        p.ShouldBeLessThan(0.05); // and it is, correctly, highly significant
+    }
+
+    [Fact]
+    public void ExtremeSeparation_SurvivesFdrAndIsLabelledSignificant()
+    {
+        // End-to-end: the value must stay positive through BH-FDR and read as significant, i.e.
+        // the cell label is "Improved"/"Slower", never "Similar".
+        const double alpha = 0.05;
+        var p = MultipleComparisons.LogRatioPValue(BaselineMean, BaselineSe, N, FastMean, FastSe, N);
+
+        var qMap = MultipleComparisons.BenjaminiHochbergAdjust(
+            new Dictionary<(string A, string B), double> { [("WithPlus", "WithStringBuilder")] = p });
+        var q = qMap[MultipleComparisons.NormalizePair("WithPlus", "WithStringBuilder")];
+
+        q.ShouldBeGreaterThan(0.0);
+        SailDiffSignificance.IsSignificantPositive(q, alpha).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EqualMeans_AreNotSignificant()
+    {
+        var p = MultipleComparisons.LogRatioPValue(5.0, 0.1, N, 5.0, 0.1, N);
+        p.ShouldBe(1.0, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void BothSidesNoVariance_Abstains_RegardlessOfMeans()
+    {
+        // With no usable variance on either side there is nothing to run a variance-based test
+        // against, so the helper abstains (NaN → "Similar", no q). This is deliberate and is
+        // distinct from the reported one-sided case above, where the baseline supplies the
+        // variance. Holds whether the means differ or not.
+        double.IsNaN(MultipleComparisons.LogRatioPValue(10.0, 0.0, N, 1.0, 0.0, N)).ShouldBeTrue();
+        double.IsNaN(MultipleComparisons.LogRatioPValue(5.0, 0.0, N, 5.0, 0.0, N)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NonPositiveMean_IsUndefined()
+    {
+        double.IsNaN(MultipleComparisons.LogRatioPValue(0.0, 0.1, N, 1.0, 0.1, N)).ShouldBeTrue();
+        double.IsNaN(MultipleComparisons.LogRatioPValue(1.0, 0.1, N, -1.0, 0.1, N)).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Fixes the two confirmed correctness bugs from a SailDiff results investigation. Both are in the comparison-output path; both ship with regression tests. Full `Tests.Library` suite green (1612 passed, net9.0 + net10.0).

## Issue 1 — extreme method-comparison differences labelled `Similar` (High)

The method-comparison tables (NxN matrix, baseline-vs-contender, CSV) run a **parametric Student-t test on the log-ratio** of two methods' means. The p-value was computed as `2*(1 - StudentT.CDF(t))`. For a large `t` (e.g. a 430× gap where one method has near-zero variance, `t ≈ 258`), the true upper tail (~1e-18) is smaller than the ULP of 1.0, so `1 - tail` rounds to **exactly 1.0** and `p` collapses to `0.0`. The `p > 0` inclusion guard then drops the pair, its q-value defaults to `0`, and `IsSignificantPositive(0, α)` is false — so the *most* significant comparison possible was reported as `Similar`.

**Fix:** centralized the three duplicated `ComputeLogRatioPValue` copies into `MultipleComparisons.LogRatioPValue`, evaluating the **lower tail directly** (`2*StudentT.CDF(-t)`, which MathNet returns without the `1-CDF` cancellation) plus a positive floor. Both-sides-zero-variance still returns `NaN` → abstains → `Similar` (preserving the deliberate N=1 / no-variance behaviour, covered by an existing test).

A regression test asserts the old form returns exactly `0.0` for the reported inputs (anchoring the root cause) and that the fixed value is positive and significant through BH-FDR.

## Issue 3 — `Change: Improved` contradicting `(REGRESSED)` (Medium)

All five SailDiff test wrappers decided the Regressed/Improved verdict from the **rounded** mean (or median, for signed-rank) — `Math.Round(.., settings.Round)`, default 3 → ms. When two genuinely-different sub-millisecond values both round to e.g. `0.001`, `after > before` is false and the verdict fell through to the *Improved* branch, mislabelling a regression. Direction now comes from the **unrounded** statistic; rounded values are kept for display only.

## Note on the brief's Issue 2 (no change)

The "q-values impossible for exact Wilcoxon at n=8" finding was a misdiagnosis: this table is a parametric Student-t test, **not** Wilcoxon, so small q-values are legitimate. The genuine defect underneath it was the cancellation above.

## Scope

Issues 4 (ScaleFish output), 5 (Skipper SIMD claim), 6 (detailed-stats display precision), and 7 (`WithGlobalSampleSize` cap semantics) are tracked separately on a follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Statistical tests now accurately report improvement or regression direction using unrounded internal values, preventing rounding-induced verdict flips when display values appear identical.

* **New Features**
  * Added enhanced log-ratio p-value calculations for method comparisons with improved numerical stability for very small p-values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->