### PR TITLE
fix(tracking): atomic tracking-file writes — no 0-byte/partial artifacts (#293, D3)

### DIFF
--- a/source/Sailfish/DefaultHandlers/Sailfish/TestClassCompletedNotificationHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/TestClassCompletedNotificationHandler.cs
@@ -1,6 +1,6 @@
+using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -37,10 +37,13 @@ public class TestClassCompletedNotificationHandler : INotificationHandler<TestCl
         var fileName = DefaultFileSettings.AppendTagsToFilename(DefaultFileSettings.DefaultTrackingFileName(_runSettings.TimeStamp), _runSettings.Tags);
         var filePath = Path.Join(trackingDirectory, fileName);
 
-        await using var fileStream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
-        using var streamReader = new StreamReader(fileStream);
-        var fileContents = await streamReader.ReadToEndAsync(); // ct overload not available in .net6
-        streamReader.Close();
+        // Read prior tracking contents WITHOUT creating the file. Opening the destination just to read it
+        // (the previous behaviour) left a 0-byte artifact behind whenever serialization later threw or the
+        // process was killed mid-write — and that empty file then tripped the next run's tracking-data
+        // retrieval.
+        var fileContents = File.Exists(filePath)
+            ? await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false)
+            : string.Empty;
 
         var classExecutionSummaryTrackingFormats = string.IsNullOrEmpty(fileContents)
             ? []
@@ -63,13 +66,40 @@ public class TestClassCompletedNotificationHandler : INotificationHandler<TestCl
             classExecutionSummaryTrackingFormats.Add(success);
         }
 
+        // Serialize BEFORE touching the destination so a serializer failure cannot leave a partial/empty
+        // tracking file behind.
         var serialized = _trackingFileSerialization.Serialize(classExecutionSummaryTrackingFormats);
 
-        await using var streamWriter = new StreamWriter(filePath, Encoding.UTF8, new FileStreamOptions
+        await WriteAtomically(trackingDirectory, filePath, serialized, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Writes <paramref name="contents" /> to <paramref name="finalPath" /> atomically: the full payload
+    ///     is staged to a temp file in the same directory and then renamed over the final name. A crash
+    ///     mid-write leaves only the temp (cleaned up on failure, and never matched by tracking-file
+    ///     discovery because it does not end in the <c>.json.tracking</c> suffix), never a partial
+    ///     <c>*.json.tracking</c> that a later run would try to read.
+    /// </summary>
+    private static async Task WriteAtomically(string directory, string finalPath, string contents, CancellationToken cancellationToken)
+    {
+        var tempPath = Path.Combine(directory, $".{Path.GetFileName(finalPath)}.{Guid.NewGuid():N}.tmp");
+        try
         {
-            Access = FileAccess.ReadWrite,
-            Mode = FileMode.OpenOrCreate
-        });
-        await streamWriter.WriteAsync(serialized).ConfigureAwait(false);
+            await File.WriteAllTextAsync(tempPath, contents, cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, finalPath, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(tempPath)) File.Delete(tempPath);
+            }
+            catch
+            {
+                // Best-effort cleanup; surface the original failure below.
+            }
+
+            throw;
+        }
     }
 }

