### PR TITLE
fix(execution): error boundary so post-measurement failures never crash the run (#292, D2)

### DIFF
--- a/source/Sailfish/Analysis/TrackingFileParser.cs
+++ b/source/Sailfish/Analysis/TrackingFileParser.cs
@@ -71,12 +71,22 @@ internal class TrackingFileParser : ITrackingFileParser
             data.AddRange(trackingFormatData);
             return true;
         }
-        catch (SerializationException ex)
+        catch (OperationCanceledException)
         {
+            // Cancellation is a control-flow signal — let it propagate to the caller.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Genuinely non-throwing: any failure (corrupt/non-V1 data, an I/O error, or a serializer that
+            // throws something other than SerializationException) is reported as a parse failure rather than
+            // propagated. The post-measurement error boundary in SailfishExecutor relies on this so a bad
+            // tracking file can never crash the run. (#294 refines this to per-file resilience.)
             _logger.Log(
                 LogLevel.Warning,
-                $"Failed to deserialize data into {nameof(PerformanceRunResultTrackingFormat)}. Please remove any non-V1 (or corrupt) tracking data from your tracking directory.\n\n",
-                ex);
+                ex,
+                "Failed to deserialize data into {TrackingFormat}. Please remove any non-V1 (or corrupt) tracking data from your tracking directory.",
+                nameof(PerformanceRunResultTrackingFormat));
             return false;
         }
     }

--- a/source/Sailfish/Execution/SailfishExecutor.cs
+++ b/source/Sailfish/Execution/SailfishExecutor.cs
@@ -68,12 +68,28 @@ internal class SailfishExecutor
             var testClassResultGroups = await _sailFishTestExecutor.Execute(testsList, cancellationToken).ConfigureAwait(false);
             var classExecutionSummaries = _classExecutionSummaryCompiler.CompileToSummaries(testClassResultGroups).ToList();
 
-            await _executionSummaryWriter.Write(classExecutionSummaries, cancellationToken);
-            await _mediator.Publish(new TestRunCompletedNotification(classExecutionSummaries.ToTrackingFormat()), cancellationToken).ConfigureAwait(false);
+            // Benchmarks are measured at this point. From here on every artifact-writing / analysis step runs
+            // inside an error boundary: a failure in post-measurement work (serialization, reporting, SailDiff,
+            // ScaleFish) must never lose the collected timings or crash the host. Previously an unhandled
+            // exception here aborted the process with exit 134. Each stage degrades independently and the
+            // failure is surfaced on the result (a graceful non-zero outcome) rather than thrown.
+            var analysisExceptions = new List<Exception>();
 
-            if (_runSettings.RunSailDiff) await _sailDiff.Analyze(cancellationToken).ConfigureAwait(false);
+            await RunPostMeasurementStage(
+                "write execution summaries",
+                () => _executionSummaryWriter.Write(classExecutionSummaries, cancellationToken),
+                analysisExceptions).ConfigureAwait(false);
 
-            if (_runSettings.RunScaleFish) await _scaleFish.Analyze(cancellationToken).ConfigureAwait(false);
+            await RunPostMeasurementStage(
+                "publish test-run-completed notification",
+                () => _mediator.Publish(new TestRunCompletedNotification(classExecutionSummaries.ToTrackingFormat()), cancellationToken),
+                analysisExceptions).ConfigureAwait(false);
+
+            if (_runSettings.RunSailDiff)
+                await RunPostMeasurementStage("SailDiff analysis", () => _sailDiff.Analyze(cancellationToken), analysisExceptions).ConfigureAwait(false);
+
+            if (_runSettings.RunScaleFish)
+                await RunPostMeasurementStage("ScaleFish analysis", () => _scaleFish.Analyze(cancellationToken), analysisExceptions).ConfigureAwait(false);
 
             var exceptions = classExecutionSummaries
                 .SelectMany(classExecutionSummary =>
@@ -83,6 +99,11 @@ internal class SailfishExecutor
                         .Select(c => c.Exception))
                 .Cast<Exception>()
                 .ToList();
+
+            // Surface post-measurement failures alongside measurement exceptions so a run whose analysis
+            // failed reports a graceful, non-crashing failure (IsValid == false) while still returning the
+            // collected timings and whatever artifacts were produced.
+            exceptions.AddRange(analysisExceptions);
 
             return SailfishRunResult.CreateResult(classExecutionSummaries, exceptions);
         }
@@ -102,6 +123,34 @@ internal class SailfishExecutor
         }
 
         return SailfishRunResult.CreateResult(Array.Empty<IClassExecutionSummary>(), testDiscoveryExceptions);
