### PR TITLE
Honor `dotnet test --filter` and surface comparison groups as Traits

### DIFF
--- a/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
+++ b/source/Sailfish.TestAdapter/Discovery/TestCaseItemCreator.cs
@@ -90,6 +90,14 @@ internal static class TestCaseItemCreator
         {
             testCase.SetPropertyValue(SailfishManagedProperty.SailfishComparisonGroupProperty, comparisonGroup);
 
+            // Surface an EXPLICIT comparison group as a Trait so it appears in Test Explorer and is filterable
+            // via `dotnet test --filter "ComparisonGroup=<name>"`. Implicit (class-wide) groups are skipped:
+            // they're already grouped by the class hierarchy and the synthetic prefix isn't user-facing.
+            if (!comparisonGroup.StartsWith(DiscoveryAnalysisMethods.ImplicitComparisonGroupPrefix, StringComparison.Ordinal))
+            {
+                testCase.Traits.Add(new Trait("ComparisonGroup", comparisonGroup));
+            }
+
             // Carry the baseline flag so the comparison reporter names this method the baseline for
             // every other method in its group. Only the baseline role is set; contenders are left unset.
             if (isBaseline)

--- a/source/Sailfish.TestAdapter/Execution/TestCaseFilter.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestCaseFilter.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Sailfish.TestAdapter.TestProperties;
+
+namespace Sailfish.TestAdapter.Execution;
+
+/// <summary>
+///     Applies the VSTest <c>--filter</c> expression (from <see cref="IRunContext.GetTestCaseFilter" />) to a set
+///     of discovered Sailfish test cases. Previously the adapter accepted <see cref="IRunContext" /> but never
+///     consulted it, so <c>dotnet test --filter</c> (and Test Explorer's filter box) silently ran everything.
+/// </summary>
+/// <remarks>
+///     Supported filter properties — usable as <c>dotnet test --filter "Method=Foo"</c>,
+///     <c>--filter "FullyQualifiedName~MyClass"</c>, <c>--filter "ComparisonGroup=Sort"</c>, etc.:
+///     <list type="bullet">
+///         <item><c>FullyQualifiedName</c> / <c>DisplayName</c> — the VSTest built-ins;</item>
+///         <item><c>Namespace</c> / <c>Class</c> / <c>Method</c> — the Sailfish type and method;</item>
+///         <item><c>ComparisonGroup</c> — the cross-method comparison group.</item>
+///     </list>
+///     Comparison group is also surfaced as a <see cref="Trait" /> at discovery, so it shows in Test Explorer.
+/// </remarks>
+internal static class TestCaseFilter
+{
+    /// <summary>How to read each supported filter property's value from a test case.</summary>
+    private static readonly Dictionary<string, Func<TestCase, string?>> ValueProviders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["FullyQualifiedName"] = tc => tc.FullyQualifiedName,
+        ["DisplayName"] = tc => tc.DisplayName,
+        ["Namespace"] = NamespaceOf,
+        ["Class"] = ClassNameOf,
+        ["Method"] = tc => tc.GetPropertyValue<string>(SailfishManagedProperty.SailfishMethodFilterProperty, null),
+        ["ComparisonGroup"] = tc => tc.GetPropertyValue<string>(SailfishManagedProperty.SailfishComparisonGroupProperty, null)
+    };
+
+    /// <summary>The TestProperty backing each supported filter name (lets the platform parse/validate the filter).</summary>
+    private static readonly Dictionary<string, TestProperty> PropertyMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["FullyQualifiedName"] = TestCaseProperties.FullyQualifiedName,
+        ["DisplayName"] = TestCaseProperties.DisplayName,
+        ["Namespace"] = TestProperty.Register("Sailfish.Filter.Namespace", "Namespace", typeof(string), typeof(TestCaseFilter)),
+        ["Class"] = TestProperty.Register("Sailfish.Filter.Class", "Class", typeof(string), typeof(TestCaseFilter)),
+        ["Method"] = TestProperty.Register("Sailfish.Filter.Method", "Method", typeof(string), typeof(TestCaseFilter)),
+        ["ComparisonGroup"] = TestProperty.Register("Sailfish.Filter.ComparisonGroup", "ComparisonGroup", typeof(string), typeof(TestCaseFilter))
+    };
+
+    private static readonly string[] SupportedProperties = ValueProviders.Keys.ToArray();
+
+    /// <summary>
+    ///     Returns the test cases that satisfy the run's filter. If there is no filter (e.g. the user selected
+    ///     cases explicitly in the IDE, or ran without <c>--filter</c>) all cases are returned. A malformed filter
+    ///     is logged and treated as "no filter" so a typo never silently drops the whole run.
+    /// </summary>
+    public static List<TestCase> Filter(List<TestCase> testCases, IRunContext? runContext, IMessageLogger? logger)
+    {
+        if (runContext is null || testCases.Count == 0) return testCases;
+
+        ITestCaseFilterExpression? filterExpression;
+        try
+        {
+            filterExpression = runContext.GetTestCaseFilter(SupportedProperties, name => PropertyMap.GetValueOrDefault(name));
+        }
+        catch (TestPlatformFormatException ex)
+        {
+            logger?.SendMessage(TestMessageLevel.Warning,
+                $"Ignoring an invalid Sailfish test filter and running all discovered tests. {ex.Message}");
+            return testCases;
+        }
+
+        if (filterExpression is null) return testCases;
+
+        var matched = testCases.Where(testCase => filterExpression.MatchTestCase(testCase, name => GetValue(testCase, name))).ToList();
+        logger?.SendMessage(TestMessageLevel.Informational,
+            $"Sailfish test filter '{filterExpression.TestCaseFilterValue}' matched {matched.Count} of {testCases.Count} test case(s).");
+        return matched;
+    }
+
+    private static object? GetValue(TestCase testCase, string propertyName)
+        => ValueProviders.TryGetValue(propertyName, out var read) ? read(testCase) : null;
+
+    private static string? NamespaceOf(TestCase testCase)
+    {
+        var fullName = testCase.GetPropertyValue<string>(SailfishManagedProperty.SailfishTypeProperty, null);
+        var lastDot = fullName?.LastIndexOf('.') ?? -1;
+        return lastDot > 0 ? fullName![..lastDot] : null;
+    }
+
+    private static string? ClassNameOf(TestCase testCase)
+    {
+        var fullName = testCase.GetPropertyValue<string>(SailfishManagedProperty.SailfishTypeProperty, null);
+        if (string.IsNullOrEmpty(fullName)) return null;
+        var lastDot = fullName.LastIndexOf('.');
+        return lastDot >= 0 ? fullName[(lastDot + 1)..] : fullName;
+    }
+}

