### PR TITLE
fix(serialization): read back NaN/±Infinity in JsonNanConverter & InfinityConverter

### DIFF
--- a/source/Sailfish/Contracts.Public/Serialization/JsonConverters/InfinityConverter.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/JsonConverters/InfinityConverter.cs
@@ -14,8 +14,12 @@ public class InfinityConverter : JsonConverter<double>
         // up before the string handling below.
         if (reader.TokenType == JsonTokenType.Number && reader.TryGetDouble(out var value)) return value;
 
-        var stringValue = reader.GetString()
-                          ?? throw new JsonException("Unable to parse a null token as a double (using custom parser).");
+        // GetString() throws InvalidOperationException on a mismatched (non-string, non-null) token type, so
+        // reject any non-string token with a deterministic JsonException instead.
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException($"Unexpected token '{reader.TokenType}' when reading a double (using custom parser).");
+
+        var stringValue = reader.GetString()!; // a String token always yields a non-null string
 
         return stringValue switch
         {

--- a/source/Sailfish/Contracts.Public/Serialization/JsonConverters/InfinityConverter.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/JsonConverters/InfinityConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,17 +9,30 @@ public class InfinityConverter : JsonConverter<double>
 {
     public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TryGetDouble(out var value)) return value;
+        // Guard on the token type first: Utf8JsonReader.TryGetDouble THROWS on a string token rather than
+        // returning false, and Write emits ±Infinity as strings — so reading those values back used to blow
+        // up before the string handling below.
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetDouble(out var value)) return value;
 
-        return reader.GetString() == double.PositiveInfinity.ToString()
-            ? double.PositiveInfinity
-            : double.NegativeInfinity;
+        var stringValue = reader.GetString()
+                          ?? throw new JsonException("Unable to parse a null token as a double (using custom parser).");
+
+        return stringValue switch
+        {
+            "Inf" => double.PositiveInfinity,
+            "-Inf" => double.NegativeInfinity,
+            _ when double.TryParse(stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => throw new JsonException($"Unable to parse value (using custom parser): {stringValue}")
+        };
     }
 
     public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
     {
-        if (double.IsInfinity(value))
-            writer.WriteStringValue(value.ToString());
+        // Explicit, culture-invariant tokens so Read can always parse them back.
+        if (double.IsPositiveInfinity(value))
+            writer.WriteStringValue("Infinity");
+        else if (double.IsNegativeInfinity(value))
+            writer.WriteStringValue("-Infinity");
         else
             writer.WriteNumberValue(value);
     }

--- a/source/Sailfish/Contracts.Public/Serialization/JsonConverters/JsonNanConverter.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/JsonConverters/JsonNanConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,26 +9,38 @@ public class JsonNanConverter : JsonConverter<double>
 {
     public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TryGetDouble(out var value)) return value;
+        // Numbers come straight through. The token-type guard is essential: Utf8JsonReader.TryGetDouble
+        // THROWS InvalidOperationException ("Cannot get the value of a token type 'String' as a number")
+        // when the current token is a string — it does not return false. Since Write emits NaN / ±Infinity
+        // as JSON strings, calling TryGetDouble on those used to blow up before the string handling below was
+        // ever reached, which made any tracking file containing a NaN/Infinity double unreadable.
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetDouble(out var value)) return value;
 
-        var stringValue = reader.GetString();
-        if (stringValue != null && stringValue.Equals("NaN", StringComparison.InvariantCultureIgnoreCase)) return double.NaN;
+        var stringValue = reader.GetString()
+                          ?? throw new JsonException("Unable to parse a null token as a double (using custom parser).");
 
         return stringValue switch
         {
-            "NaN" => double.NaN,
+            // Historical short forms — kept for backward compatibility with older tracking files.
             "Inf" => double.PositiveInfinity,
             "-Inf" => double.NegativeInfinity,
+            // "NaN", "Infinity" and "-Infinity" (the forms Write emits) are recognized natively by
+            // double.TryParse against the invariant culture.
+            _ when double.TryParse(stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) => parsed,
             _ => throw new JsonException($"Unable to parse value (using custom parser): {stringValue}")
         };
     }
 
     public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
     {
+        // NaN / ±Infinity are not valid JSON numbers, so emit them as strings. Use explicit, culture-invariant
+        // tokens (rather than value.ToString(), which is culture-dependent) so Read can always parse them back.
         if (double.IsNaN(value))
             writer.WriteStringValue("NaN");
-        else if (double.IsInfinity(value))
-            writer.WriteStringValue(value.ToString());
+        else if (double.IsPositiveInfinity(value))
+            writer.WriteStringValue("Infinity");
+        else if (double.IsNegativeInfinity(value))
+            writer.WriteStringValue("-Infinity");
         else
             writer.WriteNumberValue(value);
     }

