### PR TITLE
fix(scalefish): analyze the current run in-memory; fix ArgumentNullException("key") (#296, D6)

### DIFF
--- a/source/Sailfish.TestAdapter/Execution/AdapterScaleFish.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterScaleFish.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using Sailfish.Analysis.ScaleFish;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Contracts.Public.Requests;
+using Sailfish.Execution;
 using Sailfish.Logging;
 using Sailfish.Presentation;
 
@@ -43,7 +45,19 @@ internal class AdapterScaleFish : IAdapterScaleFish
         if (!_runSettings.RunScaleFish) return;
 
         var response = await _mediator.Send(new GetLatestExecutionSummaryRequest(), cancellationToken);
-        var executionSummaries = response.LatestExecutionSummaries;
+        await AnalyzeCore(response.LatestExecutionSummaries.ToList(), cancellationToken);
+    }
+
+    // Decoupled entry point — analyze the current run's in-memory summaries directly (no tracking-file
+    // retrieval, no baseline dependency, no Type.GetType round-trip). See IScaleFishInternal.
+    public async Task Analyze(IEnumerable<IClassExecutionSummary> executionSummaries, CancellationToken cancellationToken)
+    {
+        if (!_runSettings.RunScaleFish) return;
+        await AnalyzeCore(executionSummaries.ToList(), cancellationToken);
+    }
+
+    private async Task AnalyzeCore(List<IClassExecutionSummary> executionSummaries, CancellationToken cancellationToken)
+    {
         if (!executionSummaries.Any()) return;
 
         try

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityComputer.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityComputer.cs
@@ -66,12 +66,20 @@ public class ComplexityComputer : IComplexityComputer
 
         foreach (var testClassSummary in executionSummaries)
         {
+            // A summary whose TestClass could not be resolved (e.g. loaded from a tracking file where
+            // Type.GetType(assemblyQualifiedName) returned null because the type isn't loadable in this
+            // process) would otherwise crash Dictionary<Type, ...>.Add with ArgumentNullException("key").
+            // Skip it so analysis degrades to "no model for this class" instead of taking down the run.
+            // The normal path now feeds ScaleFish the current run's in-memory summaries (real Type), so this
+            // guard is defensive for the file-loaded path.
+            if (testClassSummary.TestClass is null) continue;
+
             var observationSet = _scalefishObservationCompiler.CompileObservationSet(testClassSummary);
             if (observationSet is null) continue;
 
             var resultsByMethod = ComputeComplexityMethodResult(observationSet, measurementsByKey);
 
-            finalResult.Add(testClassSummary.TestClass, resultsByMethod);
+            finalResult[testClassSummary.TestClass] = resultsByMethod;
         }
 
         var classes = ScalefishClassModel.ParseResults(finalResult).ToList();

--- a/source/Sailfish/Analysis/ScaleFish/IScaleFishInternal.cs
+++ b/source/Sailfish/Analysis/ScaleFish/IScaleFishInternal.cs
@@ -1,5 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Execution;
 using Sailfish.Presentation;
 
 namespace Sailfish.Analysis.ScaleFish;
 
-internal interface IScaleFishInternal : IAnalyzeFromFile;
+internal interface IScaleFishInternal : IAnalyzeFromFile
+{
+    /// <summary>
+    ///     Analyze the current run's in-memory execution summaries directly. ScaleFish is a single-run
+    ///     complexity analysis, so it must not be gated by the (SailDiff-shared) tracking-file retrieval or
+    ///     by the presence of a baseline — and analyzing the in-memory summaries (which carry the real
+    ///     <see cref="System.Type" /> for each test class) also avoids the file round-trip's
+    ///     <c>Type.GetType</c> resolution failures that produced an <c>ArgumentNullException("key")</c>.
+    /// </summary>
+    Task Analyze(IEnumerable<IClassExecutionSummary> executionSummaries, CancellationToken cancellationToken);
+}

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
@@ -10,6 +10,7 @@ using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Contracts.Public.Requests;
 using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+using Sailfish.Execution;
 using Sailfish.Logging;
 using Sailfish.Presentation;
 using Sailfish.Presentation.Console;
@@ -50,12 +51,29 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
         throw new NotImplementedException();
     }
 
