### PR TITLE
fix(logging): render exception-log templates; collapse repeated identical stacks (#297, D7)

### DIFF
--- a/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFish.cs
@@ -149,7 +149,7 @@ internal class ScaleFish : IScaleFish, IScaleFishInternal
             // Surface the failure. A silently-swallowed exception here is exactly why a null-key
             // crash in the complexity computer produced no ScaleFish output — and no error — for
             // so long; log it at Warning so the next regression is visible.
-            _logger.Log(LogLevel.Warning, ex, "ScaleFish analysis failed: {0}", ex.Message);
+            _logger.Log(LogLevel.Warning, ex, "ScaleFish analysis failed");
             _consoleWriter.WriteString(ex.Message);
         }
     }

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -153,7 +153,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             }
             catch (Exception ex)
             {
-                _logger.Log(LogLevel.Debug, ex, "Failed to create/write reproducibility manifest: {0}", ex.Message);
+                _logger.Log(LogLevel.Debug, ex, "Failed to create/write reproducibility manifest");
             }
 
             // Generate consolidated markdown content for the entire session (after manifest is available)
@@ -253,7 +253,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             }
             catch (Exception ex)
             {
-                _logger.Log(LogLevel.Debug, ex, "Failed to append environment health section: {0}", ex.Message);
+                _logger.Log(LogLevel.Debug, ex, "Failed to append environment health section");
             }
         }
 
@@ -293,7 +293,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             }
             catch (Exception ex)
             {
-                _logger.Log(LogLevel.Debug, ex, "Failed to append reproducibility summary: {0}", ex.Message);
+                _logger.Log(LogLevel.Debug, ex, "Failed to append reproducibility summary");
             }
         }
 
@@ -529,7 +529,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
         }
         catch (Exception ex)
         {
-            _logger.Log(LogLevel.Debug, ex, "Failed to append comparison distribution plot: {0}", ex.Message);
+            _logger.Log(LogLevel.Debug, ex, "Failed to append comparison distribution plot");
         }
     }
 
@@ -640,7 +640,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
         }
         catch (Exception ex)
         {
-            _logger.Log(LogLevel.Warning, ex, "Failed to create NxN comparison matrix (FDR/CI): {0}", ex.Message);
+            _logger.Log(LogLevel.Warning, ex, "Failed to create NxN comparison matrix (FDR/CI)");
             return string.Empty;
         }
     }
@@ -734,7 +734,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
         }
         catch (Exception ex)
         {
-            _logger.Log(LogLevel.Warning, ex, "Failed to create baseline comparison table: {0}", ex.Message);
+            _logger.Log(LogLevel.Warning, ex, "Failed to create baseline comparison table");
             return string.Empty;
         }
     }

--- a/source/Sailfish/Logging/DefaultLogger.cs
+++ b/source/Sailfish/Logging/DefaultLogger.cs
@@ -29,6 +29,11 @@ internal class DefaultLogger : ILogger
         { LogLevel.Fatal, "FATAL" }
     };
 
