### PR TITLE
fix(analysis): resilient tracking parsing — skip one bad file, don't abort the batch (#294, D4)

### DIFF
--- a/source/Sailfish/Analysis/TrackingFileParser.cs
+++ b/source/Sailfish/Analysis/TrackingFileParser.cs
@@ -39,55 +39,71 @@ internal class TrackingFileParser : ITrackingFileParser
     }
 
     /// <summary>
-    ///     Returns a list of deserialized IExecutionSummaries, where each element represents a tracking file. Useful for
-    ///     searching prior executions for prior results.
+    ///     Parses each tracking file into the supplied <paramref name="data" /> list, where each element
+    ///     represents one tracking file. Useful for searching prior executions for prior results.
+    ///     <para>
+    ///         Resilient by design: an individual file that cannot be parsed (corrupt, 0-byte/partial, or
+    ///         non-V1) is logged and skipped rather than failing the whole batch, so valid runs alongside it
+    ///         are still returned. Returns <c>false</c> only when every candidate file failed (and even then
+    ///         <paramref name="data" /> is simply left empty — the method never throws except to propagate
+    ///         cancellation).
+    ///     </para>
     /// </summary>
     /// <param name="trackingFiles"></param>
     /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    /// <exception cref="SerializationException"></exception>
+    /// <returns><c>true</c> if at least one file parsed or there were no failures; otherwise <c>false</c>.</returns>
     public async Task<bool> TryParseMany(IEnumerable<string> trackingFiles, TrackingFileDataList data, CancellationToken cancellationToken)
     {
         var trackingFormatData = new TrackingFileDataList();
-        try
+        var anyFailures = false;
+
+        foreach (var trackingFile in trackingFiles)
         {
-            foreach (var trackingFile in trackingFiles)
+            cancellationToken.ThrowIfCancellationRequested();
+
+            List<ClassExecutionSummaryTrackingFormat>? deserializedFile;
+            try
             {
-                var serialized = await File.ReadAllTextAsync(trackingFile, cancellationToken);
-                var deserializedFile = _trackingFileSerialization.Deserialize(serialized)?.ToList();
+                var serialized = await File.ReadAllTextAsync(trackingFile, cancellationToken).ConfigureAwait(false);
+                deserializedFile = _trackingFileSerialization.Deserialize(serialized)?.ToList();
                 if (deserializedFile is null) throw new SerializationException($"Failed to deserialize {trackingFile}");
-                if (!deserializedFile.Any()) continue;
-                try
-                {
-                    trackingFormatData.Add(deserializedFile.ToSummaryFormat().ToList());
-                }
-                catch (ArgumentException)
-                {
-                    // failed to convert all test cases to summary format
-                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is a control-flow signal — let it propagate to the caller.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // One unparseable file (corrupt, 0-byte/partial, non-V1, or an I/O error) must not take down
+                // the whole batch. Log a single warning naming the file, skip it, and keep going so valid
+                // runs alongside it are still retrieved.
+                anyFailures = true;
+                _logger.Log(
+                    LogLevel.Warning,
+                    ex,
+                    "Skipping tracking file '{TrackingFile}' — it could not be parsed (corrupt, empty/partial, or non-V1). Continuing with the remaining tracking files.",
+                    trackingFile);
+                continue;
             }
 
-            data.AddRange(trackingFormatData);
-            return true;
+            if (!deserializedFile.Any()) continue;
+            try
+            {
+                trackingFormatData.Add(deserializedFile.ToSummaryFormat().ToList());
+            }
+            catch (ArgumentException)
+            {
+                // failed to convert all test cases to summary format
+            }
         }
-        catch (OperationCanceledException)
-        {
-            // Cancellation is a control-flow signal — let it propagate to the caller.
-            throw;
-        }
-        catch (Exception ex)
-        {
-            // Genuinely non-throwing: any failure (corrupt/non-V1 data, an I/O error, or a serializer that
-            // throws something other than SerializationException) is reported as a parse failure rather than
-            // propagated. The post-measurement error boundary in SailfishExecutor relies on this so a bad
-            // tracking file can never crash the run. (#294 refines this to per-file resilience.)
-            _logger.Log(
-                LogLevel.Warning,
-                ex,
-                "Failed to deserialize data into {TrackingFormat}. Please remove any non-V1 (or corrupt) tracking data from your tracking directory.",
-                nameof(PerformanceRunResultTrackingFormat));
-            return false;
-        }
+
+        data.AddRange(trackingFormatData);
+
+        // Succeed if we parsed at least one file, or if nothing failed at all (e.g. an empty directory or
+        // only valid-but-empty files). Only "every candidate file failed" reports an overall failure — and
+        // even then we degrade gracefully (data is simply empty); we never throw or abort the process.
+        return trackingFormatData.Count > 0 || !anyFailures;
     }
 }

