### PR TITLE
fix(runsettings): resolve output directory to an absolute path once (#295, D5)

### DIFF
--- a/source/Sailfish/RunSettings.cs
+++ b/source/Sailfish/RunSettings.cs
@@ -56,7 +56,17 @@ internal class RunSettings : IRunSettings
         TrawlSettings? trawlSettings = null)
     {
         TestNames = testNames;
-        LocalOutputDirectory = localOutputDirectory;
+        // Resolve the output directory to an absolute path exactly once, anchored to the current directory
+        // at construction time, and store the absolute form. Relative resolution used to compound across
+        // successive runs — the default output directory nested one level deeper each run
+        // (sailfish_default_output -> .../sailfish_tracking_output/sailfish_default_output -> ...), so each
+        // run wrote into a fresh nested directory and SailDiff could no longer discover the previous run's
+        // tracking file. Path.GetFullPath is idempotent for an already-absolute path, so an explicitly
+        // configured absolute directory is preserved as-is and re-resolving never adds another level.
+        LocalOutputDirectory = Path.GetFullPath(
+            string.IsNullOrWhiteSpace(localOutputDirectory)
+                ? DefaultFileSettings.DefaultOutputDirectory
+                : localOutputDirectory);
         CreateTrackingFiles = createTrackingFiles;
         RunSailDiff = useSailDiff;
         RunScaleFish = useScaleFish;

--- a/source/Tests.Library/RunSettingsBuilderTests.cs
+++ b/source/Tests.Library/RunSettingsBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using NSubstitute;
 using Sailfish;
@@ -133,7 +134,8 @@ public class RunSettingsBuilderTests
 
         result.ShouldBeSameAs(builder);
         var settings = builder.Build();
-        settings.LocalOutputDirectory.ShouldBe(customDir);
+        // The output directory is resolved to an absolute path once at construction (#295).
+        settings.LocalOutputDirectory.ShouldBe(Path.GetFullPath(customDir));
     }
 
     [Fact]
@@ -483,7 +485,7 @@ public class RunSettingsBuilderTests
         var settings = builder.Build();
 
         settings.TestNames.ShouldBeEmpty();
-        settings.LocalOutputDirectory.ShouldBe(DefaultFileSettings.DefaultOutputDirectory);
+        settings.LocalOutputDirectory.ShouldBe(Path.GetFullPath(DefaultFileSettings.DefaultOutputDirectory));
         settings.CreateTrackingFiles.ShouldBeTrue(); // Default is true
         settings.RunSailDiff.ShouldBeFalse(); // Default is false
         settings.RunScaleFish.ShouldBeFalse(); // Default is false
@@ -512,7 +514,44 @@ public class RunSettingsBuilderTests
 
         var settings = builder.Build();
 
-        settings.LocalOutputDirectory.ShouldBe(DefaultFileSettings.DefaultOutputDirectory);
+        settings.LocalOutputDirectory.ShouldBe(Path.GetFullPath(DefaultFileSettings.DefaultOutputDirectory));
+    }
+
+    [Fact]
+    public void LocalOutputDirectory_IsResolvedToAbsolute_DeterministicAndIdempotent()
+    {
+        // #295: the output directory is resolved to an absolute path once at construction, so it does not
+        // drift / nest across successive runs, and re-resolving an already-absolute path is idempotent.
+        var run1 = RunSettingsBuilder.CreateBuilder().Build();
+        var run2 = RunSettingsBuilder.CreateBuilder().Build();
+
+        Path.IsPathRooted(run1.LocalOutputDirectory).ShouldBeTrue();
+        run1.LocalOutputDirectory.ShouldBe(run2.LocalOutputDirectory); // no per-run drift
+
+        // Feeding run 1's resolved (absolute) directory back in must NOT add another level — the anti-nesting
+        // guarantee that the per-run directory growth depended on.
+        var run3 = RunSettingsBuilder.CreateBuilder().WithLocalOutputDirectory(run1.LocalOutputDirectory).Build();
+        run3.LocalOutputDirectory.ShouldBe(run1.LocalOutputDirectory);
+    }
+
+    [Fact]
+    public void TrackingDirectory_IsAbsoluteOutputDirPlusSubfolder_NeverDeeper()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), "sf-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var settings = RunSettingsBuilder.CreateBuilder().WithLocalOutputDirectory(temp).Build();
+
+            settings.LocalOutputDirectory.ShouldBe(Path.GetFullPath(temp));
+
+            var tracking = settings.GetRunSettingsTrackingDirectoryPath();
+            Path.IsPathRooted(tracking).ShouldBeTrue();
+            tracking.ShouldBe(Path.Combine(settings.LocalOutputDirectory, DefaultFileSettings.DefaultExecutionSummaryTrackingDirectory));
+        }
+        finally
+        {
+            if (Directory.Exists(temp)) Directory.Delete(temp, recursive: true);
+        }
     }
 
     [Fact]
@@ -618,7 +657,7 @@ public class RunSettingsBuilderTests
         settings.StreamTrackingUpdates.ShouldBeFalse();
         settings.TestNames.ShouldContain("Test1");
         settings.TestNames.ShouldContain("Test2");
-        settings.LocalOutputDirectory.ShouldBe("custom_output");
+        settings.LocalOutputDirectory.ShouldBe(Path.GetFullPath("custom_output"));
         settings.CreateTrackingFiles.ShouldBeFalse();
         settings.RunSailDiff.ShouldBeTrue();
         settings.SailDiffSettings.ShouldBeSameAs(customSailDiffSettings);


### PR DESCRIPTION
Fixes #295 (child **D5** of epic #298).

> **Stacked on #310 (#294) → #309 (#293) → #308 (#292) → #307 (#291).** Review/merge bottom-up.

## Problem
Running the same suite repeatedly nested the default output directory one level deeper **each run**:
```
run 1: sailfish_default_output
run 2: sailfish_default_output/sailfish_tracking_output/sailfish_default_output
run 3: .../sailfish_tracking_output/sailfish_default_output/sailfish_tracking_output
```
`LocalOutputDirectory` was stored as a **relative** string and re-resolved against the process working directory at each use, so any drift compounded — each run wrote into a fresh nested directory and SailDiff could no longer discover the previous run's tracking file (before/after silently broke; history scattered).

## Fix
Resolve `LocalOutputDirectory` to an **absolute path exactly once**, in the `RunSettings` constructor — the single construction chokepoint (`RunSettingsBuilder` *and* the test adapter both route through it; it's the only `IRunSettings` implementation). The tracking directory is then derived from that stable absolute path. `Path.GetFullPath` is idempotent for an already-absolute path, so an explicitly configured absolute directory is preserved and re-resolving never adds a level.

> No `Directory.SetCurrentDirectory` exists in the codebase (the issue's suspected mechanism), so the real cause was relative-path re-resolution. Anchoring to an absolute path once is the robust, host-agnostic fix the issue prescribes.

## Tests
- Updated the four `RunSettingsBuilder` tests that asserted the old *relative* value → now assert the absolute resolution.
- `LocalOutputDirectory_IsResolvedToAbsolute_DeterministicAndIdempotent` — rooted, identical across runs, and feeding the resolved path back adds no level.
- `TrackingDirectory_IsAbsoluteOutputDirPlusSubfolder_NeverDeeper`.
- ✅ Full `Tests.Library` (1648) and `Tests.TestAdapter` (569) suites pass; solution builds clean.

---
Part of the #298 epic. D6 (#296) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)