### PR TITLE
fix(diagnostics): report effective (probed) timer resolution

### DIFF
--- a/source/Sailfish/Diagnostics/Environment/EnvironmentHealthChecker.cs
+++ b/source/Sailfish/Diagnostics/Environment/EnvironmentHealthChecker.cs
@@ -209,7 +209,25 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
             // 1) High-resolution performance counter (Stopwatch)
             var freq = Stopwatch.Frequency; // ticks per second
             var isHighRes = Stopwatch.IsHighResolution;
-            var resolutionNs = 1_000_000_000.0 / freq;
+            var reportedResolutionNs = 1_000_000_000.0 / freq; // what the API advertises: one tick
+
+            // 1b) EFFECTIVE resolution. Stopwatch.Frequency only states the tick UNIT, not how often
+            // the counter actually advances. On several platforms the advertised value is far finer
+            // than reality — e.g. Apple Silicon reports Frequency == 1e9 ("1 ns/tick") while the
+            // hardware timebase only advances every ~41.7 ns (24 MHz). Probe the smallest non-zero
+            // GetTimestamp() delta to recover the true granularity. We take the MIN because scheduler
+            // hiccups only ever inflate a delta and so cannot mask the real quantum.
+            double effectiveResolutionNs;
+            try
+            {
+                effectiveResolutionNs = MeasureEffectiveResolutionNs(freq);
+            }
+            catch
+            {
+                effectiveResolutionNs = double.NaN; // best effort only
+            }
+
+            var haveEffective = !double.IsNaN(effectiveResolutionNs) && effectiveResolutionNs > 0;
 
             // 2) Effective OS scheduler quantization for sleeps (cross‑platform)
             // Measure median elapsed for Thread.Sleep(1) across a small sample to infer the scheduler tick.
@@ -239,10 +257,17 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
                 sleepMedianMs = double.NaN; // best effort only
             }
 
-            var timerDetails = isHighRes
-                ? $"High-resolution timer: ~{resolutionNs:F0} ns"
-                : $"Timer resolution ~{resolutionNs:F0} ns (low resolution)";
+            // The gate (and the user's mental model) should reflect what the timer can ACTUALLY
+            // resolve, not what it advertises. Fall back to the reported value if the probe failed.
+            var gateResolutionNs = haveEffective ? effectiveResolutionNs : reportedResolutionNs;
 
+            var timerKind = isHighRes ? "High-resolution timer" : "Low-resolution timer";
+            var resolutionText = haveEffective
+                ? $"reported ~{reportedResolutionNs:F0} ns, effective ~{effectiveResolutionNs:F0} ns"
+                : $"reported ~{reportedResolutionNs:F0} ns";
+            var timerDetails = isHighRes
+                ? $"{timerKind}: {resolutionText}"
+                : $"{timerKind}: {resolutionText} (low resolution)";
 
             var sleepDetails = double.IsNaN(sleepMedianMs)
                 ? "Sleep(1) median: n/a"
@@ -250,19 +275,68 @@ public class EnvironmentHealthChecker : IEnvironmentHealthChecker
 
             var details = $"{timerDetails}; {sleepDetails}";
 
-            // Preserve original PASS/WARN logic based on Stopwatch; include guidance referencing sleep granularity
-            if (isHighRes && resolutionNs <= 200) // ~<=0.2us
+            // PASS when the timer can actually resolve sub-µs work (~<=0.2µs of EFFECTIVE granularity).
+            if (isHighRes && gateResolutionNs <= 200)
             {
                 return new("Timer", HealthStatus.Pass, details);
             }
 
