### PR TITLE
fix(serialization): reflection-free tracking + manifest persistence (#291, D1)

### DIFF
--- a/source/Sailfish/Contracts.Public/Serialization/JsonConverters/ExecutionSummaryTrackingFormatConverter.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/JsonConverters/ExecutionSummaryTrackingFormatConverter.cs
@@ -19,12 +19,15 @@ public class ExecutionSummaryTrackingFormatConverter : JsonConverter<ClassExecut
 
         var type = Type.GetType(typeName);
 
+        // Thread the caller's options through so nested deserialization uses the same (source-gen)
+        // resolver. Without this, these calls fall back to the reflection-based default resolver, which
+        // throws in AOT / trimmed / file-based hosts where reflection serialization is disabled.
         var settings = jsonElementClassExecutionSummary
             .GetProperty(nameof(TrackingFileSerializationHelper.ExecutionSettings))
-            .Deserialize<ExecutionSettingsTrackingFormat>() ?? throw new SailfishException("Failed to deserialize 'Settings'");
+            .Deserialize<ExecutionSettingsTrackingFormat>(options) ?? throw new SailfishException("Failed to deserialize 'Settings'");
         var compiledTestCaseResults = jsonElementClassExecutionSummary
             .GetProperty(nameof(TrackingFileSerializationHelper.CompiledTestCaseResults))
-            .Deserialize<IEnumerable<CompiledTestCaseResultTrackingFormat>>() ?? throw new SailfishException("Failed to deserialize 'CompiledTestCaseResults'");
+            .Deserialize<IEnumerable<CompiledTestCaseResultTrackingFormat>>(options) ?? throw new SailfishException("Failed to deserialize 'CompiledTestCaseResults'");
 
         return new ClassExecutionSummaryTrackingFormat(type!, settings, compiledTestCaseResults);
     }

--- a/source/Sailfish/Contracts.Public/Serialization/JsonConverters/TestCaseIdConverter.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/JsonConverters/TestCaseIdConverter.cs
@@ -13,9 +13,11 @@ public class TestCaseIdConverter : JsonConverter<TestCaseId?>
         using var doc = JsonDocument.ParseValue(ref reader);
         var testCaseId = doc.RootElement;
 
-        var testCaseName = testCaseId.GetProperty("TestCaseName").Deserialize<TestCaseName>()
+        // Pass options through so nested deserialization resolves via the same (source-gen) resolver
+        // rather than the reflection-based default, which is disabled in AOT / trimmed / file-based hosts.
+        var testCaseName = testCaseId.GetProperty("TestCaseName").Deserialize<TestCaseName>(options)
                            ?? throw new SailfishException("Failed to deserialize 'TestCaseName'");
-        var testCaseVariables = testCaseId.GetProperty("TestCaseVariables").Deserialize<TestCaseVariables>() ??
+        var testCaseVariables = testCaseId.GetProperty("TestCaseVariables").Deserialize<TestCaseVariables>(options) ??
                                 throw new SailfishException("Failed to deserialize 'TestCaseVariables'");
         return new TestCaseId(testCaseName, testCaseVariables);
     }