+    }
+
+    /// <summary>
+    ///     Runs a single post-measurement stage (artifact write, notification publish, or an analyzer) inside
+    ///     an error boundary. A throw is logged as a structured error and recorded in
+    ///     <paramref name="analysisExceptions" /> so the stage fails soft — the collected timings survive,
+    ///     the remaining stages still run, and the process is never aborted. Cancellation is a control-flow
+    ///     signal rather than an analysis failure, so it is allowed to propagate.
+    /// </summary>
+    private async Task RunPostMeasurementStage(string stageName, Func<Task> stage, List<Exception> analysisExceptions)
+    {
+        try
+        {
+            await stage().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            analysisExceptions.Add(ex);
+            _logger.Log(
+                LogLevel.Error,
+                ex,
+                "Post-measurement stage '{Stage}' failed after benchmarks were measured. The collected timings are preserved and the remaining stages continue; this step's artifacts/analysis were skipped.",
+                stageName);
+        }
     }
 
     private static int? TryParseSeed(Extensions.Types.OrderedDictionary args)

--- a/source/Tests.Library/Analysis/TrackingFileParserTests.cs
+++ b/source/Tests.Library/Analysis/TrackingFileParserTests.cs
@@ -81,4 +81,25 @@ public class TrackingFileParserTests
         data.ExecutionSettings.AsMarkdown.ShouldBeFalse();
         data.GetSuccessfulTestCases().Count().ShouldBe(1);
     }
+
+    [Fact]
+    public async Task NonSerializationExceptionFromSerializer_IsReportedAsFailure_NotThrown()
+    {
+        // #292: the parser must be genuinely non-throwing. Previously it only caught SerializationException,
+        // so a serializer that threw anything else (e.g. InvalidOperationException — exactly what
+        // System.Text.Json throws when reflection serialization is disabled) propagated and crashed the run.
+        var throwingSerialization = Substitute.For<ITrackingFileSerialization>();
+        throwingSerialization
+            .Deserialize(Arg.Any<string>())
+            .Returns(_ => throw new System.InvalidOperationException("reflection serialization disabled"));
+        var parser = new TrackingFileParser(throwingSerialization, Substitute.For<ILogger>());
+
+        var file = TempFileHelper.WriteStringToTempFile(Some.RandomString());
+        var datalist = new TrackingFileDataList();
+
+        var result = await parser.TryParse(file, datalist, CancellationToken.None);
+
+        result.ShouldBeFalse();
+        datalist.ShouldBeEmpty();
+    }
 }

--- a/source/Tests.Library/Execution/SailfishExecutorTests.cs
+++ b/source/Tests.Library/Execution/SailfishExecutorTests.cs
@@ -267,6 +267,78 @@ public class SailfishExecutorTests
             Arg.Is<object[]>(os => os.Length == 1 && Equals(os[0], 123)));
     }
 