--- a/source/Sailfish.TestAdapter/TestExecutor.cs
+++ b/source/Sailfish.TestAdapter/TestExecutor.cs
@@ -63,7 +63,9 @@ public class TestExecutor : ITestExecutor
         var tests = testCases?.ToList() ?? throw new TestAdapterException("Tests was null in the test case list!");
         if (runContext is null || frameworkHandle is null) throw new TestAdapterException("Wow more nulls");
 
-        ExecuteTests(tests, frameworkHandle);
+        // Honor `dotnet test --filter` / Test Explorer's filter box (previously runContext was ignored).
+        var filtered = TestCaseFilter.Filter(tests, runContext, frameworkHandle);
+        ExecuteTests(filtered, frameworkHandle);
     }
 
     public void Cancel()

--- a/source/Tests.TestAdapter/Execution/TestCaseFilterTests.cs
+++ b/source/Tests.TestAdapter/Execution/TestCaseFilterTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Sailfish.TestAdapter.Execution;
+using Sailfish.TestAdapter.TestProperties;
+using Shouldly;
+using Xunit;
+
+namespace Tests.TestAdapter.Execution;
+
+public class TestCaseFilterTests
+{
+    private static readonly Uri ExecutorUri = new("executor://sailfishexecutor/v1");
+
+    private static TestCase MakeCase(string method, string fullTypeName = "My.Ns.MyClass", string? comparisonGroup = null)
+    {
+        var testCase = new TestCase($"{fullTypeName}.{method}", ExecutorUri, "source.dll") { DisplayName = method };
+        testCase.SetPropertyValue(SailfishManagedProperty.SailfishTypeProperty, fullTypeName);
+        testCase.SetPropertyValue(SailfishManagedProperty.SailfishMethodFilterProperty, method);
+        if (comparisonGroup is not null)
+            testCase.SetPropertyValue(SailfishManagedProperty.SailfishComparisonGroupProperty, comparisonGroup);
+        return testCase;
+    }
+
+    [Fact]
+    public void Filter_WithNullRunContext_ReturnsAllUnchanged()
+    {
+        var tests = new List<TestCase> { MakeCase("A"), MakeCase("B") };
+        TestCaseFilter.Filter(tests, null, Substitute.For<IMessageLogger>()).ShouldBe(tests);
+    }
+
+    [Fact]
+    public void Filter_WhenPlatformSuppliesNoFilter_ReturnsAll()
+    {
+        var tests = new List<TestCase> { MakeCase("A"), MakeCase("B") };
+        var runContext = Substitute.For<IRunContext>();
+        runContext.GetTestCaseFilter(Arg.Any<IEnumerable<string>>(), Arg.Any<Func<string, TestProperty>>())
+            .Returns((ITestCaseFilterExpression?)null); // the platform returns null when no --filter is supplied
+        TestCaseFilter.Filter(tests, runContext, Substitute.For<IMessageLogger>()).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Filter_AppliesTheFilterExpression()
+    {
+        var keep = MakeCase("KeepMe");
+        var drop = MakeCase("DropMe");
+        var runContext = Substitute.For<IRunContext>();
+        var expression = Substitute.For<ITestCaseFilterExpression>();
+        runContext.GetTestCaseFilter(Arg.Any<IEnumerable<string>>(), Arg.Any<Func<string, TestProperty>>()).Returns(expression);
+        expression.MatchTestCase(Arg.Any<TestCase>(), Arg.Any<Func<string, object>>())
+            .Returns(call => ((TestCase)call[0]).FullyQualifiedName.Contains("Keep"));
+
+        var result = TestCaseFilter.Filter(new List<TestCase> { keep, drop }, runContext, Substitute.For<IMessageLogger>());
+
+        result.ShouldHaveSingleItem().FullyQualifiedName.ShouldBe(keep.FullyQualifiedName);
+    }
+
+    [Fact]
+    public void Filter_WithMalformedFilter_LogsWarningAndRunsEverything()
+    {
+        var tests = new List<TestCase> { MakeCase("A"), MakeCase("B") };
+        var runContext = Substitute.For<IRunContext>();
+        runContext.GetTestCaseFilter(Arg.Any<IEnumerable<string>>(), Arg.Any<Func<string, TestProperty>>())
+            .Throws(new TestPlatformFormatException("bad filter"));
+        var logger = Substitute.For<IMessageLogger>();
+
+        var result = TestCaseFilter.Filter(tests, runContext, logger);
+
+        result.Count.ShouldBe(2);
+        logger.Received().SendMessage(TestMessageLevel.Warning, Arg.Is<string>(m => m.Contains("invalid")));
+    }
+
+    [Fact]
+    public void Filter_ExposesSailfishPropertiesToTheFilterExpression()
+    {
+        var testCase = MakeCase("MyMethod", "My.Ns.MyClass", comparisonGroup: "Sort");
+        Func<string, object>? valueProvider = null;
+        var runContext = Substitute.For<IRunContext>();
+        var expression = Substitute.For<ITestCaseFilterExpression>();
+        runContext.GetTestCaseFilter(Arg.Any<IEnumerable<string>>(), Arg.Any<Func<string, TestProperty>>()).Returns(expression);
+        expression.MatchTestCase(Arg.Any<TestCase>(), Arg.Any<Func<string, object>>())
+            .Returns(call =>
+            {
+                valueProvider = (Func<string, object>)call[1];
+                return true;
+            });
+
+        TestCaseFilter.Filter(new List<TestCase> { testCase }, runContext, Substitute.For<IMessageLogger>());
+
+        valueProvider.ShouldNotBeNull();
+        valueProvider!("FullyQualifiedName").ShouldBe("My.Ns.MyClass.MyMethod");
+        valueProvider("Method").ShouldBe("MyMethod");
+        valueProvider("ComparisonGroup").ShouldBe("Sort");
+        valueProvider("Namespace").ShouldBe("My.Ns");
+        valueProvider("Class").ShouldBe("MyClass");
+    }
+}

--- a/source/Tests.TestAdapter/TestCaseItemCreatorTests.cs
+++ b/source/Tests.TestAdapter/TestCaseItemCreatorTests.cs
@@ -126,6 +126,22 @@ public class TestCaseItemCreatorTests
     }
 
     [Fact]