--- a/source/Sailfish/Contracts.Public/Serialization/JsonConverters/JsonNanConverter.cs
+++ b/source/Sailfish/Contracts.Public/Serialization/JsonConverters/JsonNanConverter.cs
@@ -16,8 +16,14 @@ public class JsonNanConverter : JsonConverter<double>
         // ever reached, which made any tracking file containing a NaN/Infinity double unreadable.
         if (reader.TokenType == JsonTokenType.Number && reader.TryGetDouble(out var value)) return value;
 
-        var stringValue = reader.GetString()
-                          ?? throw new JsonException("Unable to parse a null token as a double (using custom parser).");
+        // Anything that isn't a JSON number must be one of our string encodings. GetString() — like
+        // TryGetDouble — THROWS InvalidOperationException on a mismatched token type (it only returns null for
+        // a Null token), so reject any other token (Null, Boolean, object/array start, ...) with a
+        // deterministic JsonException rather than letting an InvalidOperationException escape.
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException($"Unexpected token '{reader.TokenType}' when reading a double (using custom parser).");
+
+        var stringValue = reader.GetString()!; // a String token always yields a non-null string
 
         return stringValue switch
         {

--- a/source/Tests.Library/Serialization/NanInfinityRoundTripTests.cs
+++ b/source/Tests.Library/Serialization/NanInfinityRoundTripTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Sailfish.Contracts.Public.Serialization;
+using Sailfish.Contracts.Public.Serialization.JsonConverters;
+using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Serialization;
+
+/// <summary>
+///     Regression tests for the NaN/±Infinity round-trip bug: JsonNanConverter / InfinityConverter wrote
+///     these special values as strings but their Read called Utf8JsonReader.TryGetDouble first, which THROWS
+///     on a string token — so any tracking-file double that was NaN/Infinity (e.g. a single-sample Variance)
+///     became unreadable.
+/// </summary>
+public class NanInfinityRoundTripTests
+{
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    [InlineData(12.5)]
+    public void JsonNanConverter_RoundTripsSpecialDoubles_ViaSailfishSerializer(double value)
+    {
+        // SailfishSerializer registers JsonNanConverter for every double, so this is the real persistence path.
+        var json = SailfishSerializer.Serialize(value);
+        var roundTripped = SailfishSerializer.Deserialize<double>(json);
+
+        roundTripped.ShouldBe(value); // Shouldly treats NaN.ShouldBe(NaN) as equal
+    }
+
+    [Fact]
+    public void PerformanceRunResult_WithNanAndInfinityFields_RoundTrips()
+    {
+        var original = new PerformanceRunResultTrackingFormat(
+            displayName: "Sample.Method(N: 1)",
+            mean: double.NaN,
+            median: 10.0,
+            stdDev: double.PositiveInfinity,
+            variance: double.NegativeInfinity,
+            rawExecutionResults: new[] { 10.0, double.NaN, 11.0 },
+            sampleSize: 1,
+            numWarmupIterations: 0,
+            dataWithOutliersRemoved: new[] { 10.0 },
+            upperOutliers: System.Array.Empty<double>(),
+            lowerOutliers: System.Array.Empty<double>(),
+            totalNumOutliers: 0);
+
+        var json = SailfishSerializer.Serialize(original);
+        var rt = SailfishSerializer.Deserialize<PerformanceRunResultTrackingFormat>(json);
+
+        rt.ShouldNotBeNull();
+        double.IsNaN(rt!.Mean).ShouldBeTrue();
+        rt.Median.ShouldBe(10.0);
+        double.IsPositiveInfinity(rt.StdDev).ShouldBeTrue();
+        double.IsNegativeInfinity(rt.Variance).ShouldBeTrue();
+        rt.RawExecutionResults.Length.ShouldBe(3);
+        double.IsNaN(rt.RawExecutionResults[1]).ShouldBeTrue(); // the array path goes through the same converter
+    }
+
+    [Theory]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    [InlineData(3.0)]
+    public void InfinityConverter_RoundTripsInfinity(double value)
+    {
+        var options = new JsonSerializerOptions { Converters = { new InfinityConverter() } };
+
+        var json = JsonSerializer.Serialize(value, options);
+        var roundTripped = JsonSerializer.Deserialize<double>(json, options);
+
+        roundTripped.ShouldBe(value);
+    }
+}

--- a/source/Tests.Library/Serialization/NanInfinityRoundTripTests.cs
+++ b/source/Tests.Library/Serialization/NanInfinityRoundTripTests.cs
@@ -71,4 +71,27 @@ public class NanInfinityRoundTripTests
 
         roundTripped.ShouldBe(value);
     }
