### PR TITLE
docs(process-isolation): planning spec + phased plan + living handoff for opt-in deep isolation

### DIFF
--- a/docs/projects/process-isolation/HANDOFF.md
+++ b/docs/projects/process-isolation/HANDOFF.md
@@ -1,0 +1,91 @@
+# HANDOFF — Opt-in Process Isolation
+
+> **Living document.** Update this at the end of every work session. It is the single source of
+> truth for "where are we and what's next." Keep it short and current — history goes in the session
+> log at the bottom, not inline.
+
+**Last updated:** 2026-06-03 · **By:** Claude (planning) · **Current phase:** P0 (spec)
+
+---
+
+## Current state
+
+- Planning complete. `README.md` / `SPEC.md` / `PLAN.md` written and under review in this PR.
+- No code written yet. No behavior change. `main` untouched by anything in this directory.
+
+## Next action (do this next)
+
+➡️ **Get the four open decisions resolved (below), then start P1.** P1 is pure config surface +
+resolver with no behavior change — safe to land early. Begin with `SailfishIsolation` +
+`SailfishAttribute.Isolation` and the `EffectiveIsolationResolver`, since everything else hangs off
+the resolved value.
+
+## Phase status
+
+| Phase | State | PR | Notes |
+|---|---|---|---|
+| P0 Spec & scaffolding | 🟡 In review | _(this PR)_ | docs only |
+| P1 Config surface + resolver | ⬜ Not started | — | inert; no behavior change |
+| P2 Isolated host | ⬜ Not started | — | not wired in |
+| P3 Parent spawn + round-trip | ⬜ Not started | — | first observable behavior |
+| P4 Launch-environment knobs | ⬜ Not started | — | the robustness payoff |
+| P5 Packaging / analyzer / docs | ⬜ Not started | — | ship-ready |
+
+---
+
+## Decision log
+
+Record every decision here with date + rationale. ✅ decided · ❓ open.
+
+| # | Decision | Status | Resolution / rationale |
+|---|---|---|---|
+| 1 | Default process **granularity** | ❓ open | Recommend `PerClass` (amortizes process startup; pairs naturally with `SharedInstance`). `PerCase` available as opt-in. |
+| 2 | Host **shipping mechanism** | ❓ open | Recommend `dotnet exec` a packaged framework-dependent dll (portable; avoids per-RID exe matrix). |
+| 3 | `Robust` **preset** shape | ❓ open | Recommend a new `SailfishPreset.Robust` that enables isolation + tighter stats, vs an orthogonal switch. |
+| 4 | **Analyzer ID** | ❓ open | Claim next free `SFxxxx` (SF1024 taken). Verify against `AnalyzerReleases.Unshipped.md` before use. |
+| — | Reuse `Tracking.V1` as the IPC payload | ✅ 2026-06-03 | It already round-trips raw samples (`RawExecutionResults`); no new contract, no fidelity loss. |
+| — | Fork isolation at `ClassExecutionDispatcher` | ✅ 2026-06-03 | Already the single shared lifetime fork point; same dispatcher runs on both sides of the boundary. |
+| — | Parent owns notification publishing | ✅ 2026-06-03 | Adapter records pass/fail solely from MediatR notifications, whose handlers live in the parent. Child uses a no-op mediator. |
+| — | Isolation is strictly opt-in | ✅ 2026-06-03 | Default stays `InProcess`; no existing run changes behavior. |
+
+## Open questions for Paul
+
+1. Decisions #1–#4 above.
+2. Should in-process hardening (`GC.Collect` between samples / priority / affinity without a child
+   process) ship as a separate small add-on, or be folded in / dropped? (Partial win; not a
+   substitute for process isolation — see SPEC §6.)
+3. Any objection to a new console project in the solution (`Sailfish.IsolatedHost`) vs an alternate
+   host-delivery shape?
+
+## Gotchas discovered (append as you hit them)
+
+- **Tracking format is a declared breaking-change contract** (`Tracking.V1/*` headers). Reuse as-is;
+  do not add/rename fields. A new field would force `Tracking.V2` — out of scope.
+- **Notifications are published *inside* `ActivateContainer`.** Don't let the child publish to a real
+  mediator; the parent must re-derive/publish (SPEC §2.4, §3.3).
+- **Docs site sidebar is a hand-coded array** in `site/src/components/Layout.jsx` — a new page is
+  invisible until added there (P5).
+- **Analyzer attribute detection:** use `HasAttributeAmong`, not the `.All()`-buggy
+  `HasAttributesWithNames` overload (P5).
+
+---
+
+## Key references (so the next session doesn't re-discover them)
+
+- Dispatch seam: `source/Sailfish/Execution/ClassExecutionDispatcher.cs`
+- Engine + inline notifications: `source/Sailfish/Execution/SailfishExecutionEngine.cs`
+- Raw samples: `source/Sailfish/Execution/PerformanceTimer.cs` (`ExecutionIterationPerformances`)
+- IPC payload: `source/Sailfish/Contracts.Public/Serialization/Tracking.V1/` (`PerformanceRunResultTrackingFormat.RawExecutionResults`, `ITrackingFileSerialization`)
+- Attribute to extend: `source/Sailfish/Attributes/SailfishAttribute.cs` (model on `SailfishLifetime.cs`)
+- Settings: `source/Sailfish/Contracts.Public/Models/IRunSettings.cs`, `RunSettings.cs`, `RunSettingsBuilder.cs`, `SailfishPreset.cs`
+- Adapter settings load: `source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs`, `.../TestSettingsParser/SettingsConfiguration.cs`
+- DI: `AddSailfish` + `source/Sailfish/Registration/SailfishTypeRegistrationUtility.cs`
+- Entry points: `source/Sailfish/SailfishRunner.cs`, `source/Sailfish.TestAdapter/TestExecutor.cs`
+
+---
+
+## Session log
+
+| Date | Who | What changed |
+|---|---|---|
+| 2026-06-03 | Claude | Created project directory; wrote README/SPEC/PLAN/HANDOFF; opened planning PR. Confirmed (by reading `main`): in-process-only execution, dispatcher seam, raw samples in `PerformanceTimer`, and `Tracking.V1` carries `RawExecutionResults` (reusable as IPC payload). |

