### PR TITLE
fix(formatting): render nanoseconds as whole numbers

### DIFF
--- a/source/Sailfish/Presentation/DurationFormatter.cs
+++ b/source/Sailfish/Presentation/DurationFormatter.cs
@@ -20,7 +20,10 @@ public enum DurationUnit
 /// (see <c>PerformanceRunResult.ConvertFromPerfTimer</c>), so all inputs here are milliseconds.
 /// A representative magnitude is used to pick a single, human-friendly unit (ns / µs / ms / s)
 /// for a whole table column so that values land at roughly one-to-four significant figures,
-/// BenchmarkDotNet-style. This is presentation only — it never changes stored or persisted values.
+/// BenchmarkDotNet-style. Nanoseconds are always rendered as whole numbers: no supported timer
+/// resolves below 1 ns (Stopwatch tops out at one tick/ns, and the hardware is usually far
+/// coarser), so fractional-ns digits would be false precision. This is presentation only — it
+/// never changes stored or persisted values.
 /// </summary>
 public static class DurationFormatter
 {
@@ -84,7 +87,7 @@ public static class DurationFormatter
     public static string Format(double milliseconds, DurationUnit unit, int decimals)
     {
         var value = ToUnit(milliseconds, unit);
-        return value.ToString("F" + Math.Max(0, decimals), CultureInfo.InvariantCulture);
+        return value.ToString("F" + EffectiveDecimals(unit, decimals), CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -106,13 +109,16 @@ public static class DurationFormatter
     /// Formats a millisecond value in the supplied unit, escalating decimals (4 → 6 → 8) so a
     /// small-but-non-zero value never collapses to "0.0000". Used for confidence-interval margins,
     /// which can be far smaller than the column's central values. No unit suffix.
+    /// Nanoseconds render as whole numbers (sub-ns is false precision); the escalating fractional
+    /// steps are only reached for a sub-1ns margin that would otherwise collapse to "0".
     /// </summary>
     public static string FormatAdaptive(double milliseconds, DurationUnit unit)
     {
         var value = ToUnit(milliseconds, unit);
         if (value == 0) return "0";
 
-        foreach (var decimals in AdaptiveDecimalSteps)
+        var steps = unit == DurationUnit.Nanoseconds ? NanosecondAdaptiveDecimalSteps : AdaptiveDecimalSteps;
+        foreach (var decimals in steps)
         {
             var formatted = value.ToString("F" + decimals, CultureInfo.InvariantCulture);
             if (!IsAllZero(formatted)) return formatted;
@@ -122,6 +128,19 @@ public static class DurationFormatter
     }
 
     private static readonly int[] AdaptiveDecimalSteps = { 4, 6, 8 };
+
+    // Nanoseconds try whole numbers first; fractional digits are a last resort that only a
+    // sub-1ns margin (which would otherwise render "0") ever reaches.
+    private static readonly int[] NanosecondAdaptiveDecimalSteps = { 0, 4, 6, 8 };
+
+    /// <summary>
+    /// Clamps the caller's requested decimal count to what the chosen unit can meaningfully express.
+    /// Nanoseconds are the finest resolution any supported timer reports, so fractional nanoseconds
+    /// are pure formatting noise — a "417.000 ns" sample really only carries "417 ns" — and are
+    /// always rendered as whole numbers. Coarser units (µs / ms / s) keep the requested precision.
+    /// </summary>
+    private static int EffectiveDecimals(DurationUnit unit, int requestedDecimals)
+        => unit == DurationUnit.Nanoseconds ? 0 : Math.Max(0, requestedDecimals);
 
     private static DurationUnit PickUnit(double magnitudeMs)
     {

--- a/source/Tests.Library/Presentation/DurationFormatterTests.cs
+++ b/source/Tests.Library/Presentation/DurationFormatterTests.cs
@@ -62,10 +62,22 @@ public class DurationFormatterTests
     [InlineData(0.0011, DurationUnit.Nanoseconds, 0, "1100")]
     [InlineData(12.0, DurationUnit.Milliseconds, 2, "12.00")]
     [InlineData(1500.0, DurationUnit.Seconds, 2, "1.50")]
-    [InlineData(1.5e-6, DurationUnit.Nanoseconds, 2, "1.50")]
+    [InlineData(4.1667e-4, DurationUnit.Nanoseconds, 3, "417")] // 416.67 ns: ns ignores requested decimals -> whole number
     public void Format_renders_value_in_unit(double milliseconds, DurationUnit unit, int decimals, string expected)
     {
         DurationFormatter.Format(milliseconds, unit, decimals).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Format_renders_nanoseconds_as_whole_numbers_ignoring_requested_decimals()
+    {
+        // No supported timer resolves below 1 ns, so fractional-ns digits are false precision.
+        // A 416.67 ns sample (0.00041667 ms) must render "417", never "416.670" — regardless of
+        // the requested decimal count. Repro from the IDE "Distribution (ns)" dump showing "417.000".
+        DurationFormatter.Format(0.00041667, DurationUnit.Nanoseconds, 3).ShouldBe("417");
+        DurationFormatter.FormatWithUnit(0.00041667, DurationUnit.Nanoseconds, 3).ShouldBe("417 ns");
+        // Coarser units are unaffected and keep their decimals.
+        DurationFormatter.Format(0.0011, DurationUnit.Microseconds, 3).ShouldBe("1.100");
     }
 
     [Fact]
@@ -75,7 +87,7 @@ public class DurationFormatterTests
     }
 
     [Theory]
-    [InlineData(1.5e-6, 2, "1.50 ns")]   // 1.5 ns
+    [InlineData(4.1667e-4, 2, "417 ns")] // 416.67 ns -> whole ns (decimals ignored)
     [InlineData(0.0011, 2, "1.10 µs")]   // 1.1 µs — the headline acceptance case
     [InlineData(12.0, 2, "12.00 ms")]
     [InlineData(1500.0, 2, "1.50 s")]
@@ -113,6 +125,22 @@ public class DurationFormatterTests
     public void FormatAdaptive_returns_zero_for_zero()
     {
         DurationFormatter.FormatAdaptive(0.0, DurationUnit.Microseconds).ShouldBe("0");
+    }
+
+    [Fact]
+    public void FormatAdaptive_renders_a_nanosecond_margin_as_a_whole_number()
+    {
+        // A 12.7 ns CI margin shares a ns column with whole-number means/medians, so it must
+        // render "13", not "12.7000" — sub-ns digits are false precision.
+        DurationFormatter.FormatAdaptive(12.7e-6, DurationUnit.Nanoseconds).ShouldBe("13");
+    }
+
+    [Fact]
+    public void FormatAdaptive_keeps_a_sub_nanosecond_margin_visible()
+    {
+        // A 0.3 ns margin would collapse to "0" at whole-ns precision, so the adaptive fallback
+        // escalates decimals to keep the (tiny but nonzero) value visible.
+        DurationFormatter.FormatAdaptive(0.3e-6, DurationUnit.Nanoseconds).ShouldBe("0.3000");
     }
 
     [Theory]


### PR DESCRIPTION
## What & why

The IDE **Distribution (ns)** dump — and every other nanosecond display — rendered values like `417.000`, implying picosecond precision on a timer that physically resolves ~42 ns. That `.000` was pure formatting noise:

- On this platform `Stopwatch.Frequency == 1_000_000_000`, so elapsed ticks **are** whole nanoseconds (`TickAutoConverter`: `ticks / 1e9 * 1e9 == ticks`).
- The underlying ~24 MHz hardware timebase quantizes samples to ~41.667 ns steps (the 417 / 459 / 500 / 542 / 584 / 625 clustering), even though the *reported* resolution is 1 ns/tick.

Nothing was being rounded — the samples are genuinely integral and `F3` just padded `.000`. Showing 3 decimals on a nanosecond value is false precision regardless of who's reading it.

## The change

Single chokepoint in `DurationFormatter`:

- **`EffectiveDecimals(unit, requested)`** → `0` for nanoseconds, the requested count otherwise. Routed through `Format`, so every value sink inherits it: distribution dump, mean/median/min/max, outliers, markdown tables, SailDiff detail + method-comparison tables, box/histogram axis ticks.
- **`FormatAdaptive`** (CI margins) made ns-aware too — whole number first, dropping to fractional digits **only** if a sub-1 ns margin would otherwise collapse to `0`. Keeps the margin row consistent with the mean instead of printing `± 12.7000 ns` next to `Mean: 459 ns`.

`µs` / `ms` / `s` output is **unchanged** (still 3 decimals).

### Before / after

```diff
 Distribution (ns)
 -----------------
-542.000, 501.000, 459.000, 417.000, 418.000, ...
+542, 501, 459, 417, 418, ...

-Mean    459.000 ns
+Mean    459 ns
```

## Tests

- New regression cases in `DurationFormatterTests.cs` — including the literal `0.00041667 ms → "417"` repro and the `FormatAdaptive` ns behavior (whole number; sub-1ns escalation).
- Full suite green: **1621** library + **569** adapter.

## Not included (noted follow-on)

`EnvironmentHealthChecker.CheckTimerResolution` still reports `~1 ns` from `Stopwatch.Frequency`, which overstates the ~42 ns *effective* resolution. Separate honesty issue from the display fix; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