--- a/source/Sailfish/Contracts.Public/Serialization/SailfishJsonContext.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/SailfishJsonContext.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Serialization.JsonConverters;
+using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+using Sailfish.Results;
+
+namespace Sailfish.Contracts.Public.Serialization;
+
+/// <summary>
+///     Source-generated <see cref="System.Text.Json.Serialization.JsonSerializerContext" /> covering every
+///     contract Sailfish persists at the end of a run: the V1 tracking-file graph
+///     (<see cref="ClassExecutionSummaryTrackingFormat" /> and everything reachable from it) and the
+///     reproducibility manifest.
+///     <para>
+///         Why this exists: <c>System.Text.Json</c> refuses reflection-based (de)serialization in any host
+///         where the feature switch <c>JsonSerializerIsReflectionEnabledByDefault</c> is off — Native AOT,
+///         <c>PublishTrimmed</c>, and .NET 10 file-based apps (<c>dotnet run app.cs</c>, which default to
+///         <c>PublishAot=true</c>). In those hosts the benchmarks measure fine but the run used to crash at
+///         the end (exit 134) the moment the tracking file was read back. Providing source-generated metadata
+///         lets <see cref="SailfishSerializer" /> resolve these contracts without any ambient reflection
+///         resolver, so the post-run pipeline works in every host.
+///     </para>
+///     <para>
+///         The default generation mode (<c>Metadata</c>) is used deliberately: the tracking graph relies on
+///         runtime <see cref="JsonConverter" />s (added on the options) and on an
+///         <see cref="object" />-typed property (<see cref="TestCaseVariable.Value" />), both of which require
+///         the metadata-based contract rather than the fast-path serializer.
+///     </para>
+/// </summary>
+// V1 tracking-file graph (top-level persisted shape is a list of class summaries).
+[JsonSerializable(typeof(List<ClassExecutionSummaryTrackingFormat>))]
+[JsonSerializable(typeof(ClassExecutionSummaryTrackingFormat))]
+// ExecutionSummaryTrackingFormatConverter serializes the class summary through this bridge type.
+[JsonSerializable(typeof(ExecutionSummaryTrackingFormatConverter.TrackingFileSerializationHelper))]
+[JsonSerializable(typeof(ExecutionSettingsTrackingFormat))]
+[JsonSerializable(typeof(IEnumerable<CompiledTestCaseResultTrackingFormat>))]
+[JsonSerializable(typeof(List<CompiledTestCaseResultTrackingFormat>))]
+[JsonSerializable(typeof(CompiledTestCaseResultTrackingFormat))]
+[JsonSerializable(typeof(PerformanceRunResultTrackingFormat))]
+// TestCaseId is written via TestCaseIdConverter, which round-trips these nested contracts.
+[JsonSerializable(typeof(TestCaseId))]
+[JsonSerializable(typeof(TestCaseName))]
+[JsonSerializable(typeof(TestCaseVariables))]
+[JsonSerializable(typeof(IEnumerable<TestCaseVariable>))]
+[JsonSerializable(typeof(List<TestCaseVariable>))]
+[JsonSerializable(typeof(TestCaseVariable))]
+// Reproducibility manifest (nested snapshot types are pulled in transitively).
+[JsonSerializable(typeof(ReproducibilityManifest))]
+// Leaf / helper shapes reached through the graph or written directly by the custom converters.
+[JsonSerializable(typeof(double[]))]
+[JsonSerializable(typeof(IReadOnlyList<string>))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(decimal))]
+internal sealed partial class SailfishJsonContext : JsonSerializerContext
+{
+}

--- a/source/Sailfish/Contracts.Public/Serialization/SailfishSerializer.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/SailfishSerializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Contracts.Public.Serialization.JsonConverters;
 
@@ -16,6 +17,25 @@ public static class SailfishSerializer
         new ExecutionSummaryTrackingFormatConverter(),
         new TypePropertyConverter()
     };