+    [Fact]
+    public async Task Run_WhenPostMeasurementAnalysisThrows_DoesNotCrash_AndReturnsTimingsWithFailure()
+    {
+        // Arrange: measurement succeeds, but ScaleFish analysis blows up (e.g. a serialization failure in a
+        // reflection-disabled host). The run must NOT propagate the exception (previously exit 134) — it must
+        // preserve the collected timings, report a graceful failure, and still call the other stages.
+        var testType = typeof(object);
+        var testInitResult = TestInitializationResult.CreateSuccess(new[] { testType });
+        var classExecutionSummary =
+            new ClassExecutionSummary(testType, new ExecutionSettings(), new List<ICompiledTestCaseResult>());
+
+        _testFilter.FilterAndValidate(Arg.Any<IEnumerable<Type>>(), Arg.Any<IEnumerable<string>>())
+            .Returns(testInitResult);
+        _sailFishTestExecutor.Execute(Arg.Any<IEnumerable<Type>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<TestClassResultGroup>());
+        _classExecutionSummaryCompiler.CompileToSummaries(Arg.Any<IEnumerable<TestClassResultGroup>>())
+            .Returns(new List<IClassExecutionSummary> { classExecutionSummary }.AsEnumerable());
+        _runSettings.TestNames.Returns(new List<string>());
+        _runSettings.TestLocationAnchors.Returns(new List<Type>());
+        _runSettings.Seed.Returns((int?)null);
+        _runSettings.Args.Returns(new Sailfish.Extensions.Types.OrderedDictionary());
+        _runSettings.RunSailDiff.Returns(true);
+        _runSettings.RunScaleFish.Returns(true);
+
+        var boom = new InvalidOperationException("analysis blew up");
+        _scaleFish.Analyze(Arg.Any<CancellationToken>()).Returns<Task>(_ => throw boom);
+
+        var executor = new SailfishExecutor(_mediator, _sailFishTestExecutor, _testCollector, _testFilter,
+            _classExecutionSummaryCompiler, _executionSummaryWriter, _sailDiff, _scaleFish, _runSettings, _logger);
+
+        // Act — must not throw.
+        var result = await executor.Run(CancellationToken.None);
+
+        // Assert: timings preserved, failure surfaced, sibling stages still ran.
+        result.ShouldNotBeNull();
+        result.ExecutionSummaries.ShouldNotBeEmpty();
+        result.IsValid.ShouldBeFalse();
+        result.Exceptions.ShouldContain(boom);
+        await _sailDiff.Received(1).Analyze(Arg.Any<CancellationToken>()); // SailDiff still ran despite ScaleFish failing
+        _logger.Received().Log(LogLevel.Error, boom, Arg.Any<string>(), Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public async Task Run_WhenCancelledDuringAnalysis_PropagatesCancellation()
+    {
+        // Cancellation is a control-flow signal, not an analysis failure — it must propagate, not be swallowed.
+        var testType = typeof(object);
+        var testInitResult = TestInitializationResult.CreateSuccess(new[] { testType });
+        var classExecutionSummary =
+            new ClassExecutionSummary(testType, new ExecutionSettings(), new List<ICompiledTestCaseResult>());
+
+        _testFilter.FilterAndValidate(Arg.Any<IEnumerable<Type>>(), Arg.Any<IEnumerable<string>>())
+            .Returns(testInitResult);
+        _sailFishTestExecutor.Execute(Arg.Any<IEnumerable<Type>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<TestClassResultGroup>());
+        _classExecutionSummaryCompiler.CompileToSummaries(Arg.Any<IEnumerable<TestClassResultGroup>>())
+            .Returns(new List<IClassExecutionSummary> { classExecutionSummary }.AsEnumerable());
+        _runSettings.TestNames.Returns(new List<string>());
+        _runSettings.TestLocationAnchors.Returns(new List<Type>());
+        _runSettings.Seed.Returns((int?)null);
+        _runSettings.Args.Returns(new Sailfish.Extensions.Types.OrderedDictionary());
+        _runSettings.RunSailDiff.Returns(false);
+        _runSettings.RunScaleFish.Returns(true);
+
+        _scaleFish.Analyze(Arg.Any<CancellationToken>()).Returns<Task>(_ => throw new OperationCanceledException());
+
+        var executor = new SailfishExecutor(_mediator, _sailFishTestExecutor, _testCollector, _testFilter,
+            _classExecutionSummaryCompiler, _executionSummaryWriter, _sailDiff, _scaleFish, _runSettings, _logger);
+
+        await Should.ThrowAsync<OperationCanceledException>(() => executor.Run(CancellationToken.None));
+    }
+
     [Theory]
     [InlineData("seed")]
     [InlineData("SEED")]


### PR DESCRIPTION
Fixes #292 (child **D2** of epic #298).

> **Stacked on #307 (#291 / D1).** Review/merge that first — the diff for this PR is against the D1 branch, so it shows only the D2 changes.

## Problem
After all benchmarks measured successfully, a failure in the **analysis phase** propagated as an **unhandled exception** and terminated the process (**exit 134 / SIGABRT**). Handling was inconsistent: `TestClassCompletedNotificationHandler` caught its own serialize failures, but the ScaleFish tracking-deserialize path was uncaught and fatal. A reporting/analysis problem should never lose collected timings or crash the host.

## Fix
- **Error boundary in `SailfishExecutor.Run`.** Every post-measurement stage — execution-summary write, the `TestRunCompletedNotification` publish, SailDiff, ScaleFish — now runs through `RunPostMeasurementStage(...)`, which:
  - logs a structured error and records the failure in an `analysisExceptions` list instead of throwing;
  - lets the **remaining stages still run** (independent degradation);
  - **always returns the collected timings**;
  - surfaces the failure on `SailfishRunResult` (`IsValid == false`) — a graceful, documented non-zero outcome rather than a crash;
  - **re-throws `OperationCanceledException`** (cancellation is control flow, not an analysis failure).
- **`TrackingFileParser` is now genuinely non-throwing.** The catch previously only handled `SerializationException`, so an `IOException` or — crucially — the `InvalidOperationException` STJ throws when reflection serialization is disabled escaped and crashed the run. It now catches any non-cancellation exception and reports a parse failure. (#294 refines this to per-file skip/quarantine.)

## Tests
- `Run_WhenPostMeasurementAnalysisThrows_DoesNotCrash_AndReturnsTimingsWithFailure` — throwing ScaleFish → no throw, timings preserved, `IsValid == false`, exception surfaced, **SailDiff still ran**, structured error logged.
- `Run_WhenCancelledDuringAnalysis_PropagatesCancellation` — cancellation is not swallowed.
- `NonSerializationExceptionFromSerializer_IsReportedAsFailure_NotThrown` — parser returns `false` instead of throwing.
- ✅ 1026 Execution/Tracking/SailDiff/ScaleFish tests pass; full solution builds clean.

---
Part of the #298 epic. D3 (#293) stacks on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)