+
+    // CodeRabbit (#316): a token that is neither a number nor a string (object/array/boolean/null) must
+    // surface a deterministic JsonException, not the InvalidOperationException that Utf8JsonReader.GetString()
+    // throws on a mismatched token type.
+    [Theory]
+    [InlineData("true")]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    public void JsonNanConverter_ThrowsJsonException_OnNonNumericNonStringToken(string json)
+    {
+        var options = new JsonSerializerOptions { Converters = { new JsonNanConverter() } };
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<double>(json, options));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    public void InfinityConverter_ThrowsJsonException_OnNonNumericNonStringToken(string json)
+    {
+        var options = new JsonSerializerOptions { Converters = { new InfinityConverter() } };
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<double>(json, options));
+    }
 }


### PR DESCRIPTION
Follow-up found while hardening the serialization pipeline (#298). Independent of that stack — branched off `main`.

## Problem
`JsonNanConverter` and `InfinityConverter` write `NaN`/±`Infinity` as JSON **strings**, but their `Read` calls `Utf8JsonReader.TryGetDouble(out …)` **first** — and `TryGetDouble` **throws** `InvalidOperationException` ("Cannot get the value of a token type 'String' as a number") on a string token rather than returning `false`. The string-handling fallback was therefore never reached.

Because `JsonNanConverter` is registered for **every** `double` in `SailfishSerializer`, any tracking file containing a NaN/Infinity double — e.g. a `Mean`/`StdDev`/`Variance` of NaN from a single-sample run — became **unreadable** (the deserialize threw, and with the new resilient parser the whole file is skipped).

A second asymmetry compounded it: `Write` emitted `"Infinity"`/`"-Infinity"` (via `value.ToString()`), but `JsonNanConverter.Read`'s switch only recognized the short forms `"Inf"`/`"-Inf"`, so infinity wouldn't round-trip even past the throw.

## Fix
- **Guard the numeric path** on `reader.TokenType == JsonTokenType.Number` before calling `TryGetDouble`.
- **Parse the string forms** via `double.TryParse(…, InvariantCulture)` (which natively handles `"NaN"`/`"Infinity"`/`"-Infinity"`), keeping explicit `"Inf"`/`"-Inf"` for backward compatibility with older tracking files.
- **Make `Write` culture-invariant** — emit explicit `"NaN"`/`"Infinity"`/`"-Infinity"` instead of the culture-dependent `value.ToString()`, so the representation is stable and symmetric with `Read`.

## Tests
`Tests.Library/Serialization/NanInfinityRoundTripTests.cs`:
- `NaN` / `+Infinity` / `-Infinity` (and a normal value) round-trip through `SailfishSerializer` — the real default-converter path — for a bare `double`;
- a `PerformanceRunResultTrackingFormat` with NaN/Infinity scalar fields **and** a NaN array element round-trips;
- `InfinityConverter` round-trips ±Infinity directly.
- ✅ Full `Tests.Library` (1667) passes on **net9.0 and net10.0**; solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced robustness of JSON serialization for special numeric values (NaN, Infinity) with improved error handling and culture-invariant formatting.

* **Tests**
  * Added test coverage validating round-trip serialization of special numeric values in serialization formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulegradie/Sailfish/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->