### PR TITLE
fix: resolve SailDiff-brief follow-ups (ScaleFish output, Skipper grounding, sample-size cap)

### DIFF
--- a/source/PerformanceTests/Skipper/ClaudeAgentModelProvider.cs
+++ b/source/PerformanceTests/Skipper/ClaudeAgentModelProvider.cs
@@ -65,6 +65,9 @@ public sealed class ClaudeAgentModelProvider : ISailfishAgent
         sb.AppendLine();
         sb.AppendLine("Rules:");
         sb.AppendLine("- Use ONLY the numbers in the context below. Never invent or recompute a measurement.");
+        sb.AppendLine("- Your mechanistic explanation MUST be consistent with the measured ordering: rank candidates by");
+        sb.AppendLine("  their means in the context, and never claim a candidate is faster than one the numbers show it is");
+        sb.AppendLine("  slower than, nor attribute a speed-up (e.g. SIMD/JIT intrinsics) to a candidate measured as slower.");
         sb.AppendLine("- You MAY read files under the repository root to find the cause. Cite each as path:line.");
         sb.AppendLine("- If the environment shows concerns, or a change is not statistically significant, say so and temper the verdict.");
         sb.AppendLine("- Respond with ONLY a JSON object (no prose, no code fences) matching this schema:");

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
@@ -5,6 +5,7 @@ using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Diagnostics.Environment;
 using Sailfish.Results;
 using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.SailDiff.Formatting;
 
 namespace Sailfish.Analysis.Ai;
 
@@ -134,17 +135,24 @@ internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrative
                 ChangeDescription: stats.ChangeDescription, SampleSizeBefore: 0, SampleSizeAfter: 0, Failed: true);
         }
 
-        var percentChangeMean = stats.MeanBefore != 0
-            ? (stats.MeanAfter - stats.MeanBefore) / stats.MeanBefore * 100.0
+        // Use full-precision means/medians recomputed from the raw samples. The scalar
+        // Mean*/Median* on StatisticalTestResult are pre-rounded to SailDiffSettings.Round decimals
+        // (ms), which collapses sub-millisecond values to ~0.001 — that zeroes the percent-change,
+        // flips the verdict direction when both means round equal, and feeds the agent rounded
+        // figures that disagree with the embedded results markdown.
+        var display = SailDiffDisplayStatistics.From(stats);
+
+        var percentChangeMean = display.MeanBefore != 0
+            ? (display.MeanAfter - display.MeanBefore) / display.MeanBefore * 100.0
             : 0.0;
 
         return new SailDiffCaseContext(
             displayName,
-            DeriveVerdict(stats, alpha),
-            stats.MeanBefore,
-            stats.MeanAfter,
-            stats.MedianBefore,
-            stats.MedianAfter,
+            DeriveVerdict(display, stats, alpha),
+            display.MeanBefore,
+            display.MeanAfter,
+            display.MedianBefore,
+            display.MedianAfter,
             percentChangeMean,
             stats.PValue,
             stats.QValue,
@@ -157,13 +165,15 @@ internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrative
             MinimumDetectableEffectPercent: stats.MinimumDetectableEffectPercent);
     }
 
-    private static SkipperVerdict DeriveVerdict(StatisticalTestResult stats, double alpha)
+    private static SkipperVerdict DeriveVerdict(SailDiffDisplayStatistics display, StatisticalTestResult stats, double alpha)
     {
         // Prefer the BH-FDR adjusted q-value when present (it controls the family-wise error rate across the
         // pairs in an N×N method comparison); otherwise fall back to the raw p-value.
         var p = stats.QValue ?? stats.PValue;
         if (double.IsNaN(p) || p >= alpha) return SkipperVerdict.NotSignificant;
 
-        return stats.MeanAfter > stats.MeanBefore ? SkipperVerdict.Regressed : SkipperVerdict.Improved;
+        // Direction from the full-precision means (see ToCaseContext): the rounded scalars can
+        // collapse a real sub-resolution change to equal and mislabel the direction.
+        return display.MeanAfter > display.MeanBefore ? SkipperVerdict.Regressed : SkipperVerdict.Improved;
     }
 }

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
@@ -128,6 +128,10 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         }
         catch (Exception ex)
         {
+            // Surface the failure. A silently-swallowed exception here is exactly why a null-key
+            // crash in the complexity computer produced no ScaleFish output — and no error — for
+            // so long; log it at Warning so the next regression is visible.
+            _logger.Log(LogLevel.Warning, ex, "ScaleFish analysis failed: {0}", ex.Message);
             _consoleWriter.WriteString(ex.Message);
         }
     }