--- a/source/Tests.Library/DefaultHandlers/Sailfish/TestClassCompletedNotificationHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/TestClassCompletedNotificationHandlerTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+using Sailfish.DefaultHandlers.Sailfish;
+using Sailfish.Extensions.Types;
+using Sailfish.Logging;
+using Sailfish.Presentation;
+using Shouldly;
+using Tests.Common.Builders;
+using Xunit;
+
+namespace Tests.Library.DefaultHandlers.Sailfish;
+
+public class TestClassCompletedNotificationHandlerTests : IDisposable
+{
+    private readonly string _outputDirectory;
+    private readonly string _trackingDirectory;
+    private readonly IRunSettings _runSettings = Substitute.For<IRunSettings>();
+
+    public TestClassCompletedNotificationHandlerTests()
+    {
+        _outputDirectory = Path.Combine(Path.GetTempPath(), "sailfish-test-" + Guid.NewGuid().ToString("N"));
+        _trackingDirectory = Path.Combine(_outputDirectory, DefaultFileSettings.DefaultExecutionSummaryTrackingDirectory);
+        Directory.CreateDirectory(_trackingDirectory);
+
+        _runSettings.StreamTrackingUpdates.Returns(true);
+        _runSettings.CreateTrackingFiles.Returns(true);
+        _runSettings.LocalOutputDirectory.Returns(_outputDirectory);
+        _runSettings.GetRunSettingsTrackingDirectoryPath().Returns(_trackingDirectory);
+        _runSettings.TimeStamp.Returns(DateTime.UtcNow);
+        _runSettings.Tags.Returns(new OrderedDictionary());
+    }
+
+    private static TestClassCompletedNotification Notification()
+    {
+        var summary = ClassExecutionSummaryTrackingFormatBuilder.Create().Build(); // has one successful case
+        return new TestClassCompletedNotification(summary, null!, Enumerable.Empty<dynamic>());
+    }
+
+    [Fact]
+    public async Task WhenSerializationFails_NoTrackingFileOrTempIsLeftBehind()
+    {
+        // #293: a serializer failure (e.g. reflection serialization disabled) must not leave a 0-byte /
+        // partial tracking file — nor a stray temp file — behind.
+        var serialization = Substitute.For<ITrackingFileSerialization>();
+        serialization.Deserialize(Arg.Any<string>()).Returns((System.Collections.Generic.IEnumerable<ClassExecutionSummaryTrackingFormat>?)null);
+        serialization
+            .Serialize(Arg.Any<System.Collections.Generic.IEnumerable<ClassExecutionSummaryTrackingFormat>>())
+            .Returns(_ => throw new InvalidOperationException("serialization disabled"));
+
+        var handler = new TestClassCompletedNotificationHandler(serialization, _runSettings, Substitute.For<ILogger>());
+
+        await Should.ThrowAsync<InvalidOperationException>(() => handler.Handle(Notification(), CancellationToken.None));
+
+        Directory.GetFiles(_trackingDirectory).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenSerializationSucceeds_WritesExactlyOneCompleteTrackingFile()
+    {
+        var serialization = new TrackingFileSerialization(Substitute.For<ILogger>());
+        var handler = new TestClassCompletedNotificationHandler(serialization, _runSettings, Substitute.For<ILogger>());
+
+        await handler.Handle(Notification(), CancellationToken.None);
+
+        var files = Directory.GetFiles(_trackingDirectory);
+        files.Length.ShouldBe(1);
+        files.Single().ShouldEndWith(DefaultFileSettings.TrackingSuffix);
+        new FileInfo(files.Single()).Length.ShouldBeGreaterThan(0);
+        // No leftover temp files.
+        Directory.GetFiles(_trackingDirectory, "*.tmp").ShouldBeEmpty();
+
+        // And it round-trips back into the V1 graph.
+        var roundTripped = serialization.Deserialize(await File.ReadAllTextAsync(files.Single()))?.ToList();
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.Count.ShouldBe(1);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_outputDirectory)) Directory.Delete(_outputDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
+    }
+}


### PR DESCRIPTION
Fixes #293 (child **D3** of epic #298).

> **Stacked on #308 (#292 / D2), which is stacked on #307 (#291 / D1).** Review/merge bottom-up. This PR's diff is against the D2 branch and shows only the D3 changes.

## Problem
When tracking serialization failed (or the process was killed mid-write), Sailfish still left a **0-byte / partial** `*.json.tracking` file behind: the destination was opened (`FileMode.OpenOrCreate`) just to read prior contents, and again to write — both *before* serialization succeeded. That empty file then broke the next run's tracking-data retrieval (#294).

## Fix
`TestClassCompletedNotificationHandler` now:
- **reads prior contents without creating the file** — `File.Exists(path) ? ReadAllTextAsync : ""` instead of `OpenOrCreate`, so there's no create-on-read artifact;
- **serializes before touching the destination**, so a serializer failure leaves nothing behind;
- **writes atomically** (`WriteAtomically`): stage the full payload to a temp file in the same directory, then `File.Move(temp, final, overwrite: true)`. A crash mid-write leaves only the temp (cleaned up on failure), never a partial `*.json.tracking`. The temp name doesn't end in the `.json.tracking` suffix, so tracking-file discovery (`EndsWith(TrackingSuffix)`) never matches it.

## Tests
`TestClassCompletedNotificationHandlerTests`:
- `WhenSerializationFails_NoTrackingFileOrTempIsLeftBehind` — injected serialize failure → the tracking dir is empty (no 0-byte file, no temp).
- `WhenSerializationSucceeds_WritesExactlyOneCompleteTrackingFile` — exactly one complete, round-trippable `*.json.tracking`, no `.tmp` residue.
- ✅ 156 DefaultHandlers/Tracking tests pass; full solution builds clean.

---
Part of the #298 epic. D4 (#294) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)