+
+    /// <summary>
+    ///     The metadata resolver Sailfish uses for every persisted contract.
+    ///     <para>
+    ///         In hosts where reflection-based serialization is available (the common case: local dev, CI,
+    ///         Visual Studio, VS Test Explorer) the source-generated <see cref="SailfishJsonContext" /> is
+    ///         combined with the reflection resolver so that <em>any</em> type still serializes exactly as it
+    ///         did before — zero behaviour change.
+    ///     </para>
+    ///     <para>
+    ///         In hosts where reflection serialization is disabled (Native AOT, <c>PublishTrimmed</c>, and
+    ///         .NET 10 file-based <c>dotnet run app.cs</c> launchers) only the source-gen context is used. It
+    ///         covers the full tracking-file + reproducibility-manifest persistence graph, so the post-run
+    ///         pipeline no longer crashes (exit 134) the moment a tracking file is written or read back.
+    ///     </para>
+    /// </summary>
+    internal static readonly IJsonTypeInfoResolver TypeInfoResolver = JsonSerializer.IsReflectionEnabledByDefault
+        ? JsonTypeInfoResolver.Combine(SailfishJsonContext.Default, new DefaultJsonTypeInfoResolver())
+        : SailfishJsonContext.Default;
 
     public static string Serialize<T>(T data, IEnumerable<JsonConverter>? converters = null)
     {
@@ -39,7 +59,8 @@ public static class SailfishSerializer
         allConverters.AddRange(GetDefaultConverters());
         var options = new JsonSerializerOptions
         {
-            WriteIndented = true
+            WriteIndented = true,
+            TypeInfoResolver = TypeInfoResolver
         };
         foreach (var converter in allConverters) options.Converters.Add(converter);
 

--- a/source/Sailfish/Results/ReproducibilityManifest.cs
+++ b/source/Sailfish/Results/ReproducibilityManifest.cs
@@ -171,7 +171,15 @@ namespace Sailfish.Results
             if (!Directory.Exists(outputDirectory)) Directory.CreateDirectory(outputDirectory);
             fileName ??= $"Manifest_{manifest.TimestampUtc.ToString(Presentation.DefaultFileSettings.SortableFormat)}.json";
             var path = Path.Combine(outputDirectory, fileName);
-            var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
+            // Use Sailfish's shared type-info resolver so the manifest also serializes in hosts where
+            // reflection-based serialization is disabled (Native AOT / trimmed / file-based). The manifest
+            // contract is registered in SailfishJsonContext.
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                TypeInfoResolver = Contracts.Public.Serialization.SailfishSerializer.TypeInfoResolver
+            };
+            var json = JsonSerializer.Serialize(manifest, options);
             File.WriteAllText(path, json);
         }
 