--- a/source/Sailfish/Contracts.Public/Models/TestCaseName.cs
+++ b/source/Sailfish/Contracts.Public/Models/TestCaseName.cs
@@ -13,13 +13,17 @@ public class TestCaseName
     private const char OpenBracket = '(';
     private const char Dot = '.';
 
-    [JsonConstructor]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     public TestCaseName()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
     }
 
+    // Deserialization target. Name/Parts are get-only, so the serializer cannot populate them via a
+    // parameterless ctor — that left Name null after every tracking-file round-trip, which silently
+    // broke ScaleFish (it groups observations by TestCaseName.Name). Binding them through this ctor
+    // (params match the serialized "Name"/"Parts") restores a faithful round-trip.
+    [JsonConstructor]
     public TestCaseName(string name, IReadOnlyList<string> parts)
     {
         Name = name;

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -72,17 +72,24 @@ internal class TestCaseIterator : ITestCaseIterator
 
         var strategy = useAdaptive ? _adaptiveIterationStrategy : _fixedIterationStrategy;
 
-        // Apply sample size override if specified
+        // Apply an explicit run-level sample-size override. It is authoritative and is honoured
+        // even below MinimumSampleSize: previously the adaptive branch raised only the maximum to
+        // Math.Max(override, MinimumSampleSize), so an override below the minimum — e.g. 8 against a
+        // default 10 — was silently clamped back up and ignored.
         if (_runSettings.SampleSizeOverride.HasValue)
         {
+            var target = Math.Max(_runSettings.SampleSizeOverride.Value, 1);
             if (useAdaptive)
             {
-                executionSettings.MaximumSampleSize = Math.Max(_runSettings.SampleSizeOverride.Value,
-                                                              executionSettings.MinimumSampleSize);
+                // Cap at the override; lower the floor to match when the override is smaller so
+                // adaptive sampling can actually stop at the requested size (otherwise the floor
+                // would exceed the cap and the requested size would be unreachable).
+                executionSettings.MinimumSampleSize = Math.Min(executionSettings.MinimumSampleSize, target);
+                executionSettings.MaximumSampleSize = target;
             }
             else
             {
-                executionSettings.SampleSize = Math.Max(_runSettings.SampleSizeOverride.Value, 1);
+                executionSettings.SampleSize = target;
             }
         }
 

--- a/source/Sailfish/RunSettingsBuilder.cs
+++ b/source/Sailfish/RunSettingsBuilder.cs
@@ -380,6 +380,14 @@ public class RunSettingsBuilder
         return this;
     }
 
+    /// <summary>
+    ///     Sets the effective sample size for every test case, overriding per-class
+    ///     <c>[Sailfish(SampleSize = ...)]</c> values. This is an upper bound: with adaptive
+    ///     sampling (enabled by default) a case may converge with fewer samples, but never more.
+    ///     The value is honoured even when it is below the configured minimum sample size — an
+    ///     explicit override wins over the default floor, so e.g. <c>WithGlobalSampleSize(8)</c>
+    ///     yields ~8 samples rather than being clamped back up to the minimum.
+    /// </summary>
     public RunSettingsBuilder WithGlobalSampleSize(int sampleSize)
     {
         _globalSampleSize = Math.Max(sampleSize, 1);

--- a/source/Tests.Library/Analysis/Ai/SkipperPhase0Tests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperPhase0Tests.cs
@@ -148,6 +148,35 @@ public class PerformanceNarrativeContextBuilderTests
         c.MinimumDetectableEffectPercent!.Value.ShouldBe(3.2, 1e-9);
     }
 