+    public void AssembleTestCases_WithExplicitComparisonGroup_ShouldAddComparisonGroupTrait()
+    {
+        // Arrange
+        var classMetaData = CreateClassMetaDataWithComparison();
+        var hashAlgorithm = Substitute.For<IHashAlgorithm>();
+        hashAlgorithm.GuidFromString(Arg.Any<string>()).Returns(Guid.NewGuid());
+
+        // Act
+        var testCases = TestCaseItemCreator.AssembleTestCases(classMetaData, "source.dll", hashAlgorithm).ToList();
+
+        // Assert — the explicit group is surfaced as a Trait so it shows in Test Explorer and is filterable.
+        var testCase = testCases.First();
+        testCase.Traits.ShouldContain(trait => trait.Name == "ComparisonGroup" && trait.Value == "TestGroup");
+    }
+
+    [Fact]
     public void AssembleTestCases_WithEmptyMethods_ShouldReturnEmptyList()
     {
         // Arrange

--- a/source/Tests.TestAdapter/TestExecutionFixture.cs
+++ b/source/Tests.TestAdapter/TestExecutionFixture.cs
@@ -81,6 +81,7 @@ public class TestExecutionFixture
     public void StartupExceptionsAreHandled()
     {
         var context = Substitute.For<IRunContext>();
+        context.GetTestCaseFilter(default!, default!).ReturnsForAnyArgs((ITestCaseFilterExpression?)null); // no --filter → run all
 
         var execution = Substitute.For<ITestExecution>();
         execution


### PR DESCRIPTION
## What

The Sailfish adapter accepted `IRunContext` but **never consulted it**, so `dotnet test --filter` (and Test Explorer's filter box) silently ran *every* benchmark regardless of the filter. This wires up VSTest filtering.

## How

- **`TestCaseFilter`** (new) honors `runContext.GetTestCaseFilter(...)` and is applied in `TestExecutor.RunTests` before execution. Supported filter properties:
  - `FullyQualifiedName`, `DisplayName` — the VSTest built-ins
  - `Namespace`, `Class`, `Method` — the Sailfish type/method
  - `ComparisonGroup` — the cross-method comparison group
  - A **malformed filter is logged and treated as "no filter"**, so a typo never silently drops the whole run.
- **Traits at discovery**: an *explicit* comparison group is now emitted as a `ComparisonGroup` Trait, so it shows in Test Explorer and is filterable. Implicit (class-wide) groups are skipped — they're already grouped by the class hierarchy and the synthetic prefix isn't user-facing.

## Why

- `dotnet test --filter "FullyQualifiedName~MyClass"` / `--filter "Method=Foo"` now work — table stakes for a test adapter.
- Unlocks **CI sharding** (split benchmarks across agents) and IDE category filtering.
- A prerequisite for the performance regression-gate work.

## Verification

- **Unit**: `TestCaseFilterTests` covers honoring the filter, the no-filter and malformed-filter paths, the match application, and that the value provider resolves every supported property (FQN/DisplayName/Namespace/Class/Method/ComparisonGroup). New discovery test asserts the `ComparisonGroup` trait.
- **End-to-end** against `PerformanceTests` (which references the adapter): `--filter "FullyQualifiedName~zzz"` and the custom `--filter "Method=zzz"` both correctly match **0** tests (before this change the filter was ignored and all benchmarks ran). The `Method` case is decisive — it only resolves through the new `GetTestCaseFilter` support.
- Adapter suite **166/166** green on net9.0 + net10.0; full solution builds clean.

## Notes / follow-ups

- A user-facing category attribute (e.g. `[SailfishCategory("…")]`) could add arbitrary `TestCategory` traits later; for now the filter exposes the metadata that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tests can now be filtered via `dotnet test --filter`, supporting comparison groups and other test properties in Test Explorer and command line.

* **Tests**
  * Added test coverage for test filtering functionality and comparison group trait mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->