--- a/source/Tests.Library/Analysis/TrackingFileParserTests.cs
+++ b/source/Tests.Library/Analysis/TrackingFileParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,6 +81,46 @@ public class TrackingFileParserTests
         data.TestClass.Name.ShouldBe(nameof(ClassExecutionSummaryTrackingFormatBuilder.TestClass));
         data.ExecutionSettings.AsMarkdown.ShouldBeFalse();
         data.GetSuccessfulTestCases().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task OneValidPlusOneGenuinelyCorruptFile_ReturnsValid_AndWarnsOnceNamingTheBadFile()
+    {
+        // #294: a single corrupt file must not abort the batch. The valid run is still returned and a single
+        // skip warning names the offending file.
+        var parserLogger = Substitute.For<ILogger>();
+        var parser = new TrackingFileParser(new TrackingFileSerialization(Substitute.For<ILogger>()), parserLogger);
+
+        var corruptFile = TempFileHelper.WriteStringToTempFile(Some.RandomString()); // not valid JSON
+        var goodFile = TempFileHelper.WriteStringToTempFile(SailfishSerializer.Serialize(
+            new List<ClassExecutionSummaryTrackingFormat> { ClassExecutionSummaryTrackingFormatBuilder.Create().Build() }));
+
+        var datalist = new TrackingFileDataList();
+        var result = await parser.TryParseMany(new List<string> { corruptFile, goodFile }, datalist, CancellationToken.None);
+
+        result.ShouldBeTrue();
+        datalist.Count.ShouldBe(1);
+        datalist.Single().Single().TestClass.Name.ShouldBe(nameof(ClassExecutionSummaryTrackingFormatBuilder.TestClass));
+
+        parserLogger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<Exception>(),
+            Arg.Is<string>(s => s.Contains("Skipping tracking file")),
+            Arg.Is<object[]>(args => args.Length == 1 && Equals(args[0], corruptFile)));
+    }
+
+    [Fact]
+    public async Task OnlyCorruptFiles_ReturnsFalse_WithEmptyResult_AndDoesNotThrow()
+    {
+        // #294: when every file is corrupt, retrieval degrades gracefully — empty result, no throw/abort.
+        var corruptA = TempFileHelper.WriteStringToTempFile(Some.RandomString());
+        var corruptB = TempFileHelper.WriteStringToTempFile(Some.RandomString());
+
+        var datalist = new TrackingFileDataList();
+        var result = await _parser.TryParseMany(new List<string> { corruptA, corruptB }, datalist, CancellationToken.None);
+
+        result.ShouldBeFalse();
+        datalist.ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #294 (child **D4** of epic #298).

> **Stacked on #309 (#293 / D3) → #308 (#292) → #307 (#291).** Review/merge bottom-up. This PR's diff is against the D3 branch.

## Problem
`TrackingFileParser.TryParseMany` read every file under a **single** try/catch, so one empty/corrupt/non-V1 file failed the **entire** retrieval — disabling all downstream analysis even when valid runs existed. A 0-byte leftover from a crashed run (#293) was enough to trip it.

## Fix
Move the try/catch **inside the per-file loop**:
- a file that can't be parsed (corrupt, 0-byte/partial, non-V1, or an I/O error) is logged **once** — the warning names the offending file — and **skipped**, and parsing continues with the rest;
- the method returns `false` **only when every candidate file failed**, and even then degrades gracefully (`data` is simply empty) rather than throwing/aborting;
- cancellation still propagates.

Quarantine-on-rename (the issue's optional item) was deliberately left out: renaming a file as a side effect of a *read* is risky for transiently-locked files, and #293 already stops new 0-byte files being produced.

## Tests
- `OneValidPlusOneGenuinelyCorruptFile_ReturnsValid_AndWarnsOnceNamingTheBadFile`
- `OnlyCorruptFiles_ReturnsFalse_WithEmptyResult_AndDoesNotThrow`
- ✅ 943 SailDiff/Tracking/Analysis tests pass.

---
Part of the #298 epic. D5 (#295) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)