+    // IAnalyzeFromFile entry point — retained for compatibility (ad-hoc / IDE callers). Reads the most
+    // recent tracking file, then runs the same core analysis. The run pipeline uses the in-memory overload
+    // below instead.
     public async Task Analyze(CancellationToken cancellationToken)
     {
         if (!_runSettings.RunScaleFish) return;
 
         var response = await _mediator.Send(new GetLatestExecutionSummaryRequest(), cancellationToken);
-        var executionSummaries = response.LatestExecutionSummaries;
+        await AnalyzeCore(response.LatestExecutionSummaries.ToList(), cancellationToken).ConfigureAwait(false);
+    }
+
+    // Decoupled entry point: analyze the CURRENT run's in-memory summaries directly. No tracking-file
+    // retrieval, no baseline dependency, and no Type.GetType round-trip — so ScaleFish (and therefore
+    // Skipper, which fires off the completion notification) runs on a single run even when SailDiff has no
+    // before/after, and the ArgumentNullException("key") from an unresolved test-class Type can't occur.
+    public async Task Analyze(IEnumerable<IClassExecutionSummary> executionSummaries, CancellationToken cancellationToken)
+    {
+        if (!_runSettings.RunScaleFish) return;
+        await AnalyzeCore(executionSummaries.ToList(), cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task AnalyzeCore(List<IClassExecutionSummary> executionSummaries, CancellationToken cancellationToken)
+    {
         if (!executionSummaries.Any()) return;
 
         try

--- a/source/Sailfish/Execution/SailfishExecutor.cs
+++ b/source/Sailfish/Execution/SailfishExecutor.cs
@@ -89,7 +89,7 @@ internal class SailfishExecutor
                 await RunPostMeasurementStage("SailDiff analysis", () => _sailDiff.Analyze(cancellationToken), analysisExceptions).ConfigureAwait(false);
 
             if (_runSettings.RunScaleFish)
-                await RunPostMeasurementStage("ScaleFish analysis", () => _scaleFish.Analyze(cancellationToken), analysisExceptions).ConfigureAwait(false);
+                await RunPostMeasurementStage("ScaleFish analysis", () => _scaleFish.Analyze(classExecutionSummaries, cancellationToken), analysisExceptions).ConfigureAwait(false);
 
             var exceptions = classExecutionSummaries
                 .SelectMany(classExecutionSummary =>

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishDecouplingTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishDecouplingTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using NSubstitute;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Contracts.Public.Requests;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Sailfish.Presentation;
+using Sailfish.Presentation.Console;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.ScaleFish;
+
+public class ScaleFishDecouplingTests
+{
+    [Fact]
+    public async Task Analyze_WithInMemorySummaries_DoesNotQueryTrackingFiles_AndPublishesCompletion()
+    {
+        // #296: ScaleFish is a single-run analysis. Given the current run's in-memory summaries it must NOT
+        // go through the SailDiff-shared tracking-file retrieval (which has no baseline on a first run), and
+        // it must publish the completion notification that Skipper hangs off — so Skipper fires on a single
+        // run.
+        var mediator = Substitute.For<IMediator>();
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.RunScaleFish.Returns(true);
+        runSettings.ScaleFishSettings.Returns(new ScaleFishSettings { EnableTrendTracking = false, EmitHtmlReport = false });
+
+        var computer = Substitute.For<IComplexityComputer>();
+        computer.AnalyzeComplexityWithMeasurements(Arg.Any<List<IClassExecutionSummary>>())
+            .Returns(new ComplexityAnalysisResult(
+                new List<ScalefishClassModel> { new("NS", "Cls", Enumerable.Empty<ScaleFishMethodModel>()) },
+                new Dictionary<string, ComplexityMeasurement[]>()));
+
+        var markdown = Substitute.For<IMarkdownTableConverter>();
+        markdown.ConvertScaleFishResultToMarkdown(Arg.Any<IEnumerable<ScalefishClassModel>>()).Returns("md");
+
+        var scaleFish = new Sailfish.Analysis.ScaleFish.ScaleFish(
+            mediator, runSettings, computer, markdown, Substitute.For<IConsoleWriter>(), Substitute.For<ILogger>());
+
+        var currentRun = new List<IClassExecutionSummary> { Substitute.For<IClassExecutionSummary>() };
+        await scaleFish.Analyze(currentRun, CancellationToken.None);
+
+        // Decoupled: no tracking-file retrieval.
+        await mediator.DidNotReceive().Send(Arg.Any<GetLatestExecutionSummaryRequest>(), Arg.Any<CancellationToken>());
+        // It analyzed exactly the in-memory summaries it was handed.
+        computer.Received(1).AnalyzeComplexityWithMeasurements(Arg.Is<List<IClassExecutionSummary>>(s => s.Count == 1));
+        // Skipper hangs off this notification — it must fire on a single run.
+        await mediator.Received(1).Publish(Arg.Any<ScaleFishAnalysisCompleteNotification>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void ComplexityComputer_SkipsSummaryWithUnresolvedType_InsteadOfThrowingNullKey()
+    {
+        // #296: a summary loaded from a tracking file whose TestClass could not be resolved
+        // (Type.GetType -> null) must be skipped, not crash Dictionary<Type,...>.Add with
+        // ArgumentNullException("key").
+        var computer = new ComplexityComputer(
+            Substitute.For<IComplexityEstimator>(),
+            Substitute.For<IScalefishObservationCompiler>());
+
+        var summary = Substitute.For<IClassExecutionSummary>();
+        summary.TestClass.Returns((Type)null!);
+
+        var result = computer.AnalyzeComplexityWithMeasurements(new List<IClassExecutionSummary> { summary });
+
+        result.Classes.ShouldBeEmpty();
+    }
+}

--- a/source/Tests.Library/Execution/SailfishExecutorTests.cs
+++ b/source/Tests.Library/Execution/SailfishExecutorTests.cs
@@ -190,8 +190,9 @@ public class SailfishExecutorTests
         // Act
         await executor.Run(CancellationToken.None);
 
-        // Assert
-        await _scaleFish.Received(1).Analyze(Arg.Any<CancellationToken>());
+        // Assert — ScaleFish now analyzes the current run's in-memory summaries directly (#296), decoupled
+        // from the SailDiff tracking-file retrieval.
+        await _scaleFish.Received(1).Analyze(Arg.Any<IEnumerable<IClassExecutionSummary>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -292,7 +293,7 @@ public class SailfishExecutorTests
         _runSettings.RunScaleFish.Returns(true);
 
         var boom = new InvalidOperationException("analysis blew up");
-        _scaleFish.Analyze(Arg.Any<CancellationToken>()).Returns<Task>(_ => throw boom);
+        _scaleFish.Analyze(Arg.Any<IEnumerable<IClassExecutionSummary>>(), Arg.Any<CancellationToken>()).Returns<Task>(_ => throw boom);
 
         var executor = new SailfishExecutor(_mediator, _sailFishTestExecutor, _testCollector, _testFilter,
             _classExecutionSummaryCompiler, _executionSummaryWriter, _sailDiff, _scaleFish, _runSettings, _logger);
@@ -331,7 +332,7 @@ public class SailfishExecutorTests
         _runSettings.RunSailDiff.Returns(false);
         _runSettings.RunScaleFish.Returns(true);
 
-        _scaleFish.Analyze(Arg.Any<CancellationToken>()).Returns<Task>(_ => throw new OperationCanceledException());
+        _scaleFish.Analyze(Arg.Any<IEnumerable<IClassExecutionSummary>>(), Arg.Any<CancellationToken>()).Returns<Task>(_ => throw new OperationCanceledException());
 
         var executor = new SailfishExecutor(_mediator, _sailFishTestExecutor, _testCollector, _testFilter,
             _classExecutionSummaryCompiler, _executionSummaryWriter, _sailDiff, _scaleFish, _runSettings, _logger);


### PR DESCRIPTION
Fixes #296 (child **D6** of epic #298).

> **Stacked on #311 (#295) → #310 (#294) → #309 (#293) → #308 (#292) → #307 (#291).** Review/merge bottom-up.

## Problem
On a clean single run with a `scaleFish: true` variable, ScaleFish produced **no model** and **Skipper never fired**, and an `ArgumentNullException` (`Parameter 'key'`) was logged at the end. Two coupled causes:

1. **Coupling.** ScaleFish fetched its data via `GetLatestExecutionSummaryRequest` — the same tracking-file retrieval SailDiff uses for before/after. That round-trips the current run through disk and rebuilds each summary's `TestClass` via `Type.GetType(assemblyQualifiedName)`, which returns **null** in hosts where the test type isn't loadable by name. (It also sat *outside* ScaleFish's own error handling.)
2. **Null key.** `ComplexityComputer` then did `Dictionary<Type, …>.Add(summary.TestClass, …)`; a null `TestClass` throws `ArgumentNullException("key")` — exactly the "no model / no Skipper / null-key at the end" symptom.

## Fix
- Add an **in-memory** `IScaleFishInternal.Analyze(IEnumerable<IClassExecutionSummary>, ct)` overload and have `SailfishExecutor` feed ScaleFish the **current run's summaries directly**. No tracking-file retrieval, no baseline dependency, no `Type.GetType` round-trip — so ScaleFish runs (and the `ScaleFishAnalysisCompleteNotification` that Skipper hangs off fires) on a single run, while SailDiff still degrades independently when it has no before/after. The file-backed `Analyze(ct)` entry point is retained for ad-hoc/IDE callers; `AdapterScaleFish` gets the same overload.
- **Guard `ComplexityComputer`** against a null `TestClass` (skip the summary instead of crashing) and use an indexer assignment so a duplicate type can't throw either — defensive for the file-loaded path.

## Tests
- `Analyze_WithInMemorySummaries_DoesNotQueryTrackingFiles_AndPublishesCompletion` — no retrieval; completion notification (Skipper trigger) fires.
- `ComplexityComputer_SkipsSummaryWithUnresolvedType_InsteadOfThrowingNullKey`.
- Updated the three executor tests that referenced the old `Analyze(ct)` call.
- ✅ Full `Tests.Library` (1650) and `Tests.TestAdapter` (569) suites pass.

---
Part of the #298 epic. D7 (#297) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)