### PR TITLE
fix(trawl): un-poison main — guarantee a closed-model virtual user runs ≥1 request

### DIFF
--- a/source/Sailfish/Execution/ClosedModelScheduler.cs
+++ b/source/Sailfish/Execution/ClosedModelScheduler.cs
@@ -127,7 +127,13 @@ internal sealed class ClosedModelScheduler
         long success = 0;
         long errors = 0;
 
-        while (!cancellationToken.IsCancellationRequested && Stopwatch.GetTimestamp() < deadlineTimestamp)
+        // Each virtual user performs at least one request unless the run was cancelled before it started.
+        // The deadline is checked at the BOTTOM of the loop (not the top) so that a worker whose thread-pool
+        // start is delayed past a short deadline still contributes one request rather than recording nothing.
+        // Without this, a brief scheduling stall on a busy machine makes a perfectly healthy scenario look
+        // like it "produced no requests" — the empty-run guard in TrawlExecutionEngine should mean the work
+        // could not complete a single request, not that the scheduler was slow to get going.
+        while (!cancellationToken.IsCancellationRequested)
         {
             var start = Stopwatch.GetTimestamp();
             try
@@ -147,6 +153,8 @@ internal sealed class ClosedModelScheduler
                 // a time-to-failure is rarely comparable to a successful-response latency.
                 errors++;
             }
+
+            if (Stopwatch.GetTimestamp() >= deadlineTimestamp) break;
         }
 
         return new WorkerResult(samples ?? (IReadOnlyList<RequestSample>)Array.Empty<RequestSample>(), success, errors);


### PR DESCRIPTION
## What poisoned main

The `Tests.Library` **net10.0** job on `main` ([run 26873047031](https://github.com/paulegradie/Sailfish/actions/runs/26873047031/job/79253376006)) failed on a single test:

```
Tests.Library.Trawl.TrawlRegressionGatingTests.FailOnRegression_FailsTheCase_WhenRegressed [FAIL]
  result.Exception!.Message should contain "regression"
    but was actually
  "Trawl scenario 'GateWork.Scenario()' produced no requests in 0.2s."
```

The **net9.0** job passed on the same commit — the signature of a timing race, not a logic regression. The test (and its `0.2s` / `Task.Delay(2)` config) has been unchanged since it was introduced in `103bb9e`; the flake was latent from day one and finally tripped on a loaded runner (six unit-test jobs run in parallel).

## Root cause

`ClosedModelScheduler` computes the run deadline **before** spawning its virtual-user workers via `Task.Run`, and each worker checked the deadline at the **top** of its loop:

```csharp
while (!cancellationToken.IsCancellationRequested && Stopwatch.GetTimestamp() < deadlineTimestamp)
```

If thread-pool startup eats the entire 0.2s window before a worker's first check runs, the worker does **zero** work. With both workers starved, `SuccessCount == 0 && ErrorCount == 0`, so `TrawlExecutionEngine` returns *"produced no requests"* and the regression gate under test is never reached.

Because the scenario's `Task.Delay(2, None)` can never throw, `SuccessCount == 0` is reachable **only** when no worker ever executed the loop body — i.e. exactly this start-delay race.

## Fix

Check the deadline at the **bottom** of the worker loop, so each non-cancelled virtual user contributes at least one request even when its start is delayed:

```csharp
while (!cancellationToken.IsCancellationRequested)
{
    ... invoke ...
    if (Stopwatch.GetTimestamp() >= deadlineTimestamp) break;
}
```

This also makes the engine's empty-run guard mean what it says — *"the work could not complete a single request"* — rather than *"the scheduler was slow to get going."* For realistic multi-second load runs the behaviour is unchanged (workers always start well within the window); the change only affects the pathological case where a worker starts after the deadline.

## Verification

- `Tests.Library` **net10.0** (the failing job) — **1618 passed, 0 failed** locally.
- `ClosedModelSchedulerTests` (6) + `TrawlRegressionGatingTests` (2) — all green; none asserted a zero-request outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)