--- a/source/Tests.Library/Serialization/ReflectionFreeSerializationTests.cs
+++ b/source/Tests.Library/Serialization/ReflectionFreeSerializationTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Serialization;
+using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+using Sailfish.Results;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Serialization;
+
+/// <summary>
+///     Regression tests for #291: the tracking-file and reproducibility-manifest contracts must (de)serialize
+///     without any reflection-based resolver, so a Sailfish suite run from a Native-AOT / trimmed / .NET 10
+///     file-based host (where <c>JsonSerializer.IsReflectionEnabledByDefault</c> is false) no longer crashes
+///     at the end of the run.
+///     <para>
+///         Rather than flipping a process-global feature switch, these tests pin the options'
+///         <c>TypeInfoResolver</c> to the source-gen <see cref="SailfishJsonContext" /> alone — the exact
+///         configuration <see cref="SailfishSerializer" /> uses in a reflection-disabled host. If any type in
+///         the persisted graph is missing from the context, the round-trip throws and the test fails.
+///     </para>
+/// </summary>
+public class ReflectionFreeSerializationTests
+{
+    private static List<ClassExecutionSummaryTrackingFormat> BuildTrackingSample()
+    {
+        var performance = new PerformanceRunResultTrackingFormat(
+            displayName: "TrackingSample.Method(N: 100)",
+            mean: 12.5,
+            median: 12.0,
+            stdDev: 1.25,
+            variance: 1.5625,
+            rawExecutionResults: new[] { 11.0, 12.0, 13.0 },
+            sampleSize: 3,
+            numWarmupIterations: 2,
+            dataWithOutliersRemoved: new[] { 11.0, 12.0, 13.0 },
+            upperOutliers: Array.Empty<double>(),
+            lowerOutliers: Array.Empty<double>(),
+            totalNumOutliers: 0);
+
+        // Display name carries a variable section so the TestCaseId -> TestCaseName -> TestCaseVariables ->
+        // TestCaseVariable(object Value) chain is exercised end to end.
+        var testCaseId = new TestCaseId("TrackingSample.Method(N: 100)");
+
+        var compiled = new CompiledTestCaseResultTrackingFormat(
+            groupingId: "TrackingSample",
+            performanceRunResult: performance,
+            exception: null,
+            testCaseId: testCaseId);
+
+        var settings = new ExecutionSettingsTrackingFormat(
+            asCsv: true, asConsole: true, asMarkdown: false, numWarmupIterations: 2, sampleSize: 3, disableOverheadEstimation: false);
+
+        var summary = new ClassExecutionSummaryTrackingFormat(
+            typeof(ReflectionFreeSerializationTests),
+            settings,
+            new[] { compiled });
+
+        return new List<ClassExecutionSummaryTrackingFormat> { summary };
+    }
+
+    private static void AssertMatchesSample(IReadOnlyList<ClassExecutionSummaryTrackingFormat>? roundTripped)
+    {
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.Count.ShouldBe(1);
+
+        var summary = roundTripped[0];
+        summary.TestClass.ShouldBe(typeof(ReflectionFreeSerializationTests));
+        // SampleSize has a public setter so it round-trips. (The other ExecutionSettings flags use private
+        // setters and are not repopulated on read — a pre-existing behaviour, identical under both the
+        // reflection and source-gen resolvers, so it is out of scope for this reflection-freeness change.)
+        summary.ExecutionSettings.SampleSize.ShouldBe(3);
+
+        var cases = summary.CompiledTestCaseResults.ToList();
+        cases.Count.ShouldBe(1);
+
+        var only = cases[0];
+        only.GroupingId.ShouldBe("TrackingSample");
+        only.PerformanceRunResult.ShouldNotBeNull();
+        only.PerformanceRunResult!.Mean.ShouldBe(12.5);
+        only.PerformanceRunResult.RawExecutionResults.ShouldBe(new[] { 11.0, 12.0, 13.0 });
+
+        // The TestCaseId graph (incl. the object-typed variable value) must survive the round-trip — this is
+        // what ScaleFish groups observations by, so a faithful round-trip matters.
+        only.TestCaseId.ShouldNotBeNull();
+        only.TestCaseId!.TestCaseName.Name.ShouldBe("TrackingSample.Method");
+        only.TestCaseId.TestCaseVariables.Variables.Single().Name.ShouldBe("N");
+    }
+
+    [Fact]
+    public void TrackingGraph_RoundTrips_ThroughSailfishSerializer()
+    {
+        // Functional baseline: the normal SailfishSerializer path (source-gen + reflection fallback on hosts
+        // that allow it) round-trips the full graph.
+        var sample = BuildTrackingSample();
+        var json = SailfishSerializer.Serialize(sample);
+        var roundTripped = SailfishSerializer.Deserialize<List<ClassExecutionSummaryTrackingFormat>>(json);
+        AssertMatchesSample(roundTripped);
+    }
+
+    [Fact]
+    public void TrackingGraph_RoundTrips_WithSourceGenResolverOnly()
+    {
+        // AOT proof: pin the resolver to the source-gen context with NO reflection fallback. This is the
+        // configuration used in Native-AOT / trimmed / file-based hosts. If any contract type is missing
+        // from SailfishJsonContext, serialize or deserialize throws here.
+        var options = SourceGenOnlyTrackingOptions();
+
+        var sample = BuildTrackingSample();
+        var json = JsonSerializer.Serialize(sample, options);
+        var roundTripped = JsonSerializer.Deserialize<List<ClassExecutionSummaryTrackingFormat>>(json, options);
+        AssertMatchesSample(roundTripped);
+    }
+
+    [Fact]
+    public void ReproducibilityManifest_RoundTrips_WithSourceGenResolverOnly()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            TypeInfoResolver = SailfishJsonContext.Default
+        };
+
+        var manifest = new ReproducibilityManifest
+        {
+            SailfishVersion = "1.2.3",
+            DotNetRuntime = ".NET 10.0",
+            Os = "TestOS",
+            SessionId = "session-1",
+            TimestampUtc = new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc),
+            Tags = new Dictionary<string, string> { ["env"] = "ci", ["branch"] = "main" }
+        };
+        manifest.Methods.Add(new ReproducibilityManifest.MethodSnapshot
+        {
+            TestCaseDisplayName = "Sample.Method",
+            SampleSize = 3,
+            NumWarmupIterations = 2,
+            Mean = 12.5,
+            StdDev = 1.25,
+            Ci95MarginOfError = 0.4,
+            Ci99MarginOfError = 0.6
+        });
+
+        var json = JsonSerializer.Serialize(manifest, options);
+        var roundTripped = JsonSerializer.Deserialize<ReproducibilityManifest>(json, options);
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.SailfishVersion.ShouldBe("1.2.3");
+        roundTripped.SessionId.ShouldBe("session-1");
+        roundTripped.Tags["env"].ShouldBe("ci");
+        roundTripped.Methods.Single().TestCaseDisplayName.ShouldBe("Sample.Method");
+        roundTripped.Methods.Single().Mean.ShouldBe(12.5);
+    }
+
+    private static JsonSerializerOptions SourceGenOnlyTrackingOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            TypeInfoResolver = SailfishJsonContext.Default
+        };
+        // Mirror SailfishSerializer's converter set so the source-gen-only round-trip matches the real path.
+        foreach (var converter in SailfishSerializer.GetDefaultConverters()) options.Converters.Add(converter);
+        return options;
+    }
+}