--- a/docs/projects/process-isolation/PLAN.md
+++ b/docs/projects/process-isolation/PLAN.md
@@ -1,0 +1,134 @@
+# PLAN — Opt-in Process Isolation
+
+**Status:** Planning (P0) · **Last updated:** 2026-06-03
+
+The executable roadmap. Stacked PRs, each independently green, each leaving `main` shippable
+(isolation stays opt-in and inert until P3 lights it up). Tick boxes as steps land; record actual PR
+numbers and discoveries in [`HANDOFF.md`](./HANDOFF.md). Design rationale for every step is in
+[`SPEC.md`](./SPEC.md).
+
+**Conventions**
+- Each phase = one PR (split if it grows). Branch off the previous phase's branch (stacked).
+- Definition of done per phase: code + tests + green CI + the phase's acceptance criteria met +
+  `HANDOFF.md` updated.
+- Keep `main` behavior unchanged until **P3**. Through P1–P2, `Process` resolves but the dispatcher
+  still runs in-process behind the resolver (no observable change).
+
+---
+
+## P0 — Spec & scaffolding  ·  _this PR_
+
+- [x] Write `README.md`, `SPEC.md`, `PLAN.md`, `HANDOFF.md` under `docs/projects/process-isolation/`.
+- [ ] Open the PR with the plan (this one).
+- [ ] File a tracking issue ("Opt-in process isolation") linking this directory; create sub-issues per phase.
+- [ ] Paul resolves the four open decisions (README → "Open decisions"); record outcomes in `HANDOFF.md`.
+
+**Acceptance:** docs merged; tracking issue + phase sub-issues exist; open decisions logged.
+
+---
+
+## P1 — Config surface + effective-isolation resolver  ·  _no behavior change_
+
+Goal: every way of expressing "isolate this" exists and round-trips, and a single resolver computes
+the effective isolation for a class. Nothing spawns yet.
+
+- [ ] Add `SailfishIsolation { InProcess = 0, Process = 1 }` enum (`source/Sailfish/Attributes/SailfishIsolation.cs`).
+- [ ] Add `Isolation` property to [`SailfishAttribute`](../../../source/Sailfish/Attributes/SailfishAttribute.cs) (default `InProcess`).
+- [ ] Add `[ProcessIsolation]` class attribute + its enums (`IsolationGranularity`, `GcPolicy`, `TieringPolicy`, `ProcessPriority`) under `source/Sailfish/Attributes/`.
+- [ ] Add `ProcessIsolationSettings` model + `ProcessIsolation` knob to [`IRunSettings`](../../../source/Sailfish/Contracts.Public/Models/IRunSettings.cs) and [`RunSettings`](../../../source/Sailfish/RunSettings.cs).
+- [ ] Add `WithProcessIsolation(...)` to [`RunSettingsBuilder`](../../../source/Sailfish/RunSettingsBuilder.cs).
+- [ ] Add `ProcessIsolation` section to [`SettingsConfiguration`](../../../source/Sailfish.TestAdapter/TestSettingsParser/SettingsConfiguration.cs) and map it in [`AdapterRunSettingsLoader`](../../../source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs).
+- [ ] Add the `Robust` preset (or orthogonal switch — per decision #3) to [`SailfishPreset`](../../../source/Sailfish/SailfishPreset.cs).
+- [ ] Implement `EffectiveIsolationResolver` (precedence: attribute > run-settings override > run-settings default > InProcess). Pure, no I/O.
+
+**Acceptance:** unit tests cover the resolver precedence matrix and `.sailfish.json` → `IRunSettings`
+round-trip; full suite green; **no behavioral change** to any existing run.
+
+---
+
+## P2 — The isolated host (in-process-equivalent)  ·  _not yet wired in_
+
+Goal: a standalone process can run one class and emit a faithful `Tracking.V1` blob, driven directly
+(e.g. from a test), independent of the adapter.
+
+- [ ] New project `source/Sailfish.IsolatedHost/` (console exe, multi-targeted to supported TFMs); add to `Sailfish.sln`.
+- [ ] Job contract: define the serialized job (assembly path, type, optional case selector, `IRunSettings`, output path, timeout). Put shared types where both host and library see them.
+- [ ] Assembly loading via `AssemblyLoadContext` + `AssemblyDependencyResolver` (deps.json).
+- [ ] Container build reusing `AddSailfish` + [`SailfishTypeRegistrationUtility`](../../../source/Sailfish/Registration/SailfishTypeRegistrationUtility.cs), with a **no-op `IMediator`** registered.
+- [ ] Run [`ClassExecutionDispatcher.Dispatch`](../../../source/Sailfish/Execution/ClassExecutionDispatcher.cs) for the selected class; honor `Lifetime` as usual inside the child.
+- [ ] Emit results as `Tracking.V1` via [`ITrackingFileSerialization`](../../../source/Sailfish/Contracts.Public/Serialization/Tracking.V1/TrackingFileSerialization.cs) + a status sidecar for summary-less failures; exit code for catastrophic failure.
+
+**Acceptance:** golden test — running a deterministic benchmark class through the host produces a
+tracking blob whose `RawExecutionResults`/summaries are equivalent (within tolerance) to the same
+class run in-process; host handles a throwing benchmark without hanging (sidecar + non-zero exit).
+
+---
+
+## P3 — Parent-side spawn + result round-trip  ·  _lights it up_
+
+Goal: when effective isolation is `Process`, the class actually runs out-of-process and the result is
+indistinguishable downstream (same pass/fail, equivalent stats), in **both** the programmatic and
+adapter paths.
+
+- [ ] `OutOfProcessClassRunner`: build `ProcessStartInfo`, locate the host (stub path for P3; real discovery in P5), launch, stream logs, await with **timeout + cancellation** (wire the adapter's `Cancel()`).
+- [ ] Branch in [`ClassExecutionDispatcher`](../../../source/Sailfish/Execution/ClassExecutionDispatcher.cs) (or a decorator): effective isolation `Process` → `OutOfProcessClassRunner`; else existing in-process path.
+- [ ] Rehydrate the child's `Tracking.V1` blob into the result/summary shape; **publish notifications in the parent** (started/completed/exception) from the rehydrated results (SPEC §3.3).
+- [ ] **Failure fidelity:** child crash / non-zero exit / timeout → `TestCaseExceptionNotification` for every affected case in the group (SPEC §2.4, §3.3).
+- [ ] Honor `Granularity`: `PerClass` (one child/class) and `PerCase` (one child/case).
+- [ ] _(Stretch)_ factor measurement apart from publish/compile so both paths share one publish path.
+
+**Acceptance:** E2E in adapter + programmatic paths — an isolated run reports identical pass/fail and
+equivalent statistics to in-process for the same workload; a benchmark that throws is reported failed
+(not dropped); a hanging benchmark is killed at timeout and reported; cancellation propagates to the
+child; full suite green.
+
+---
+
+## P4 — Launch-environment knobs
+
+Goal: the dedicated process is actually launched under the requested GC / JIT / priority / affinity —
+the reason process isolation buys robustness.
+
+- [ ] Apply env vars from `[ProcessIsolation]` / settings: `DOTNET_gcServer`, `DOTNET_gcConcurrent`, `DOTNET_TieredCompilation`, `DOTNET_TC_QuickJitForLoops`, `DOTNET_TieredPGO`.
+- [ ] Apply `Process.PriorityClass` and (best-effort, platform-aware) `Process.ProcessorAffinity`.
+- [ ] Finalize the `Robust` preset values (per decision #3).
+- [ ] Child-side diagnostic that reports its actual runtime config (server GC, concurrent, tiering) back in the blob/sidecar for assertion + display.
+
+**Acceptance:** integration test asserts the child runs under the requested GC/JIT (probe via
+`GCSettings.IsServerGC` etc. in the child and assert in the parent); knobs documented with platform
+caveats; full suite green.
+
+---
+
+## P5 — Packaging, analyzer, docs, hardening
+
+Goal: it works installed-from-package, is guarded against foot-guns, and is documented.
+
+- [ ] Package the host into the Sailfish NuGet; implement runtime **host discovery** from the running adapter; invoke via `dotnet exec` against the test assembly's TFM (per decision #2).
+- [ ] Add analyzer `SFxxxx` (claim next free ID; SF1024 is taken — verify against [`AnalyzerReleases.Unshipped.md`](../../../source/Sailfish.Analyzers/AnalyzerReleases.Unshipped.md)): warn on cross-process `ISailfishFixture<T>` sharing under `Process` isolation, and on `[ProcessIsolation]` present without `Isolation = Process`. Use `HasAttributeAmong` for attribute detection (not the buggy `.All()` overload).
+- [ ] Docs page under the published site (`site/`), and **add it to the manual sidebar** in `site/src/components/Layout.jsx` (orphaned-page gotcha). Cover: what it is, how it differs from `PerCase`, the cross-process fixture/singleton/static semantics (SPEC §4), cost trade-offs.
+- [ ] Note in SailDiff/ScaleFish/Skipper docs that the measured environment is the child under isolation.
+- [ ] Install-from-package E2E; analyzer unit tests; finalize `PerCase` granularity.
+
+**Acceptance:** a consumer project installing the produced package can opt a class into `Process`
+isolation and get results; analyzer fires on the foot-guns with tests; docs live and linked in the
+sidebar; full suite (library + adapter + analyzer) green.
+
+---
+
+## Dependency graph
+
+```
+P0 ─▶ P1 ─▶ P2 ─▶ P3 ─▶ P4 ─▶ P5
+                   │
+                   └─ P3 is the first phase with observable behavior; P1–P2 are inert.
+```
+
+## Test strategy (cross-cutting)
+
+- **Unit:** resolver precedence; settings round-trip; job (de)serialization; rehydration mapping.
+- **Golden/equivalence:** host vs in-process produce equivalent raw samples/summaries for a
+  deterministic workload (the core fidelity guarantee).
+- **E2E:** adapter + programmatic isolated runs (pass, fail, hang/timeout, cancel).
+- **Integration:** launch knobs actually applied (probe runtime state in the child).
+- **Packaging:** install-from-package consumer can opt in and run.

--- a/docs/projects/process-isolation/README.md
+++ b/docs/projects/process-isolation/README.md
@@ -1,0 +1,62 @@
+# Project: Opt-in Process Isolation ("deep isolation mode")
+
+> Let a benchmark (or a whole run) opt in to executing in a **dedicated child process** with a
+> controlled launch environment, so benchmarks that need genuinely robust results are no longer
+> contaminated by the shared test host.
+
+**Status:** `Planning` · **Phase:** P0 (spec) · **Owner:** Paul · **Created:** 2026-06-03
+
+---
+
+## TL;DR
+
+Sailfish runs **100% in-process** today. When run as a test (IDE / `dotnet test`), the dominant
+source of measurement noise is the **test host itself** — other tests in the run, the vstest/IDE
+infrastructure, its background threads, GC pressure, and JIT activity, all sharing your process.
+
+The existing `[Sailfish(Lifetime = PerCase)]` gives **object** isolation (fresh instance + DI scope
+per case). It does **not** touch any process-level noise, and it cannot — server/workstation GC and
+JIT tiering are fixed at process launch. "Deep isolation that produces robust results" therefore
+*requires* getting the benchmark out of the shared host into a dedicated child process. That is the
+BenchmarkDotNet toolchain model, and this project adds it to Sailfish as an **opt-in**.
+
+The good news, established during planning:
+
+1. **No codegen/build step needed.** Sailfish's engine is reflection/DI-driven over discovered
+   types, so the child host just loads the already-built test assembly and runs the existing engine
+   on a selected class. (BDN has to generate + build a project precisely because it has no such
+   engine.)
+2. **The seam already exists.** [`ClassExecutionDispatcher`](../../../source/Sailfish/Execution/ClassExecutionDispatcher.cs)
+   is the single shared fork point for the class's `Lifetime`; isolation forks at the same place,
+   and the *same dispatcher* runs on both sides of the process boundary.
+3. **The IPC payload already exists.** The `Tracking.V1` serialization
+   ([`PerformanceRunResultTrackingFormat`](../../../source/Sailfish/Contracts.Public/Serialization/Tracking.V1/PerformanceRunResultTrackingFormat.cs))
+   already round-trips raw per-iteration samples (`double[] RawExecutionResults`) to disk for
+   SailDiff. The child emits a tracking blob; the parent ingests it exactly as it already ingests a
+   completed run. No new data contract required.
+
+## Document map
+
+| Doc | Purpose |
+|---|---|
+| [`SPEC.md`](./SPEC.md) | **The context + design.** Current-architecture facts, the out-of-process model, the seam, the IPC boundary, the config surface, semantics that change, risks, alternatives considered. Read this first. |
+| [`PLAN.md`](./PLAN.md) | **The steps.** Phased, stacked-PR implementation plan (P0–P5), each step with concrete file targets and acceptance criteria. The executable roadmap to completion. |
+| [`HANDOFF.md`](./HANDOFF.md) | **Living state.** Current phase/step, what's done, the single next action, decision log, open questions, and gotchas discovered along the way. **Update this every work session.** |
+
+## Status at a glance
+
+| Phase | Title | State |
+|---|---|---|
+| P0 | Spec & scaffolding (this PR) | 🟡 In review |
+| P1 | Config surface + effective-isolation resolver | ⬜ Not started |
+| P2 | The isolated host (in-process-equivalent) | ⬜ Not started |
+| P3 | Parent-side spawn + result round-trip | ⬜ Not started |
+| P4 | Launch-environment knobs (GC / JIT / priority / affinity) | ⬜ Not started |
+| P5 | Packaging, analyzer, docs, hardening | ⬜ Not started |
+
+## Open decisions (need Paul's call — see HANDOFF "Decision log")
+
+1. **Default process granularity** — per-class (recommended) vs per-case.
+2. **Host shipping mechanism** — `dotnet exec` a packaged framework-dependent dll (recommended) vs per-RID native exe.
+3. **`Robust` preset** — new `SailfishPreset` value vs an orthogonal switch.
+4. **Analyzer ID** — claim next free `SFxxxx` (SF1024 is taken; verify against `AnalyzerReleases.Unshipped.md`).

--- a/docs/projects/process-isolation/SPEC.md
+++ b/docs/projects/process-isolation/SPEC.md
@@ -1,0 +1,313 @@
+# SPEC — Opt-in Process Isolation
+
+**Status:** Planning (P0) · **Last updated:** 2026-06-03
+
+This document is the design of record. It captures the context, the architecture facts the design
+relies on (with file references), the proposed design, the configuration surface, the semantics that
+change, the risks, and the alternatives considered. The step-by-step build is in [`PLAN.md`](./PLAN.md);
+live progress is in [`HANDOFF.md`](./HANDOFF.md).
+
+---
+
+## 1. Context & problem statement
+
+### 1.1 What we have today
+
+Sailfish's benchmark execution is **entirely in-process**. There is no `Process.Start` anywhere in
+the core measurement path; the only process spawning in the repo is in diagnostics
+(`ComplexityHistoryStore`, `EnvironmentHealthChecker`). A benchmark runs inside whichever host
+invoked it:
+
+- **IDE / `dotnet test`** — inside the vstest `testhost` process, via the test adapter
+  ([`TestExecutor`](../../../source/Sailfish.TestAdapter/TestExecutor.cs),
+  [`TestDiscoverer`](../../../source/Sailfish.TestAdapter/TestDiscoverer.cs)).
+- **Programmatic** — inside the caller's process, via
+  [`SailfishRunner.Run`](../../../source/Sailfish/SailfishRunner.cs) →
+  [`SailfishExecutionCaller`](../../../source/Sailfish/Execution/SailfishExecutionCaller.cs).
+
+### 1.2 Why that limits robustness
+
+When a benchmark runs as a test, **the test host is the dominant noise source**: other tests in the
+same run, the vstest/IDE machinery, its background threads, its allocations and GC pressure, and its
+JIT activity all share the benchmark's process. None of that can be controlled from inside the
+process after launch.
+
+Crucially, the knobs that most affect measurement robustness are **fixed at process launch** and
+cannot be changed at runtime:
+
+- GC flavor — workstation vs **server**, concurrent vs non-concurrent (`DOTNET_gcServer`, `DOTNET_gcConcurrent`).
+- JIT tiering — **tiered compilation off** / quick-JIT-for-loops off / PGO
+  (`DOTNET_TieredCompilation`, `DOTNET_TC_QuickJitForLoops`, `DOTNET_TieredPGO`), so steady-state code
+  is fully optimized and not changing mid-measurement.
+
+### 1.3 Why `PerCase` is *not* this feature
+
+The shipped `[Sailfish(Lifetime = PerCase)]`
+([`SailfishLifetime`](../../../source/Sailfish/Attributes/SailfishLifetime.cs)) gives a fresh
+instance + DI scope per case. That is **object** isolation. It does not remove the host, other
+tests, the shared GC heap, or JIT carryover. It is orthogonal to this project and must not be
+conflated with it in docs or UI.
+
+### 1.4 The ask
+
+> "Make it **optional** to go **deep isolation mode** on test runs for benchmarks that really need
+> robust results."
+
+Restated precisely: allow a benchmark class (or a whole run) to **opt in to out-of-process
+execution** in a dedicated child process whose **launch environment** (GC / JIT / priority /
+affinity) we control. Default behavior is unchanged (in-process).
+
+### 1.5 Levels of isolation (shared vocabulary)
+
+| Level | Isolates | Achievable in-process? | This project? |
+|---|---|---|---|
+| SharedInstance (default) | nothing | — | no |
+| `PerCase` (shipped) | object state + DI scope | yes (already) | no — orthogonal |
+| In-process hardening | `GC.Collect` between samples, `PriorityClass`, `ProcessorAffinity` | **partially** (priority/affinity yes; GC/JIT no) | optional cheap add-on |
+| **Process isolation** | the whole host: other tests, host threads, GC heap, JIT | **no — needs a child process** | ✅ **primary** |
+| Process-per-case | + cross-case heap/JIT carryover | child process per case | ✅ P4/P5 option |
+
+---
+
+## 2. Architecture facts the design relies on
+
+All confirmed by reading the current code on `main` (2026-06-03).
+
+### 2.1 The dispatch seam
+
+[`ClassExecutionDispatcher.Dispatch`](../../../source/Sailfish/Execution/ClassExecutionDispatcher.cs)
+is — by its own doc comment — the single place "shared by the main-library executor and the
+test-adapter engine so the instance-lifecycle policy lives in exactly one place." It reads the
+`[Sailfish]` attribute and forks on `Lifetime`. **Isolation forks at the same point.** And elegantly,
+**the same dispatcher runs on both sides**: parent-side it decides "spawn a child instead of running
+in-process"; child-side it is the in-process worker honoring `Lifetime` as usual.
+
+```
+SailfishExecutor → SailFishTestExecutor → ClassExecutionDispatcher.Dispatch(testType, providers, group)
+                                                  │
+                       ┌──────────────────────────┴───────────────────────────┐
+              effective isolation == InProcess                    effective isolation == Process
+                       │                                                       │
+        _engine.ActivateContainer(provider, …)            OutOfProcessClassRunner.Run(testType, …)
+        (existing in-process path)                         → spawn Sailfish.IsolatedHost
+                                                            → child runs Dispatch IN-PROCESS
+                                                            → child emits Tracking.V1 blob
+                                                            → parent rehydrates + publishes
+```
+
+### 2.2 The measurement data and where raw samples live
+
+- The engine ([`SailfishExecutionEngine.ActivateContainer`](../../../source/Sailfish/Execution/SailfishExecutionEngine.cs))
+  runs per-case hooks → `IterateOverVariableCombos` → `ITestCaseIterator.Iterate` (the warmup +
+  sampling loop) and produces a [`TestCaseExecutionResult`](../../../source/Sailfish/Execution/TestCaseExecutionResult.cs).
+- A result carries a [`PerformanceTimer`](../../../source/Sailfish/Execution/PerformanceTimer.cs)
+  whose `ExecutionIterationPerformances` is the **raw per-iteration sample list** (per-operation
+  ticks, plus overhead-calibration diagnostics). This is the ground-truth measurement data.
+- [`ClassExecutionSummaryCompiler`](../../../source/Sailfish/Execution/ClassExecutionSummaryCompiler.cs)
+  compiles raw results into statistical summaries; all downstream analysis (outliers, SailDiff,
+  ScaleFish) runs from there.
+
+### 2.3 The IPC payload already exists (key finding)
+
+The `Tracking.V1` serialization already persists raw samples and round-trips them:
+
+- [`PerformanceRunResultTrackingFormat`](../../../source/Sailfish/Contracts.Public/Serialization/Tracking.V1/PerformanceRunResultTrackingFormat.cs)
+  carries **`double[] RawExecutionResults` (milliseconds)** plus mean/median/stddev/variance, the
+  outlier-removed array, upper/lower outliers, sample size, warmup count.
+- [`ITrackingFileSerialization`](../../../source/Sailfish/Contracts.Public/Serialization/Tracking.V1/TrackingFileSerialization.cs)
+  exposes `Serialize(IEnumerable<ClassExecutionSummaryTrackingFormat>)` /
+  `Deserialize(string)`.
+
+This is exactly the format Sailfish writes to disk after a run and reads back for SailDiff's
+before/after comparison. **The child→parent channel reuses it**: the child produces a tracking blob;
+the parent ingests it as if it were a just-completed run. No new data contract, no fidelity loss —
+the parent's analysis already runs from these same raw arrays today.
+
+### 2.4 Notifications are published *inside* the engine
+
+`ActivateContainer` publishes MediatR notifications inline — `TestCaseStarted`, `TestCaseCompleted`,
+`TestCaseException`, `TestCaseDisabled`, `TestClassCompleted` — and the test adapter records pass/fail
+**solely** from those notifications. Those handlers live in the **parent** and have side effects (IDE
+results, console, files). Therefore the design must ensure the **parent owns notification
+publishing**; the child must not try to reach the parent's mediator. See §3.3.
+
+### 2.5 DI registration is centralized and reusable
+
+Both entry points build the container via the `AddSailfish` registration extension +
+[`SailfishTypeRegistrationUtility`](../../../source/Sailfish/Registration/SailfishTypeRegistrationUtility.cs)
+(which auto-discovers `IRegisterSailfishServices` in the configured assemblies). The isolated host
+reuses this verbatim — it does not reinvent container construction.
+
+---
+
+## 3. Proposed design
+
+### 3.1 Component: `Sailfish.IsolatedHost` (new console project)
+
+A small console executable (multi-targeted to the supported TFMs) that runs exactly one class's
+benchmark in a clean process. Responsibilities:
+
+1. **Parse the job** (args or a job-file path): test assembly path, fully-qualified test type,
+   optional method/case selector, the effective `IRunSettings` (serialized), output blob path,
+   timeout, and a cancellation signal.
+2. **Load the user assembly** + dependencies via `AssemblyLoadContext` + `AssemblyDependencyResolver`
+   (deps.json resolution).
+3. **Build the container** via `AddSailfish` + `SailfishTypeRegistrationUtility` — *identical* to the
+   in-process path — but with a **no-op `IMediator`** (notifications fire into the void here; the
+   parent re-derives them; see §3.3).
+4. **Run** `ClassExecutionDispatcher.Dispatch` for the selected class. Because the same dispatcher
+   runs here, the class's `Lifetime` is honored normally inside the child.
+5. **Emit** results as a `Tracking.V1` blob (via `ITrackingFileSerialization.Serialize`) to the
+   output path, plus a tiny status sidecar (per-case status / exception text for failures that never
+   produced a summary). Exit code communicates catastrophic failure.
+
+> Why a dedicated host and not "re-invoke vstest"? See §6 (Alternatives).
+
+### 3.2 Component: parent-side `OutOfProcessClassRunner` + dispatch branch
+
+Introduce an isolation branch at the dispatch seam (§2.1). When a class's **effective isolation** is
+`Process`:
+
+1. Resolve the **granularity**: `PerClass` (one child for the whole class — amortizes process
+   startup; natural default) or `PerCase` (one child per case — strictest).
+2. Build a `ProcessStartInfo`: locate the host (see §3.5), pass the job, and set the launch
+   environment (P4): GC/JIT env vars, `PriorityClass`, `ProcessorAffinity`.
+3. Launch, stream logs, await with timeout + cancellation (wired to the adapter's `Cancel()`).
+4. Read the child's `Tracking.V1` blob, **deserialize** via `ITrackingFileSerialization`, and
+   **rehydrate** into the result/summary shape the in-process path produces.
+5. **Publish the notifications** for each case/class from the rehydrated results (started/completed/
+   exception), so the adapter's pass/fail and the console/report writers behave identically.
+
+### 3.3 The notification-ownership refactor
+
+`ActivateContainer` currently interleaves measurement with notification publishing and inline
+summary compilation (§2.4). To let the parent own publishing cleanly there are two options:
+
+- **P3 minimal (chosen for first cut):** the child uses a **no-op mediator**; the parent re-derives
+  and publishes notifications from the rehydrated tracking blob + status sidecar. Notifications are
+  effectively "this case started/completed/failed with these samples," and re-deriving them in the
+  parent is faithful because the compiler is deterministic over the raw arrays.
+- **Cleaner follow-up (optional):** factor the measurement loop (produces raw `TestCaseExecutionResult`)
+  apart from the publish/compile step, so both in-process and out-of-process share one publish path.
+  Tracked as a P3 stretch / P5 cleanup — not required for correctness.
+
+> ⚠️ Failure fidelity is a first-class requirement, not a nice-to-have. A child crash, non-zero exit,
+> or timeout **must** map to a `TestCaseExceptionNotification` for every affected case, or the adapter
+> silently drops them. This is explicitly covered by P3 acceptance criteria.
+
+### 3.4 Configuration surface
+
+Mirrors how `Lifetime` and the adaptive-sampling/outlier knobs were added (attribute layer +
+run-settings layer + `.sailfish.json` + preset).
+
+**Attribute layer** — [`SailfishAttribute`](../../../source/Sailfish/Attributes/SailfishAttribute.cs):
+
+```csharp
+// on/off switch, mirrors SailfishLifetime
+public SailfishIsolation Isolation { get; set; } = SailfishIsolation.InProcess;
+```
+
+```csharp
+public enum SailfishIsolation { InProcess = 0, Process = 1 }
+```
+
+A companion **class-level `[ProcessIsolation(...)]`** attribute holds the launch knobs, keeping the
+already-large `[Sailfish]` attribute uncluttered and giving the analyzer something precise to bind to:
+
+```csharp
+[ProcessIsolation(
+    Granularity   = IsolationGranularity.PerClass,   // | PerCase
+    Gc            = GcPolicy.Server,                  // Inherit | Workstation | Server
+    Concurrent    = true,
+    Tiering       = TieringPolicy.Disabled,           // Inherit | Disabled
+    Priority      = ProcessPriority.High,             // Inherit | AboveNormal | High | RealTime
+    AffinityCore  = -1)]                              // -1 = unpinned
+```
+
+**Run-settings layer** — a `ProcessIsolationSettings` object on
+[`IRunSettings`](../../../source/Sailfish/Contracts.Public/Models/IRunSettings.cs) /
+[`RunSettings`](../../../source/Sailfish/RunSettings.cs), with
+`RunSettingsBuilder.WithProcessIsolation(...)`
+([`RunSettingsBuilder`](../../../source/Sailfish/RunSettingsBuilder.cs)). This sets the run-wide
+default and a global override.
+
+**`.sailfish.json`** — a `ProcessIsolation` section in
+[`SettingsConfiguration`](../../../source/Sailfish.TestAdapter/TestSettingsParser/SettingsConfiguration.cs),
+mapped through
+[`AdapterRunSettingsLoader`](../../../source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs).
+
+**Preset** — a `Robust` value on [`SailfishPreset`](../../../source/Sailfish/SailfishPreset.cs) (or an
+orthogonal switch — open decision) that enables process isolation + tighter stats in one call.
+
+**Effective-isolation resolver** — precedence: **method/attribute > run-settings override >
+run-settings default > built-in default (InProcess)**. Implemented once and unit-tested (P1), used by
+the dispatch branch (P3).
+
+### 3.5 Host discovery & packaging
+
+The host must be locatable when the adapter runs from the NuGet cache / build output. Recommended:
+ship the host **framework-dependent dll** in the Sailfish package and invoke
+`dotnet exec Sailfish.IsolatedHost.dll <job>` targeting the test assembly's TFM (portable; no per-RID
+native exe matrix). Resolving the host path from the running adapter and selecting the right TFM is
+the fiddliest operational piece — owned by P5.
+
+---
+
+## 4. Semantics that change under process isolation
+
+These are behavioral cliffs that **must be documented** (P5) and ideally analyzer-guarded:
+
+- **`ISailfishFixture<T>` and singletons are process-scoped.** They can be shared across cases/classes
+  *within* a process but **cannot** be shared across processes. Under `Process` isolation (especially
+  `PerCase`), a fixture is constructed per child. Genuinely-once cross-class sharing is impossible
+  out-of-process — call this out loudly.
+- **Static / `[ThreadStatic]` state** does not carry across the boundary (often the point, but
+  surprising if relied upon).
+- **Working directory, environment, and ambient config** are the child's. Tracking-file output paths
+  must be coordinated so the parent and child agree on locations.
+- **The environment health check / Skipper environment snapshot** now describe the *child*. That is
+  the correct, relevant environment for the measurement — but the reported environment changes.
+- **Lifetime × granularity composition:** `PerClass` + `SharedInstance` = ctor + GlobalSetup once in
+  one child (natural pairing). `PerCase` granularity makes per-class lifetime moot (one case per
+  child).
+
+---
+
+## 5. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Silent loss of failures across the boundary | P3 maps crash/non-zero-exit/timeout → `TestCaseExceptionNotification` per case; explicit tests. |
+| Host can't be located at runtime (packaging) | P5 owns discovery; `dotnet exec` packaged dll; integration test that installs from the produced package. |
+| Per-process startup cost dominates short benchmarks | `PerClass` default amortizes; document the cost; isolation is opt-in for exactly the cases that justify it. |
+| Launch knobs don't actually take effect | P4 integration test probes runtime state in the child (`GCSettings.IsServerGC`, etc.) and asserts. |
+| Tracking format is a declared **breaking-change contract** | Reuse as-is; do not modify `Tracking.V1` shapes. If a new field is unavoidable, version to `Tracking.V2` — out of scope here. |
+| Cross-platform affinity/priority differences | Treat priority/affinity as best-effort; `Inherit`/unpinned defaults; document platform caveats. |
+
+---
+
+## 6. Alternatives considered
+
+- **Re-invoke `dotnet vstest` in single-test mode per case.** Avoids a new exe but is heavier (full
+  vstest spin-up per unit of work), fragile (nested test runs, runsettings plumbing, recursion
+  guards), and still needs result plumbing back. Rejected.
+- **Self-relaunch the entry assembly** (`Environment.ProcessPath` + a sentinel arg). Works for the
+  programmatic console path but not for the adapter (the "entry assembly" is the test host), and is
+  fragile to how the process was started. Rejected as the general mechanism; the dedicated host
+  serves all entry points uniformly.
+- **Named pipes / shared memory IPC instead of a tracking blob.** More moving parts for no benefit at
+  this granularity (we exchange one payload per class/case). A temp-file `Tracking.V1` blob is simple,
+  debuggable, and reuses existing serialization. Revisit only if streaming live per-iteration progress
+  to the IDE becomes a requirement.
+- **In-process hardening only** (`GC.Collect` between samples, priority, affinity). A cheap partial
+  win that does **not** remove the host/other-tests/GC-heap/JIT noise, so it cannot deliver "robust."
+  May ship as an independent small add-on but is not a substitute.
+
+---
+
+## 7. Out of scope
+
+- Distributed / multi-node execution (that's Trawl's domain).
+- Changing default behavior (isolation is strictly opt-in).
+- Modifying the `Tracking.V1` contract.
+- A standalone `dotnet sailfish` CLI tool (tracked separately; not required here).


### PR DESCRIPTION
## Description

Establishes the **design of record** for an opt-in "deep isolation mode": running a benchmark (or a whole run) in a **dedicated child process** with a controlled launch environment (GC / JIT / priority / affinity), so benchmarks that really need robust results are no longer contaminated by the shared test host.

This PR is **docs only** — no code, no behavior change. It lands a project directory under `docs/projects/process-isolation/` (sibling to the existing `docs/diagnosis/`) containing the context, the design, the step-by-step plan, and a living handoff doc that gets updated as the work proceeds.

**Why this matters:** Sailfish runs 100% in-process today. When run as a test, the dominant noise source is the test host itself (other tests, vstest/IDE infra, its threads/GC/JIT). The shipped `[Sailfish(Lifetime = PerCase)]` only gives *object* isolation — it can't touch process-level noise, and GC flavor / JIT tiering are fixed at process launch. Genuinely robust results require getting out of the shared host into a dedicated process. This is the BenchmarkDotNet model, added as an opt-in.

## Results

New directory `docs/projects/process-isolation/`:

| Doc | Purpose |
|---|---|
| `README.md` | Index, status dashboard, doc map, open decisions |
| `SPEC.md` | Context + design: the dispatcher seam, the IPC payload, config surface, semantics that change, risks, alternatives |
| `PLAN.md` | Phased stacked-PR roadmap **P0–P5**, each step with file targets + acceptance criteria |
| `HANDOFF.md` | **Living** state: next action, decision log, gotchas — updated every work session |

Three findings from reading `main` that make this tractable and de-risk it:

1. **No codegen/build needed** — the engine is reflection/DI-driven, so the child host just loads the already-built test assembly and runs the existing engine. (BDN generates+builds precisely because it lacks such an engine.)
2. **The seam already exists** — `ClassExecutionDispatcher` is the single shared fork point for `Lifetime`; isolation forks at the same place, and the *same dispatcher* runs on both sides of the boundary.
3. **The IPC payload already exists** — `Tracking.V1` (`PerformanceRunResultTrackingFormat.RawExecutionResults`, a `double[]` of raw samples) already round-trips to disk for SailDiff. The child emits a tracking blob; the parent ingests it exactly as it ingests a completed run. No new data contract, no analysis-fidelity loss.

### Phase roadmap
- **P0** Spec & scaffolding _(this PR)_
- **P1** Config surface + effective-isolation resolver _(inert; no behavior change)_
- **P2** The isolated host (`Sailfish.IsolatedHost`, in-process-equivalent)
- **P3** Parent-side spawn + result round-trip _(first observable behavior)_
- **P4** Launch-environment knobs (GC / JIT / priority / affinity) _(the robustness payoff)_
- **P5** Packaging, analyzer, docs, hardening

`main` stays shippable throughout — isolation is strictly opt-in and inert until P3.

### Decisions I need your call on (logged in `HANDOFF.md`)
1. **Default granularity** — per-class (recommended) vs per-case.
2. **Host shipping** — `dotnet exec` a packaged framework-dependent dll (recommended) vs per-RID native exe.
3. **`Robust` preset** — new `SailfishPreset` value vs an orthogonal switch.
4. **Analyzer ID** — next free `SFxxxx` (SF1024 is taken).

Plus: should in-process hardening (GC.Collect between samples / priority / affinity, no child process) ship as a small separate add-on, or be dropped? It's a partial win, not a substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)