### PR TITLE
fix(execution): disabled tests must not invoke user constructors or DI (#300)

### DIFF
--- a/source/Sailfish/Execution/SailfishExecutionEngine.cs
+++ b/source/Sailfish/Execution/SailfishExecutionEngine.cs
@@ -341,6 +341,20 @@ internal class SailfishExecutionEngine : ISailfishExecutionEngine
         // scope disposal is in a finally so it always runs, even if the instance's own disposal throws.
         try
         {
+            // A disabled test is materialized WITHOUT running its constructor (#300: TypeActivator allocates it
+            // via RuntimeHelpers.GetUninitializedObject), so the instance is uninitialized. Never invoke its
+            // IDisposable/IAsyncDisposable.Dispose here — running user teardown against an object whose
+            // constructor never ran breaks the "no user code for disabled tests" guarantee and can throw on
+            // fields the ctor would have set, reporting a disabled test as failed. This covers both a disabled
+            // class and a disabled method in an enabled class (both reach disposal with a dehydrated instance).
+            // Just drop the reference; the DI scope (disposed in the finally) is null for disabled tests anyway,
+            // but is still released defensively if one is ever present.
+            if (instanceContainer is { Disabled: true })
+            {
+                instanceContainer.Instance = null!;
+                return;
+            }
+
             switch (instanceContainer?.Instance)
             {
                 case IAsyncDisposable asyncDisposable:

--- a/source/Sailfish/Execution/TypeActivator.cs
+++ b/source/Sailfish/Execution/TypeActivator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Exceptions;
@@ -25,29 +26,26 @@ public class TypeActivator : ITypeActivator
 
     public TestInstanceActivation CreateDehydratedTestInstance(Type test, TestCaseId testCaseId, bool disabled)
     {
-        var ctorArgTypes = test.GetCtorParamTypes();
         if (disabled)
         {
-            // Disabled tests are never executed, so they are not resolved through the container (no scope).
+            // A disabled test (or a disabled class) is never executed, so materializing it must run NO user
+            // code: it has to report cleanly as disabled even when its constructor would throw or its DI
+            // dependencies are unresolved. Allocate the instance WITHOUT invoking any constructor
+            // (GetUninitializedObject) and without touching the DI container (no scope). The reporting /
+            // notification plumbing only describes the case by type (the instance is referenced solely via
+            // GetType()), so an uninitialized instance is sufficient while the user's constructor side
+            // effects — and any unresolved-dependency failures — never occur. (#300)
             try
             {
-                // The parameterless-args Activator.CreateInstance overload only finds PUBLIC constructors; include
-                // non-public so a disabled test with a non-public constructor still materializes (matching the
-                // enabled path, which discovers non-public constructors via GetConstructors).
-                return new TestInstanceActivation(
-                    Activator.CreateInstance(
-                        test,
-                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                        binder: null,
-                        args: ctorArgTypes.Select(_ => null! as object).ToArray(),
-                        culture: null)!,
-                    null);
+                return new TestInstanceActivation(RuntimeHelpers.GetUninitializedObject(test), null);
             }
             catch (Exception ex)
             {
                 throw new TestClassInstantiationException(test, ex);
             }
         }
+
+        var ctorArgTypes = test.GetCtorParamTypes();
 
         if (ctorArgTypes.Length != ctorArgTypes.Distinct().Count()) throw new SailfishException($"Multiple ctor arguments of the same type were found in {test.Name}");
 

--- a/source/Tests.Library/Execution/SailfishExecutionEngineDisabledDisposalTests.cs
+++ b/source/Tests.Library/Execution/SailfishExecutionEngineDisabledDisposalTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.Execution;
+using Sailfish.Logging;
+using Sailfish.Presentation.Console;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Execution;
+
+// Regression for #300 (CodeRabbit follow-up): a disabled test is materialized WITHOUT running its constructor
+// (TypeActivator allocates it via RuntimeHelpers.GetUninitializedObject), so the instance is uninitialized. The
+// engine still routes that instance through DisposeOfTestInstance, which must NOT invoke the user's
+// IDisposable/IAsyncDisposable.Dispose — doing so runs user teardown against a half-built object, breaking the
+// "no user code for disabled tests" guarantee and potentially reporting a disabled test as failed.
+public class SailfishExecutionEngineDisabledDisposalTests
+{
+    [Sailfish(Disabled = true)]
+    private class DisabledDisposableClass : IDisposable, IAsyncDisposable
+    {
+        public static bool DisposeCalled;
+        public static bool DisposeAsyncCalled;
+
+        [SailfishMethod]
+        public void Method() { }
+
+        public void Dispose() => DisposeCalled = true;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCalled = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Sailfish] // enabled class ...
+    private class EnabledClassWithDisabledDisposableMethod : IDisposable, IAsyncDisposable
+    {
+        public static bool DisposeCalled;
+        public static bool DisposeAsyncCalled;
+
+        [SailfishMethod(Disabled = true)] // ... with a disabled method
+        public void Method() { }
+
+        public void Dispose() => DisposeCalled = true;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCalled = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static SailfishExecutionEngine BuildEngine(out IMediator mediator)
+    {
+        mediator = Substitute.For<IMediator>();
+        return new SailfishExecutionEngine(
+            Substitute.For<ILogger>(),
+            Substitute.For<IConsoleWriter>(),
+            Substitute.For<ITestCaseIterator>(),
+            Substitute.For<ITestCaseCountPrinter>(),
+            mediator,
+            Substitute.For<IClassExecutionSummaryCompiler>(),
+            Substitute.For<IRunSettings>());
+    }
+
+    private static TestInstanceContainerProvider ProviderFor(Type testType)
+    {
+        var method = testType.GetMethod(nameof(DisabledDisposableClass.Method))!;
+        return new TestInstanceContainerProvider(
+            Substitute.For<IRunSettings>(),
+            new TypeActivator(new ServiceCollection().BuildServiceProvider()),
+            testType,
+            new List<PropertySet>(),
+            method);
+    }
+
+    // A disabled class short-circuits at the top of ActivateContainer (line ~138) and disposes the uninitialized
+    // instance there.
+    [Fact]
+    public async Task DisabledClass_ThatIsDisposable_IsNeverDisposed()
+    {
+        DisabledDisposableClass.DisposeCalled = false;
+        DisabledDisposableClass.DisposeAsyncCalled = false;
+
+        var engine = BuildEngine(out var mediator);
+
+        var results = await engine.ActivateContainer(ProviderFor(typeof(DisabledDisposableClass)), CancellationToken.None);
+
+        results.ShouldBeEmpty(); // the disabled short-circuit produces no execution results
+        await mediator.Received(1).Publish(Arg.Any<TestCaseDisabledNotification>(), Arg.Any<CancellationToken>());
+
+        // The uninitialized instance's disposal must never run (its constructor never did).
+        DisabledDisposableClass.DisposeCalled.ShouldBeFalse();
+        DisabledDisposableClass.DisposeAsyncCalled.ShouldBeFalse();
+    }
+
+    // A disabled method on an enabled class is skipped inside the per-case loop, but its (uninitialized) instance
+    // still reaches DisposeOfTestInstance via the loop's finally (line ~226) — that path must be guarded too.
+    [Fact]
+    public async Task DisabledMethod_OnEnabledClass_DoesNotDisposeUninitializedInstance()
+    {
+        EnabledClassWithDisabledDisposableMethod.DisposeCalled = false;
+        EnabledClassWithDisabledDisposableMethod.DisposeAsyncCalled = false;
+
+        var engine = BuildEngine(out var mediator);
+
+        await engine.ActivateContainer(ProviderFor(typeof(EnabledClassWithDisabledDisposableMethod)), CancellationToken.None);
+
+        await mediator.Received(1).Publish(Arg.Any<TestCaseDisabledNotification>(), Arg.Any<CancellationToken>());
+
+        EnabledClassWithDisabledDisposableMethod.DisposeCalled.ShouldBeFalse();
+        EnabledClassWithDisabledDisposableMethod.DisposeAsyncCalled.ShouldBeFalse();
+    }
+}

--- a/source/Tests.Library/Execution/TypeActivatorTests.cs
+++ b/source/Tests.Library/Execution/TypeActivatorTests.cs
@@ -80,4 +80,36 @@ public class TypeActivatorTests
         ex.InnerException.ShouldBeOfType<InvalidOperationException>();
         ex.InnerException!.Message.ShouldBe("boom from ctor");
     }
+
+    [Fact]
+    public void CreateDehydratedTestInstance_WhenDisabled_AndConstructorThrows_DoesNotThrow_AndDoesNotInvokeConstructor()
+    {
+        // #300: a disabled test whose constructor throws must still materialize cleanly (so it is reported as
+        // disabled, not failed) — the constructor must not run. If it ran, "boom from ctor" would throw here.
+        var activator = new TypeActivator(EmptyProvider());
+
+        var activation = activator.CreateDehydratedTestInstance(
+            typeof(TestClassThatThrowsInCtor),
+            new TestCaseId("TestClassThatThrowsInCtor.Method"),
+            disabled: true);
+
+        activation.Instance.ShouldBeOfType<TestClassThatThrowsInCtor>(); // a real instance of the type, ctor-free
+        activation.Scope.ShouldBeNull();                                 // disabled tests are not resolved through DI
+    }
+
+    [Fact]
+    public void CreateDehydratedTestInstance_WhenDisabled_AndDependencyNotRegistered_DoesNotResolveDi_AndDoesNotThrow()
+    {
+        // #300: a disabled test with unresolved DI dependencies must not attempt resolution — it reports as
+        // disabled rather than failing on a missing registration.
+        var activator = new TypeActivator(EmptyProvider());
+
+        var activation = activator.CreateDehydratedTestInstance(
+            typeof(TestClassWithDependency),
+            new TestCaseId("TestClassWithDependency.Method"),
+            disabled: true);
+
+        activation.Instance.ShouldBeOfType<TestClassWithDependency>();
+        activation.Scope.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
Fixes #300 (follow-up split out of #290).

> **Independent of the #298 serialization stack** — branched off `main`, touches only the activation path.

## Problem
For a disabled test (`[Sailfish(Disabled = true)]` or `[SailfishMethod(Disabled = true)]`) the engine short-circuits *execution*, but it still **constructed the test-class instance**: `TypeActivator`'s disabled branch called `Activator.CreateInstance(test, …)`, so a disabled test's constructor (and any side effects) ran — and a disabled class whose constructor throws was reported as **failed** before it was ever reported as **disabled**.

## Fix
Materialize disabled instances with `RuntimeHelpers.GetUninitializedObject(test)` — it allocates the instance **without invoking any constructor** and without touching the DI container (no scope).

This is safe because the reporting/notification plumbing only ever describes a disabled case **by type**:
- `TestInstanceContainer.CreateTestInstance` references the instance solely via `GetType()`;
- `CoreInvoker` stores the instance but compiles/invokes lazily (never at construction);
- the `TestCaseDisabledNotificationHandler` reads only type-level identity (`TestCaseId` / `DisplayName`), never instance state.

So an uninitialized instance is sufficient, while the user's constructor side effects — and any unresolved-dependency failures — never occur. The disabled-test code path, `TestCaseId`, and notifications are otherwise **byte-identical** to before, so existing reporting is unchanged for the common case.

> Note: the SharedInstance dispatcher already guards `!disabled` before creating the class instance, so the constructor only ever ran via this PerCase/disabled `TypeActivator` path. This is a minimal, low-risk fix that fully satisfies the issue's acceptance criteria without the larger "type-only activation" plumbing restructure the issue sketched.

## Tests
- `..._WhenDisabled_AndConstructorThrows_DoesNotThrow_AndDoesNotInvokeConstructor` (the throwing ctor would fail the test if it ran)
- `..._WhenDisabled_AndDependencyNotRegistered_DoesNotResolveDi_AndDoesNotThrow`
- Existing enabled-path tests (ctor-throws / missing-dependency both surface `TestClassInstantiationException`) remain green.
- ✅ Full `Tests.Library` (1641) and `Tests.TestAdapter` (569) suites pass; solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled tests now instantiate without invoking constructors or dependency injection, preventing constructor failures or missing dependencies from affecting test execution.

* **Tests**
  * Added test coverage verifying disabled tests instantiate correctly even when constructors fail or dependencies are unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->