+    [Fact]
+    public void SubMillisecondChange_UsesFullPrecisionMeans_NotRoundedScalars()
+    {
+        // Real data: before ≈ 0.0006 ms, after ≈ 0.000625 ms (a ~4% regression). The statistical
+        // tests pre-round the scalar means to SailDiffSettings.Round (3) → both 0.001, which would
+        // zero the percent-change and flip the verdict to Improved. The context must recompute from
+        // the raw arrays so the agent sees the real, correctly-directed change.
+        var before = Enumerable.Range(0, 10).Select(i => 0.000595 + i * 1e-6).ToArray();
+        var after = Enumerable.Range(0, 10).Select(i => 0.000620 + i * 1e-6).ToArray();
+        var stats = new StatisticalTestResult(
+            meanBefore: Math.Round(before.Average(), 3),  // 0.001 — the pre-rounded scalar
+            meanAfter: Math.Round(after.Average(), 3),    // 0.001 — identical once rounded
+            medianBefore: Math.Round(before.Average(), 3),
+            medianAfter: Math.Round(after.Average(), 3),
+            testStatistic: 0, pValue: 0.01, changeDescription: "desc",
+            sampleSizeBefore: 10, sampleSizeAfter: 10,
+            rawDataBefore: before, rawDataAfter: after,
+            additionalResults: new Dictionary<string, object>());
+        var result = new SailDiffResult(new TestCaseId("WithJoin"), new TestResultWithOutlierAnalysis(stats, null, null));
+
+        var c = builder.Build(new SailDiffAnalysisCompleteNotification(new[] { result }, "## md"), Alpha).Comparisons.Single();
+
+        c.MeanBefore.ShouldBe(before.Average(), 1e-12); // full precision, not the rounded 0.001
+        c.MeanAfter.ShouldBe(after.Average(), 1e-12);
+        c.MeanBefore.ShouldNotBe(c.MeanAfter);          // would have been equal with the rounded scalars
+        c.PercentChangeMean.ShouldBeGreaterThan(3.0);   // the real change is visible, not zeroed
+        c.Verdict.ShouldBe(SkipperVerdict.Regressed);   // and correctly directed
+    }
+
     private PerformanceNarrativeContext Build(params SailDiffResult[] results) =>
         builder.Build(new SailDiffAnalysisCompleteNotification(results, "## markdown"), Alpha);
 

--- a/source/Tests.Library/Execution/TestCaseIteratorTests.cs
+++ b/source/Tests.Library/Execution/TestCaseIteratorTests.cs
@@ -177,6 +177,27 @@ public class TestCaseIteratorTests
     }
 
     [Fact]