### PR DESCRIPTION
Fixes #291 (child **D1** of epic #298).

## Problem
`System.Text.Json` refuses reflection-based (de)serialization in any host where the feature switch `JsonSerializerIsReflectionEnabledByDefault` is **off** — Native AOT, `PublishTrimmed`, and **.NET 10 file-based apps** (`dotnet run app.cs`, which default to `PublishAot=true`). The benchmarks measure fine, but the run **crashes at the end (exit 134)** the moment a tracking file is written or read back, which takes ScaleFish, SailDiff, and the reproducibility manifest down with it.

## Fix
- New source-generated `SailfishJsonContext` (`Contracts.Public/Serialization/SailfishJsonContext.cs`) covering the **full V1 tracking-file graph** (`List<ClassExecutionSummaryTrackingFormat>` → settings, compiled results, `PerformanceRunResultTrackingFormat`, the `TestCaseId`/`TestCaseName`/`TestCaseVariables` chain, the converter bridge type) and the **reproducibility manifest**.
- `SailfishSerializer` and `ReproducibilityManifest.WriteJson` now resolve through a **host-aware resolver**:
  - **reflection enabled** (dev, CI, VS, VS Test Explorer) → source-gen **combined with** the reflection resolver, so *any* type serializes exactly as before — **zero behaviour change**.
  - **reflection disabled** (AOT / trimmed / file-based) → **source-gen only**, which covers the persistence graph, so the pipeline no longer crashes.
- Threaded the caller's `options` through the nested `Deserialize` calls in `ExecutionSummaryTrackingFormatConverter` and `TestCaseIdConverter` (they previously fell back to the reflection-based default resolver).

## Tests
`Tests.Library/Serialization/ReflectionFreeSerializationTests.cs` pins the resolver to the **source-gen context alone** — the exact configuration of a reflection-disabled host — and round-trips both the tracking graph and the manifest. A missing contract registration fails the test rather than only failing on a real AOT host (a deterministic stand-in for the suggested AOT CI job).

- ✅ Sailfish + full solution build clean (no new STJ/source-gen warnings)
- ✅ 860 Tracking/SailDiff/Serialization/ScaleFish/Reproducibility tests pass; 3 new tests pass

## Scope notes / honest limitations
- The **polymorphic ScaleFish model-JSON** (registry-backed `ComplexityFunction` converters) is intentionally left on the reflection path. Making it source-gen/AOT-safe means rearchitecting the extensible `ComplexityFunctionRegistry` for `[JsonDerivedType]` — a separate, larger effort. Under a reflection-disabled host the **markdown** ScaleFish report (the primary artifact) is written, and the model-JSON degrades gracefully via the post-measurement error boundary (**#292**, D2) rather than crashing. Tracked as a follow-up.
- While writing the test I found two **pre-existing, unrelated** latent bugs in the serialization layer (identical under both resolvers, so not regressions): `JsonNanConverter.Read`/`InfinityConverter.Read` throw on a string token instead of handling `"NaN"`/`"Infinity"`, and `ExecutionSettingsTrackingFormat`'s `private set` fields are dropped on read. Left out of this PR to keep it focused; will flag separately.

---
Part of the #298 pipeline-hardening epic. This is **D1**, the unblocking root-cause fix; D2 (#292) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)