-            var recommendation = "Ensure high-resolution timers; sub-tick sleeps will quantize to the OS scheduler tick";
+            // When the effective granularity is far coarser than advertised, the actionable fix is to
+            // raise the work per measurement rather than chase a finer timer.
+            var recommendation = haveEffective && effectiveResolutionNs > reportedResolutionNs * 4
+                ? "Effective timer granularity is much coarser than advertised; for sub-µs operations raise the work per measurement (OperationsPerInvoke / batch the call) so each sample sits well above the timer floor"
+                : "Ensure high-resolution timers; sub-tick sleeps will quantize to the OS scheduler tick";
             return new("Timer", HealthStatus.Warn, details, recommendation);
         }
         catch (Exception ex)
         {
             return new("Timer", HealthStatus.Unknown, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Probes the smallest non-zero <see cref="Stopwatch.GetTimestamp"/> delta to estimate the timer's
+    /// TRUE granularity, which <see cref="Stopwatch.Frequency"/> does not reveal (it only states the tick
+    /// unit). Tight-loops sampling deltas, ignoring zeros (counter hasn't advanced yet), until enough
+    /// non-zero deltas are gathered or the iteration cap is hit.
+    /// </summary>
+    private static double MeasureEffectiveResolutionNs(long freq)
+    {
+        const int targetNonZeroSamples = 200;
+        const int maxIterations = 100_000;
+        var deltas = new List<long>(targetNonZeroSamples);
+        var previous = Stopwatch.GetTimestamp(); // first reading is discarded (no delta recorded for it)
+        var nonZero = 0;
+        for (var i = 0; i < maxIterations && nonZero < targetNonZeroSamples; i++)
+        {
+            var now = Stopwatch.GetTimestamp();
+            var delta = now - previous;
+            previous = now;
+            if (delta <= 0) continue; // 0 = sub-tick (counter unchanged); <0 guards against any wrap
+            deltas.Add(delta);
+            nonZero++;
+        }
+
+        return EffectiveResolutionNsFromTickDeltas(deltas, freq);
+    }
+
+    /// <summary>
+    /// Pure, deterministic core of the effective-resolution probe (exposed for unit tests). The
+    /// smallest non-zero tick delta is the observed quantum; converting via 1e9/freq yields nanoseconds.
+    /// Returns <see cref="double.NaN"/> when no advance was observed so callers can fall back to the
+    /// reported resolution.
+    /// </summary>
+    internal static double EffectiveResolutionNsFromTickDeltas(IReadOnlyList<long> deltaTicks, long stopwatchFrequency)
+    {
+        if (deltaTicks is null || deltaTicks.Count == 0) return double.NaN;
+        var nsPerTick = 1_000_000_000.0 / Math.Max(1, stopwatchFrequency);
+        var minNonZero = long.MaxValue;
+        foreach (var delta in deltaTicks)
+        {
+            if (delta > 0 && delta < minNonZero) minNonZero = delta;
+        }
+
+        return minNonZero == long.MaxValue ? double.NaN : minNonZero * nsPerTick;
     }
 
     private static HealthCheckEntry CheckOsPowerHints()

--- a/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerTests.cs
+++ b/source/Tests.Library/Diagnostics/Environment/EnvironmentHealthCheckerTests.cs
@@ -243,6 +243,9 @@ public class EnvironmentHealthCheckerTests
         timer.ShouldNotBeNull();
         timer.Status.ShouldBeOneOf(HealthStatus.Pass, HealthStatus.Warn);
         timer.Details.ShouldNotBeNullOrWhiteSpace();
+        // Details now state the advertised resolution explicitly (the probed "effective ~N ns" value
+        // is appended whenever the live probe observed the counter advance, which it does on real timers).
+        timer.Details.ShouldContain("reported ~");
     }
 
     [Fact]

--- a/source/Tests.Library/Diagnostics/Environment/TimerResolutionProbeTests.cs
+++ b/source/Tests.Library/Diagnostics/Environment/TimerResolutionProbeTests.cs
@@ -1,0 +1,60 @@
+using Sailfish.Diagnostics.Environment;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Diagnostics.Environment;
+
+/// <summary>
+/// Deterministic coverage for the effective-resolution probe. The live sampler
+/// (<c>MeasureEffectiveResolutionNs</c>) is hardware-dependent, so the testable seam is the pure
+/// reducer <see cref="EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas"/> fed synthetic
+/// tick deltas.
+/// </summary>
+public class TimerResolutionProbeTests
+{
+    private const long GHz = 1_000_000_000; // Stopwatch.Frequency on macOS/Linux: 1 tick == 1 ns
+    private const long TenMHz = 10_000_000;  // typical Windows QPC: 1 tick == 100 ns
+
+    [Fact]
+    public void EffectiveResolution_takes_the_smallest_nonzero_delta()
+    {
+        // Apple-Silicon-shaped sample: Frequency advertises 1 ns/tick, but the counter advances in
+        // ~42-tick jumps and sub-tick reads show 0. The observed quantum is 42 ns, not the reported 1 ns.
+        var deltas = new long[] { 0, 0, 42, 0, 42, 84, 0, 42 };
+        EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas(deltas, GHz).ShouldBe(42.0, 1e-9);
+    }
+
+    [Fact]
+    public void EffectiveResolution_ignores_upward_outliers_from_scheduler_hiccups()
+    {
+        // A context switch inflates one delta to a million ticks; taking the MIN must ignore it.
+        var deltas = new long[] { 41, 42, 1_000_000, 41, 42 };
+        EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas(deltas, GHz).ShouldBe(41.0, 1e-9);
+    }
+
+    [Fact]
+    public void EffectiveResolution_scales_by_frequency()
+    {
+        // On a 10 MHz counter each tick is 100 ns, so a 1-tick min delta => 100 ns effective resolution.
+        var deltas = new long[] { 1, 2, 3, 1 };
+        EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas(deltas, TenMHz).ShouldBe(100.0, 1e-9);
+    }
+
+    [Fact]
+    public void EffectiveResolution_equals_reported_when_counter_advances_every_tick()
+    {
+        // A genuinely fine timer advances one tick at a time => effective == reported (1 ns at 1 GHz).
+        var deltas = new long[] { 1, 1, 1, 1 };
+        EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas(deltas, GHz).ShouldBe(1.0, 1e-9);
+    }
+
+    [Fact]
+    public void EffectiveResolution_is_NaN_when_no_advance_is_observed()
+    {
+        // All sub-tick reads (or no samples at all) => caller falls back to the reported value.
+        double.IsNaN(EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas(new long[] { 0, 0, 0 }, GHz))
+            .ShouldBeTrue();
+        double.IsNaN(EnvironmentHealthChecker.EffectiveResolutionNsFromTickDeltas(new long[0], GHz))
+            .ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## What & why

`EnvironmentHealthChecker.CheckTimerResolution` reported timer resolution as `1e9 / Stopwatch.Frequency`. On macOS/Linux (incl. Apple Silicon) `Stopwatch.Frequency == 1e9`, so it printed **"~1 ns"** — but that's the tick *unit*, not how often the counter actually advances. The real hardware timebase is far coarser (e.g. ~41.7 ns on Apple Silicon's 24 MHz counter), so the health check overstated timer quality by ~40×.

This is the follow-on explicitly scoped **out** of #315 (nanosecond display rounding).

## The change

- **Probe the effective resolution**: sample the smallest non-zero `Stopwatch.GetTimestamp()` delta. `MIN` is used deliberately — scheduler hiccups only ever *inflate* a delta, so they can't mask the true quantum. Convert via `1e9 / Frequency`.
- **Report both** advertised and observed, e.g.:
  ```
  High-resolution timer: reported ~1 ns, effective ~41 ns; Sleep(1) median ≈ 1.0 ms
  ```
- **Gate on the honest number**: PASS/WARN now keys off the *effective* resolution (falling back to reported if the probe fails). A genuinely fine timer where reported == effective is unaffected; a timer that's coarse *in practice* now correctly warns.
- **Actionable recommendation**: when effective granularity is much coarser than advertised, the WARN guidance points at raising work-per-measurement (`OperationsPerInvoke` / batching) so each sample sits above the timer floor — rather than chasing a finer timer.
- The existing `Sleep(1)` scheduler-quantization probe is **unchanged**.

### Verified on this machine (Apple Silicon)

```
freq=1,000,000,000  non-zero samples=200  min-delta-ticks=41
DETAILS -> High-resolution timer: reported ~1 ns, effective ~41 ns
gate<=200ns PASS? True
```

So the misleading "~1 ns" is replaced by the truthful "reported ~1 ns, effective ~41 ns", and status stays PASS (41 ns is genuinely fine — no false alarm).

## Tests

- New `TimerResolutionProbeTests` — deterministic coverage of the pure reducer `EffectiveResolutionNsFromTickDeltas` over synthetic tick deltas: smallest-non-zero selection, robustness to upward outliers, frequency scaling, reported==effective on fine timers, and NaN fallback when no advance is observed.
- Augmented the existing real-probe `Timer_ReturnsValidStatus` to assert the new wording wires through.
- Full suite green: **1664** library + **569** adapter.

## Deliberately not included

A workload-relative warning (effective resolution as a fraction of the measured sample magnitude) was considered but **not** added here: `CheckTimerResolution` is an environment-level check with no workload context, and that signal belongs in per-test validation rather than the environment report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
