### PR TITLE
docs(site): add "Reading the Console Output" walkthrough page

### DIFF
--- a/site/markdoc/tags.js
+++ b/site/markdoc/tags.js
@@ -1,7 +1,14 @@
 import { Callout } from '@/components/Callout'
 import { QuickLink, QuickLinks } from '@/components/QuickLinks'
+import { Terminal } from '@/components/Terminal'
 
 const tags = {
+  terminal: {
+    attributes: {
+      title: { type: String },
+    },
+    render: Terminal,
+  },
   callout: {
     attributes: {
       title: { type: String },

--- a/site/src/components/Layout.jsx
+++ b/site/src/components/Layout.jsx
@@ -50,6 +50,7 @@ const navigation = [
     {
         title: 'Outputs',
         links: [
+            { title: 'Reading the Console Output', href: '/docs/1/console-output', badge: 'NEW' },
             { title: 'Output Attributes', href: '/docs/1/output-attributes' },
             { title: 'Markdown Output', href: '/docs/1/markdown-output' },
             { title: 'CSV Output', href: '/docs/1/csv-output' },

--- a/site/src/components/Terminal.jsx
+++ b/site/src/components/Terminal.jsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx'
+
+// A terminal-window chrome used to present Sailfish console output beautifully.
+// Wraps a fenced code block: the fence supplies the monospace, pre-formatted body
+// (preserving the box-drawing / block glyphs in distribution plots) while this
+// component paints the window frame, the traffic-light dots, and an optional title.
+//
+// Usage in Markdoc:
+//   {% terminal title="ConcatBenchmarks ▸ dotnet test" %}
+//   ```
+//   ...console output...
+//   ```
+//   {% /terminal %}
+export function Terminal({ title, children }) {
+  return (
+    <div className="not-prose my-8 overflow-hidden rounded-xl bg-slate-900 shadow-xl ring-1 ring-slate-300/10 dark:bg-slate-800/40">
+      <div className="flex items-center gap-2 border-b border-white/5 bg-slate-800/80 px-4 py-2.5">
+        <span className="h-3 w-3 rounded-full bg-red-500/90" />
+        <span className="h-3 w-3 rounded-full bg-amber-400/90" />
+        <span className="h-3 w-3 rounded-full bg-green-500/90" />
+        {title && (
+          <span className="ml-3 truncate font-mono text-xs font-medium tracking-wide text-slate-400">
+            {title}
+          </span>
+        )}
+      </div>
+      <div className="overflow-x-auto text-[13px] leading-relaxed [&_pre]:!my-0 [&_pre]:!rounded-none [&_pre]:!bg-transparent [&_pre]:!shadow-none [&_pre]:!ring-0">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/site/src/pages/docs/1/console-output.md
+++ b/site/src/pages/docs/1/console-output.md
@@ -1,0 +1,301 @@
+---
+title: Reading the Console Output
+---
+
+Every Sailfish run prints a per-test report to **StdOut** (and to the **Test Output** window in your IDE). For a `[Sailfish]` class with a baseline, you also get a **method-comparison** block and an **environment health** summary. This page walks through a complete run end-to-end so you know how to read every line — including the inline distribution plots.
+
+Here is a full run of a two-method comparison — `WithPlus` (the baseline) vs. `WithJoin` — measured in nanoseconds:
+
+{% terminal title="CompareCpuAlgorithms ▸ dotnet test" %}
+```
+CompareCpuAlgorithms.WithJoin
+
+Descriptive Statistics
+----------------------
+| Stat     |  Time (ns) |
+| ---      | ---        |
+| N        |        188 |
+| Mean     |    575.814 |
+| Median   |    542.000 |
+| 95% CI ± |     9.0287 |
+| 99% CI ± |    11.9105 |
+| Min      |    458.000 |
+| Max      |    709.000 |
+
+
+Distribution Plot
+-----------------
+                                                           Time (ns)
+
+                 ▁▁▁   ▃▃▃▄▄▄███▅▅▅▅▃▃▃▂▂▂   ▃▃▃   ▃▃▃▃
+                             ╿    ╵
+
+    400 ├──────────────┬──────────────┬─────────────┬──────────────┤ 800
+                      500            600           700
+
+  ╵ mean   ╿ median   ▁▂▃▄▅▆▇█ count per bin
+
+        n=188  outliers=12  min=458.000  max=709.000
+
+Outliers Removed (12)
+---------------------
+12 Upper Outliers: 750.000, 1000.000, 1000.000, 750.000, 792.000, 1208.000, 750.000, 750.000, 792.000, 792.000, 750.000, 750.000
+
+Distribution (ns)
+-----------------
+625.000, 667.000, 625.000, 541.000, 542.000, 542.000, 500.000, 500.000, 542.000, 667.000, 541.000, 584.000, 667.000, 625.000, 584.000, 625.000, 708.000, 583.000, 541.000, 542.000, 500.000, 541.000, … (188 values total)
+
+📊 PERFORMANCE COMPARISON
+Group: Concat
+==================================================
+
+🟢 IMPACT: WithJoin(N: 100) is 80.5% faster than baseline WithPlus(N: 100) (IMPROVED)
+   P-Value: 0.000000 | Mean: 2.952 µs → 0.576 µs
+
+
+📋 DETAILED STATISTICS:
+
+| Metric      | WithPlus(N: 100) (baseline) | WithJoin(N: 100) | Change | P-Value  |
+| ----------- | --------------------------- | ---------------- | ------ | -------- |
+| Mean (µs)   | 2.952                       | 0.576            | -80.5% | 0.000000 |
+| Median (µs) | 2.958                       | 0.542            | -81.7% | -        |
+
+Change = comparison vs. baseline (positive = slower, negative = faster).
+
+Statistical Test: Two-Sample Wilcoxon Signed-Rank Test
+Alpha Level: 0.0001
+Sample Size: 188
+Outliers Removed: 18
+
+📊 DISTRIBUTION
+                                                                       Time (µs)
+
+  WithPlus(N: 100)                 ▇▇▇▇▂▂▂▁▁▁▁▄▄▄███▂▂▂▂▃▃▃▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁
+                                                 ╽
+  WithJoin(N: 100)       ▃▂▃
+                         ╿╵
+
+                  0 ├───────────────────┬──────────────────┬───────────────────┤ 6
+                                        2                  4
+
+  ╵ mean   ╿ median   ▁▂▃▄▅▆▇█ count per bin   ╽ mean≈median
+
+  WithPlus(N: 100)  n=188  outliers=0  min=1.500  max=5.708
+  WithJoin(N: 100)  n=188  outliers=0  min=0.458  max=0.709
+
+==================================================
+
+Sailfish Environment Health: 64/100 (Fair)
+ - Build Mode: Warn (Debug) - Use Release (optimized) for stable measurements
+ - JIT (Tiered/OSR): Pass (Tiered=default; QuickJit=default; QuickJitForLoops=default; OSR=default)
+ - Process Priority: Warn (Normal) - Consider High or AboveNormal to reduce scheduler noise
+ - GC Mode: Warn (Workstation GC) - Enable Server GC for more stable throughput measurements
+ - CPU Affinity: Unknown (Not supported on this OS)
+ - Timer: Pass (High-resolution timer: ~1 ns; Sleep(1) median ≈ 1.1 ms)
+```
+{% /terminal %}
+
+That's a lot at a glance — so let's read it one section at a time.
+
+## 1. Descriptive statistics
+
+Every test case opens with a small stats table, headed by the test's display name (`CompareCpuAlgorithms.WithJoin`). The unit in the column header (`Time (ns)`) is chosen automatically to keep the numbers readable.
+
+{% terminal title="Descriptive Statistics" %}
+```
+Descriptive Statistics
+----------------------
+| Stat     |  Time (ns) |
+| ---      | ---        |
+| N        |        188 |
+| Mean     |    575.814 |
+| Median   |    542.000 |
+| 95% CI ± |     9.0287 |
+| 99% CI ± |    11.9105 |
+| Min      |    458.000 |
+| Max      |    709.000 |
+```
+{% /terminal %}
+
+| Row | Meaning |
+| --- | --- |
+| **N** | Number of measurements kept **after** outlier removal — this is the sample the stats are computed from. |
+| **Mean** | Arithmetic average of the retained measurements. |
+| **Median** | Middle value. When it sits well below the mean (as here, 542 vs. 576) the distribution is **right-skewed** — a few slow runs are pulling the mean up. |
+| **95% CI ± / 99% CI ±** | Half-width of the confidence interval on the **mean**. "Mean 575.814 with 95% CI ± 9.0287" means the true mean is very likely within `575.814 ± 9.0287` ns. Tighter is better. |
+| **Min / Max** | Fastest and slowest retained measurement. |
+
+{% callout title="Why prefer the median?" type="note" %}
+For microbenchmarks the **median** is usually the number to trust — it's robust to the occasional slow run that the OS scheduler or GC injects. The gap between mean and median is itself a signal: a large gap means a skewed distribution, which the plot below makes visible. See [Confidence Intervals](/docs/1/confidence-intervals) for how the CI is computed.
+{% /callout %}
+
+## 2. The distribution plot
+
+Numbers summarize; the plot shows the **shape**. Sailfish draws a compact, text-only distribution directly in the output so you never have to leave the console to see how your measurements are spread.
+
+{% terminal title="Distribution Plot" %}
+```
+Distribution Plot
+-----------------
+                                                           Time (ns)
+
+                 ▁▁▁   ▃▃▃▄▄▄███▅▅▅▅▃▃▃▂▂▂   ▃▃▃   ▃▃▃▃
+                             ╿    ╵
+
+    400 ├──────────────┬──────────────┬─────────────┬──────────────┤ 800
+                      500            600           700
+
+  ╵ mean   ╿ median   ▁▂▃▄▅▆▇█ count per bin
+
+        n=188  outliers=12  min=458.000  max=709.000
+```
+{% /terminal %}
+
+How to read it:
+
+- **The bars** are a histogram. The x-axis is time; each column is a bin, and its height (`▁▂▃▄▅▆▇█`, eight levels) is **how many measurements landed in that bin**. The tall `███` cluster just past 500 ns is where most runs landed.
+- **`╿` marks the median** and **`╵` marks the mean**, placed under the axis at their true positions. Here `╿` (median ≈ 542) sits left of `╵` (mean ≈ 576) — the same right-skew the stats table hinted at, now visible as a long thin tail stretching toward 700+.
+- **The axis** is labelled at both ends (`400` … `800`) with interior ticks (`500`, `600`, `700`) so you can read values off the bars.
+- **The footer** repeats the essentials: `n` (retained count), `outliers` removed, and the `min`/`max` of the retained sample.
+
+{% callout title="Box plot or histogram" type="note" %}
+The plot above is the **Histogram** style. The default is a compact **box plot** (quartile box with whiskers, mean, and median). Switch styles, or turn the inline plot off entirely:
+
+```csharp
+var runSettings = RunSettingsBuilder.CreateBuilder()
+    .WithDistributionPlotStyle(DistributionPlotStyle.Histogram) // default: BoxPlot
+    .WithDistributionPlots(true)                                // false to hide the plot
+    .Build();
+```
+{% /callout %}
+
+## 3. Outliers removed
+
+Before computing statistics, Sailfish detects and **sets aside** outliers so a handful of scheduler hiccups don't distort your mean. They're reported, never silently dropped — you can always see exactly what was excluded and why.
+
+{% terminal title="Outliers Removed" %}
+```
+Outliers Removed (12)
+---------------------
+12 Upper Outliers: 750.000, 1000.000, 1000.000, 750.000, 792.000, 1208.000, 750.000, 750.000, 792.000, 792.000, 750.000, 750.000
+```
+{% /terminal %}
+
+The count in the header (`12`) is how many measurements were excluded; they're listed split into **Upper** (slow) and **Lower** (fast) outliers. Notice the values here — 750 to 1208 ns — sit far above the ~542 ns median, exactly the kind of slow-path noise you want kept out of the summary. See [Outlier Handling](/docs/1/outlier-handling) to tune the detection method and bounds.
+
+## 4. The retained distribution
+
+For full transparency, Sailfish then prints the **actual retained measurements** — the exact sample the statistics and plot were built from (outliers already removed).
+
+{% terminal title="Distribution (ns)" %}
+```
+Distribution (ns)
+-----------------
+625.000, 667.000, 625.000, 541.000, 542.000, 542.000, 500.000, 500.000, 542.000, 667.000, … (188 values total)
+```
+{% /terminal %}
+
+This is what makes a Sailfish result reproducible and auditable: paste it into a notebook, re-run your own stats, or diff it against a previous run. (The full list is printed; it's truncated here for space.)
+
+## 5. The performance comparison (SailDiff)
+
+When a `[Sailfish]` class has a baseline, **SailDiff** compares each method against it and prints a verdict block. This is the part you actually act on.
+
+{% terminal title="Performance Comparison" %}
+```
+📊 PERFORMANCE COMPARISON
+Group: Concat
+==================================================
+
+🟢 IMPACT: WithJoin(N: 100) is 80.5% faster than baseline WithPlus(N: 100) (IMPROVED)
+   P-Value: 0.000000 | Mean: 2.952 µs → 0.576 µs
+
+
+📋 DETAILED STATISTICS:
+
+| Metric      | WithPlus(N: 100) (baseline) | WithJoin(N: 100) | Change | P-Value  |
+| ----------- | --------------------------- | ---------------- | ------ | -------- |
+| Mean (µs)   | 2.952                       | 0.576            | -80.5% | 0.000000 |
+| Median (µs) | 2.958                       | 0.542            | -81.7% | -        |
+
+Change = comparison vs. baseline (positive = slower, negative = faster).
+
+Statistical Test: Two-Sample Wilcoxon Signed-Rank Test
+Alpha Level: 0.0001
+Sample Size: 188
+Outliers Removed: 18
+```
+{% /terminal %}
+
+Reading top to bottom:
+
+- **`Group: Concat`** — the comparison group these methods belong to.
+- **The `IMPACT` line** is the headline verdict, always phrased as *"{compared} is N% slower/faster than baseline {primary}"*. The colored dot and tag tell you the direction at a glance: 🟢 `IMPROVED`, 🔴 `REGRESSED`, or ⚪ `NOT SIGNIFICANT` when the difference can't be distinguished from noise.
+- **`P-Value: 0.000000`** — the probability this difference is due to chance. Below the **Alpha Level** (here `0.0001`) it's significant; well below it, as here, it's a confident result.
+- **`Mean: 2.952 µs → 0.576 µs`** — the before/after means, in the comparison's chosen unit (µs here, because the two methods together span microseconds).
+- **The `DETAILED STATISTICS` table** breaks the change out by **Mean** and **Median**. `Change` is signed relative to the baseline: **negative = faster**, positive = slower. Both rows agreeing (−80.5% / −81.7%) is a strong, consistent improvement.
+- **The test footer** names the statistical test (a **Two-Sample Wilcoxon Signed-Rank Test** — non-parametric, robust to skew), the alpha level, the sample size, and how many outliers were removed for the comparison.
+
+{% callout title="More on the verdict" type="note" %}
+SailDiff's full mechanics — baseline vs. N×N modes, the Mann-Whitney/Wilcoxon/t-test options, BH-FDR q-values, and the ratio confidence intervals written to Markdown/CSV — are covered on the [SailDiff](/docs/2/saildiff) page.
+{% /callout %}
+
+## 6. The comparison distribution plot
+
+SailDiff also overlays both methods on a **shared axis**, so the improvement isn't just a number — you can see the entire `WithJoin` distribution sitting to the left of `WithPlus`, with no overlap.
+
+{% terminal title="Comparison Distribution" %}
+```
+📊 DISTRIBUTION
+                                                                       Time (µs)
+
+  WithPlus(N: 100)                 ▇▇▇▇▂▂▂▁▁▁▁▄▄▄███▂▂▂▂▃▃▃▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁
+                                                 ╽
+  WithJoin(N: 100)       ▃▂▃
+                         ╿╵
+
+                  0 ├───────────────────┬──────────────────┬───────────────────┤ 6
+                                        2                  4
+
+  ╵ mean   ╿ median   ▁▂▃▄▅▆▇█ count per bin   ╽ mean≈median
+
+  WithPlus(N: 100)  n=188  outliers=0  min=1.500  max=5.708
+  WithJoin(N: 100)  n=188  outliers=0  min=0.458  max=0.709
+```
+{% /terminal %}
+
+Both rows share **one x-axis** (`0` … `6` µs), so position is directly comparable: `WithJoin`'s tiny cluster near 0.5 µs is visibly faster than `WithPlus`'s spread around 3 µs. The same `╿` median / `╵` mean markers appear under each row; the extra **`╽` marks where mean and median coincide** — handy for a tight, symmetric distribution like `WithPlus` here. Each row gets its own `n / outliers / min / max` footer.
+
+## 7. Environment health
+
+Finally, Sailfish grades the **machine it ran on**. Microbenchmarks are sensitive to build mode, GC, process priority, and timer resolution — this 0–100 score tells you how much to trust the numbers above.
+
+{% terminal title="Environment Health" %}
+```
+Sailfish Environment Health: 64/100 (Fair)
+ - Build Mode: Warn (Debug) - Use Release (optimized) for stable measurements
+ - JIT (Tiered/OSR): Pass (Tiered=default; QuickJit=default; QuickJitForLoops=default; OSR=default)
+ - Process Priority: Warn (Normal) - Consider High or AboveNormal to reduce scheduler noise
+ - GC Mode: Warn (Workstation GC) - Enable Server GC for more stable throughput measurements
+ - CPU Affinity: Unknown (Not supported on this OS)
+ - Timer: Pass (High-resolution timer: ~1 ns; Sleep(1) median ≈ 1.1 ms)
+```
+{% /terminal %}
+
+Each check is `Pass`, `Warn`, `Fail`, or `Unknown` (when the OS can't report it — `CPU Affinity` on macOS here), with an actionable hint. A score of **64 (Fair)** is a nudge: this run was in `Debug` with Workstation GC, so treat the absolute numbers as indicative. The fix is in the messages — build in `Release`, enable Server GC — and the [Environment Health Check](/docs/1/environment-health) page explains every check and how to disable it.
+
+## Where this output shows up
+
+- **Console / `dotnet test`** — printed to StdOut as the run proceeds.
+- **IDE Test Output window** — the same per-test report appears under each test in Rider / Visual Studio.
+- **Consolidated Markdown & CSV** — add `[WriteToMarkdown]` / `[WriteToCsv]` to capture comparison tables and stats to disk. See [Markdown Output](/docs/1/markdown-output) and [CSV Output](/docs/1/csv-output).
+
+{% callout title="Tune what you see" type="note" %}
+Most of this output is configurable on the run settings:
+
+- **Distribution plot** — `WithDistributionPlotStyle(...)` (box plot / histogram), `WithDistributionPlots(false)` to hide it.
+- **Outliers** — see [Outlier Handling](/docs/1/outlier-handling).
+- **Confidence intervals** — see [Confidence Intervals](/docs/1/confidence-intervals).
+- **Environment health** — `WithEnvironmentHealthCheck(false)` to silence it. See [Environment Health Check](/docs/1/environment-health).
+- **Comparison verdict & test** — see [SailDiff](/docs/2/saildiff).
+{% /callout %}


### PR DESCRIPTION
## What

Adds a dedicated docs page — **Reading the Console Output** — that walks through a complete Sailfish run end-to-end, presented in a terminal-window frame so the output looks the way it does in a real console.

The page opens with the full run as a hero, then breaks it into seven annotated sections:

1. **Descriptive statistics** — what N / Mean / Median / 95% & 99% CI ± / Min / Max each mean, and why the mean–median gap signals skew.
2. **The distribution plot** — how to read the histogram bars, the `╿` median / `╵` mean markers, the axis, and the footer.
3. **Outliers removed** — why they're reported, never silently dropped.
4. **The retained distribution** — the exact sample the stats were built from.
5. **The performance comparison (SailDiff)** — the `🟢 IMPACT` verdict line, the detailed-statistics table, and the statistical-test footer.
6. **The comparison distribution plot** — both methods on a shared axis, with the `╽` mean≈median marker.
7. **Environment health** — the 0–100 score and per-check Pass/Warn/Unknown lines.

## How

- New reusable **`{% terminal %}`** Markdoc tag backed by a `Terminal` component: window chrome (traffic-light dots + title) wrapping a fenced code block. The fence keeps the monospace / `white-space: pre` rendering so box-drawing and block glyphs (`▁▂▃▄▅▆▇█`, `┌─┐`, `╿╵╽`) stay aligned; the component neutralizes the inner block's default rounding/background so it sits flush in the frame.
- Wording follows the established SailDiff vocabulary (*"{Compared} is N% faster than baseline {Primary}"*, `NOT SIGNIFICANT` for the null verdict).
- Added to the **Outputs** nav section (the sidebar is a hard-coded array in `Layout.jsx`) with a `NEW` badge.

## Files

- `site/src/pages/docs/1/console-output.md` *(new)* — the page
- `site/src/components/Terminal.jsx` *(new)* — terminal-window component
- `site/markdoc/tags.js` — register the `terminal` tag
- `site/src/components/Layout.jsx` — nav entry

## Verification

- `npm run build` is green — no Markdoc validation errors; the page is generated as static HTML.
- Rendered in the browser in **dark and light mode**: the chrome renders, the sidebar entry highlights, and the histogram bars, the `400 ├──┬──┬──┬──┤ 800` axis, the marker line, and the SailDiff impact line all align correctly. The terminal stays dark in light mode (matching the site's existing code-block treatment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a terminal component that displays console output in a styled, terminal-like window format.
  * Added a new "Reading the Console Output" navigation link to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->