+    // Signature of the most recently logged exception, used to collapse a burst of identical exception logs
+    // (e.g. one root failure surfacing once per test case) instead of printing N identical full stacks.
+    private string? _lastExceptionSignature;
+    private int _repeatCount;
+
     public DefaultLogger(LogLevel minimumLogLevel)
     {
         _allowedLogLevels = new List<LogLevel>
@@ -51,7 +56,26 @@ internal class DefaultLogger : ILogger
 
     public void Log(LogLevel level, Exception ex, string template, params object[] values)
     {
-        var lines = new List<string> { template, ex.Message };
+        // Fill in the message template with the supplied values. This overload previously logged the raw
+        // template, so structured placeholders ({0}, {Stage}, ...) were printed verbatim and the supplied
+        // arguments were dropped entirely.
+        var message = FormatTemplate(template, values);
+
+        // Collapse repeated identical exceptions: the same root cause surfacing once per test case used to
+        // print its full stack N times. Log it in full once, then drop subsequent identical occurrences to a
+        // terse Debug line (with a running count) so they don't bury the console.
+        var signature = $"{level}|{message}|{ex.Message}|{ex.StackTrace}";
+        if (signature == _lastExceptionSignature)
+        {
+            _repeatCount++;
+            JoinAndWriteLines(LogLevel.Debug, new[] { $"(previous error repeated, occurrence #{_repeatCount + 1}): {ex.Message}" });
+            return;
+        }
+
+        _lastExceptionSignature = signature;
+        _repeatCount = 0;
+
+        var lines = new List<string> { message, ex.Message };
         if (ex.StackTrace is not null)
             lines.Add(ex.StackTrace);
 

--- a/source/Tests.Library/Logging/DefaultLoggerTests.cs
+++ b/source/Tests.Library/Logging/DefaultLoggerTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Sailfish.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Logging;
+
+// These tests redirect System.Console, which is process-global — keep them off the parallel path.
+[CollectionDefinition("ConsoleCaptureSerial", DisableParallelization = true)]
+public class ConsoleCaptureSerialCollection;
+
+[Collection("ConsoleCaptureSerial")]
+public class DefaultLoggerTests
+{
+    private static Exception MakeException(string message)
+    {
+        try
+        {
+            throw new InvalidOperationException(message);
+        }
+        catch (Exception e)
+        {
+            return e; // carries a real stack trace
+        }
+    }
+
+    private static string Capture(Action action)
+    {
+        var original = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return sw.ToString();
+    }
+
+    [Fact]
+    public void ExceptionOverload_FillsTemplatePlaceholders_AndIncludesExceptionMessage()
+    {
+        // #297: the exception overload used to log the raw template, so "{0}" printed verbatim and the
+        // supplied arguments were dropped entirely.
+        var output = Capture(() =>
+        {
+            var logger = new DefaultLogger(LogLevel.Verbose);
+            logger.Log(LogLevel.Error, MakeException("boom-detail"), "stage {0} failed", "ALPHA");
+        });
+
+        output.ShouldContain("stage ALPHA failed");
+        output.ShouldNotContain("{0}");
+        output.ShouldContain("boom-detail"); // the exception message is still surfaced
+    }
+
+    [Fact]
+    public void RepeatedIdenticalException_LogsTemplateOnce_ThenCollapsesRepeats()
+    {
+        // #297: one root failure surfacing repeatedly (e.g. once per test case) should not print N identical
+        // full stacks — log it once, then collapse repeats to a terse counted note.
+        var ex = MakeException("repeated-boom");
+        var output = Capture(() =>
+        {
+            var logger = new DefaultLogger(LogLevel.Verbose);
+            logger.Log(LogLevel.Error, ex, "the same failure");
+            logger.Log(LogLevel.Error, ex, "the same failure");
+            logger.Log(LogLevel.Error, ex, "the same failure");
+        });
+
+        // The full template line is logged exactly once, not three times.
+        Regex.Matches(output, "the same failure").Count.ShouldBe(1);
+        // The 2nd and 3rd identical occurrences collapse to a counted note.
+        output.ShouldContain("occurrence #2");
+        output.ShouldContain("occurrence #3");
+    }
+}


### PR DESCRIPTION
Fixes #297 (child **D7** of epic #298 — completes the epic).

> **Top of the stack: #312 (#296) → #311 (#295) → #310 (#294) → #309 (#293) → #308 (#292) → #307 (#291).** Review/merge bottom-up.

Two logging-hygiene fixes (the failures they surfaced are fixed upstream in this stack; this is the polish).

## 1. Unformatted message template
`DefaultLogger.Log(level, ex, template, values)` logged the **raw** template and ignored `values`, so structured placeholders printed verbatim — e.g. the reproducibility-manifest failure showed `...: {0}` instead of the actual error (the issue's headline). The overload now runs `FormatTemplate(template, values)` before appending the exception's message and stack.

This was a **general** logger bug: every exception-overload call site with placeholders was affected (`{Stage}`, `{TrackingFile}`, `OPI={OPI}`, …). I also dropped the now-redundant trailing `: {0}", ex.Message` from the call sites that relied on the old behavior (the overload already appends `ex.Message`), so the message isn't printed twice.

## 2. Repeated full-stack spam
The same exception (one root cause surfacing once per test case) printed its full stack N times. `DefaultLogger` now logs an exception **in full once**, then collapses immediately-following identical occurrences (same level + message + stack) to a terse **Debug** line with a running occurrence count — so a single root cause no longer buries the console.

## Tests
New `DefaultLoggerTests` (in a non-parallel collection, since it redirects `System.Console`):
- the exception overload fills placeholders (`stage {0}` → `stage ALPHA`) and still surfaces the message;
- three identical exceptions log the template once and collapse the repeats into counted notes.
- ✅ Full `Tests.Library` (1652) and `Tests.TestAdapter` (569) suites pass; solution builds clean.

---
This is **D7**, the last child of the #298 epic. Once #307–#312 and this merge, #298 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)