+    public async Task Iterate_AdaptiveSampleSizeOverrideBelowMinimum_CapsBothBoundsAtOverride()
+    {
+        // Regression (Issue 7): an override below the minimum used to be clamped back up via
+        // Math.Max(override, minimum), so WithGlobalSampleSize(8) under a default minimum of 10
+        // yielded 10. The explicit override must win as both the floor and the cap so adaptive
+        // sampling can actually stop at the requested size.
+        var executionSettings = Substitute.For<IExecutionSettings>();
+        executionSettings.UseAdaptiveSampling.Returns(true);
+        executionSettings.MinimumSampleSize.Returns(10);
+        executionSettings.MaximumSampleSize.Returns(1000);
+        var method = typeof(TestClass).GetMethod(nameof(TestClass.TestMethod))!;
+        var container = TestInstanceContainer.CreateTestInstance(new TestClass(), method, [], [], false, executionSettings);
+        _mockRunSettings.SampleSizeOverride.Returns(8);
+
+        await _testCaseIterator.Iterate(container, true, CancellationToken.None);
+
+        executionSettings.MaximumSampleSize.ShouldBe(8);
+        executionSettings.MinimumSampleSize.ShouldBe(8);
+    }
+
+    [Fact]
     public async Task Iterate_WithOverheadEstimationEnabled_ShouldApplyOverheadEstimates()
     {
         // Arrange

--- a/source/Tests.Library/Integration/ScaleFishProgrammaticOutputTests.cs
+++ b/source/Tests.Library/Integration/ScaleFishProgrammaticOutputTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Sailfish;
+using Sailfish.Attributes;
+using Shouldly;
+using Tests.Common.Utils;
+using Xunit;
+
+namespace Tests.Library.Integration;
+
+/// <summary>
+/// Issue 4 repro/guard: a benchmark with a <c>scaleFish</c> variable, run through the programmatic
+/// <see cref="SailfishRunner"/> API with <c>WithScaleFish()</c>, must write ScaleFish output
+/// (<c>Scalefish_*.md</c> + <c>ScalefishModels_*.json</c>) in a single run.
+/// </summary>
+public class ScaleFishProgrammaticOutputTests
+{
+    [Fact]
+    public async Task ScaleFishEnabledVariable_ViaProgrammaticApi_WritesScaleFishOutput()
+    {
+        var outputDir = Some.RandomString();
+        var runSettings = RunSettingsBuilder.CreateBuilder()
+            .WithLocalOutputDirectory(outputDir)
+            .TestsFromAssembliesContaining(typeof(ScaleFishReproBenchmark))
+            .WithTestNames(typeof(ScaleFishReproBenchmark).FullName!)
+            .DisableOverheadEstimation()
+            .WithScaleFish()
+            .Build();
+
+        var result = await SailfishRunner.Run(runSettings);
+
+        result.IsValid.ShouldBeTrue();
+        result.Exceptions.Count().ShouldBe(0);
+
+        Directory.Exists(outputDir).ShouldBeTrue();
+        var allFiles = Directory.GetFiles(outputDir, "*", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(outputDir, f)).ToList();
+        allFiles.Any(f => Path.GetFileName(f).Contains("scalefish", StringComparison.OrdinalIgnoreCase))
+            .ShouldBeTrue($"expected a ScaleFish output file under '{outputDir}'; found (recursive): {string.Join(" | ", allFiles)}");
+    }
+}
+
+[Sailfish(SampleSize = 3, NumWarmupIterations = 1)]
+public class ScaleFishReproBenchmark
+{
+    [SailfishVariable(scaleFish: true, 100, 1_000, 10_000)]
+    public int N { get; set; }
+
+    [SailfishMethod]
+    public void ScalesLinearlyWithN()
+    {
+        var acc = 0.0;
+        for (var i = 0; i < N * 50; i++) acc += Math.Sqrt(i);
+        // Defeat dead-code elimination so the loop is actually measured.
+        if (acc < 0) throw new InvalidOperationException("unreachable");
+    }
+}


### PR DESCRIPTION
Resolves the four remaining issues from the SailDiff investigation brief (Issues 4–7). Companion to #301 (Issues 1 & 3). Branched off `main`; full `Tests.Library` (1606) and `Tests.TestAdapter` (569) suites green on net9.0 + net10.0.

## Issue 4 — ScaleFish produces no output via the programmatic API (High of this set)

**Real bug, reproduced.** ScaleFish reads the run's execution summaries back from the tracking file. `TestCaseId` is deserialized via `TestCaseIdConverter`, which deserializes the nested `TestCaseName` — but `TestCaseName` had a parameterless `[JsonConstructor]` and a **get-only `Name`**, so the serializer could never populate `Name`. Every `TestCaseName` round-tripped through a tracking file came back with `Name == null`.

`ScalefishObservationCompiler` groups observations by `TestCaseId.TestCaseName.Name`, so the null name became a **null `Dictionary` key** in `ComplexityComputer` → `ArgumentNullException` → caught and **silently swallowed** in `ScaleFish.Analyze` → no notification, no output, no error. (SailDiff / method comparison don't key on `TestCaseName.Name`, which is why only ScaleFish broke.)

**Fix:** make the `(name, parts)` constructor the `[JsonConstructor]` so `Name`/`Parts` round-trip faithfully; log the previously-swallowed ScaleFish failure at Warning. Adds an end-to-end regression test that runs a scaleFish benchmark through `SailfishRunner` and asserts `Scalefish_*.md` is written in a single run.

## Issue 6 — sub-millisecond means shown as `0.001 ms` / wrong Skipper verdict

`PerformanceNarrativeContextBuilder` built the AI context from the **pre-rounded** scalar means on `StatisticalTestResult` (rounded to `SailDiffSettings.Round` ms-decimals). For sub-ms cases both means collapse to `~0.001`, which zeroed `PercentChangeMean`, flipped the derived verdict's direction, and fed the agent figures that disagreed with the embedded results markdown. Now recomputes from the raw arrays via `SailDiffDisplayStatistics` (the same helper the unified formatter uses).

## Issue 5 — AI explanation contradicting the measurements

The agent could claim a measured-slower candidate is faster (the bogus "string.Join is SIMD-optimised" write-up). Added a prompt rule: rank candidates by their means in the context and never claim/attribute a speed-up to a candidate measured as slower. (Issue 6 also makes those means accurate.)

## Issue 7 — `WithGlobalSampleSize(n)` ignored below the minimum

`WithGlobalSampleSize` lands as `SampleSizeOverride`; with adaptive sampling (on by default) the iterator applied it as `MaximumSampleSize = Math.Max(override, MinimumSampleSize)`, so an override **below** the minimum (8 vs default 10) was silently clamped back up. Now an explicit override is authoritative: cap at it and lower the floor to match when it's smaller. Documented the upper-bound semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
