### PR TITLE
Attach each test case's Sailfish report as a downloadable artifact

### DIFF
--- a/source/Sailfish.TestAdapter/Handlers/FrameworkHandlers/FrameworkTestCaseEndNotification.cs
+++ b/source/Sailfish.TestAdapter/Handlers/FrameworkHandlers/FrameworkTestCaseEndNotification.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Sailfish.Diagnostics.Environment;
@@ -8,7 +9,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Sailfish.Contracts.Public.Models;
 using Sailfish.Execution;
+using Sailfish.Presentation;
 using Sailfish.TestAdapter.Display.VSTestFramework;
 
 namespace Sailfish.TestAdapter.Handlers.FrameworkHandlers;
@@ -55,8 +58,10 @@ internal record FrameworkTestCaseEndNotification : INotification
 internal class FrameworkTestCaseEndNotificationHandler : INotificationHandler<FrameworkTestCaseEndNotification>
 {
     private readonly Dictionary<StatusCode, TestOutcome> _outcomeMap = new() { { StatusCode.Success, TestOutcome.Passed }, { StatusCode.Failure, TestOutcome.Failed } };
+    private static readonly Uri SailfishReportUri = new("sailfish://report/v1");
     private readonly ITestFrameworkWriter _testFrameworkWriter;
     private readonly IEnvironmentHealthReportProvider? _healthProvider;
+    private readonly IRunSettings? _runSettings;
 
 
     public FrameworkTestCaseEndNotificationHandler(ITestFrameworkWriter testFrameworkWriter)
@@ -67,6 +72,14 @@ internal class FrameworkTestCaseEndNotificationHandler : INotificationHandler<Fr
     {
         _testFrameworkWriter = testFrameworkWriter;
         _healthProvider = healthProvider;
+    }
+
+    // Preferred ctor: the run settings let us write each case's report to disk and attach it (DI picks the
+    // longest satisfiable ctor). When run settings aren't available the handler still works, just without attachments.
+    public FrameworkTestCaseEndNotificationHandler(ITestFrameworkWriter testFrameworkWriter, IEnvironmentHealthReportProvider healthProvider, IRunSettings runSettings)
+        : this(testFrameworkWriter, healthProvider)
+    {
+        _runSettings = runSettings;
     }
 
 
@@ -95,8 +108,50 @@ internal class FrameworkTestCaseEndNotificationHandler : INotificationHandler<Fr
             notification.Duration,
             outputMessage);
 
+        TryAttachReport(testResult, notification.TestCase, outputMessage);
+
         _testFrameworkWriter.RecordEnd(notification.TestCase, outcome);
         _testFrameworkWriter.RecordResult(testResult);
+    }
+
+    /// <summary>
+    ///     Writes the test case's formatted Sailfish report to a markdown file and attaches it to the result, so
+    ///     it surfaces as a downloadable artifact in the IDE result pane and in .trx / CI runs — not just as inline
+    ///     console output. Named with the per-run session id so it correlates with the other TestSession_* files.
+    ///     Best-effort: a write/attach failure never fails the test.
+    /// </summary>
+    private void TryAttachReport(TestResult testResult, TestCase testCase, string report)
+    {
+        if (_runSettings is null || string.IsNullOrWhiteSpace(report)) return;
+
+        try
+        {
+            var reportsDirectory = Path.Combine(_runSettings.LocalOutputDirectory, "test_reports");
+            var sessionId = DefaultFileSettings.SessionId(_runSettings.TimeStamp);
+            var name = SanitizeFileName(testCase.DisplayName ?? testCase.FullyQualifiedName);
+            var path = Path.Combine(reportsDirectory, $"TestSession_{sessionId}_{name}.md");
+
+            // Runtime adapter IO. RS1035 targets analyzer assemblies; this project only references Roslyn for
+            // discovery parsing, so file IO is suppressed here exactly as elsewhere in the adapter.
+#pragma warning disable RS1035
+            Directory.CreateDirectory(reportsDirectory);
+            File.WriteAllText(path, report);
+#pragma warning restore RS1035
+
+            var attachmentSet = new AttachmentSet(SailfishReportUri, "Sailfish report");
+            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri(path), $"{testCase.DisplayName} (Sailfish report)"));
+            testResult.Attachments.Add(attachmentSet);
+        }
+        catch
+        {
+            // Best-effort: never fail a test because its report couldn't be written or attached.
+        }
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        foreach (var invalid in Path.GetInvalidFileNameChars()) name = name.Replace(invalid, '_');
+        return name.Length > 120 ? name[..120] : name;
     }
 
     private static string AppendEnvironmentHealthSummary(string testOutputWindowMessage, EnvironmentHealthReport report)

--- a/source/Tests.TestAdapter/Handlers/FrameworkHandlers/FrameworkTestCaseEndNotificationHandlerTests.cs
+++ b/source/Tests.TestAdapter/Handlers/FrameworkHandlers/FrameworkTestCaseEndNotificationHandlerTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NSubstitute;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Execution;
+using Sailfish.TestAdapter.Display.VSTestFramework;
+using Sailfish.TestAdapter.Handlers.FrameworkHandlers;
+using Shouldly;
+using Xunit;
+
+namespace Tests.TestAdapter.Handlers.FrameworkHandlers;
+
+public class FrameworkTestCaseEndNotificationHandlerTests
+{
+    private static readonly Uri ExecutorUri = new("executor://sailfishexecutor/v1");
+
+    private static (ITestFrameworkWriter Writer, Func<TestResult?> Recorded) WriterCapturingResult()
+    {
+        TestResult? recorded = null;
+        var writer = Substitute.For<ITestFrameworkWriter>();
+        writer.When(w => w.RecordResult(Arg.Any<TestResult>())).Do(call => recorded = call.Arg<TestResult>());
+        return (writer, () => recorded);
+    }
+
+    private static FrameworkTestCaseEndNotification SuccessNotification(string report)
+    {
+        var testCase = new TestCase("My.Ns.MyClass.MyMethod", ExecutorUri, "source.dll") { DisplayName = "MyMethod" };
+        return new FrameworkTestCaseEndNotification(report, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, 1.0, testCase, StatusCode.Success, null);
+    }
+
+    [Fact]
+    public async Task Handle_AttachesTheFormattedReportAsAFileOnTheResult()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "sf_attach_" + Guid.NewGuid().ToString("N")[..8]);
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.LocalOutputDirectory.Returns(tempDir);
+        runSettings.TimeStamp.Returns(new DateTime(2026, 6, 8, 12, 0, 0, DateTimeKind.Utc));
+
+        var (writer, recorded) = WriterCapturingResult();
+        var handler = new FrameworkTestCaseEndNotificationHandler(writer, Substitute.For<IEnvironmentHealthReportProvider>(), runSettings);
+
+        try
+        {
+            await handler.Handle(SuccessNotification("Descriptive Statistics\n| Mean | 1.0 |"), CancellationToken.None);
+
+            var result = recorded();
+            result.ShouldNotBeNull();
+            var attachment = result!.Attachments.ShouldHaveSingleItem().Attachments.ShouldHaveSingleItem();
+            File.Exists(attachment.Uri.LocalPath).ShouldBeTrue();
+            File.ReadAllText(attachment.Uri.LocalPath).ShouldContain("Descriptive Statistics");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public async Task Handle_WithoutRunSettings_RecordsResultWithNoAttachment()
+    {
+        var (writer, recorded) = WriterCapturingResult();
+        // 1-arg ctor → no run settings → report can't be written, so the result is recorded without an attachment.
+        var handler = new FrameworkTestCaseEndNotificationHandler(writer);
+
+        await handler.Handle(SuccessNotification("some report"), CancellationToken.None);
+
+        var result = recorded();
+        result.ShouldNotBeNull();
+        result!.Attachments.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## What

Each per-case `TestResult` now carries the formatted Sailfish report (descriptive stats, distribution plot, and any cross-method comparison) as a **markdown attachment**, so it surfaces in the IDE result pane and flows into `.trx` / CI artifacts as a **downloadable file** — not just inline console output.

## How

- `FrameworkTestCaseEndNotificationHandler` writes the per-case report to `<LocalOutputDirectory>/test_reports/TestSession_<sessionId>_<case>.md` and adds it to `TestResult.Attachments` (an `AttachmentSet` + `UriDataAttachment`).
- Named with the per-run **session id** (from #318/#319 work), so the attachment correlates with the other `TestSession_*` output files.
- **Best-effort**: a write/attach failure never fails the test. File IO uses the adapter's standard `#pragma warning disable RS1035` (the project references Roslyn only for discovery parsing, which otherwise bans IO).

## Scope / why per-case

VSTest attaches at the **per-result** level, and results are recorded *during* execution. The richer run-level reports (the consolidated comparison-matrix markdown, the session CSV) are written at **run-end**, *after* per-case results are already recorded — so surfacing those as attachments needs a per-group write-at-completion change and is a natural **follow-up**. This PR does the per-case slice and establishes the attachment plumbing the follow-up reuses.

## Verification

- New `FrameworkTestCaseEndNotificationHandlerTests`: asserts the report is written to a file and attached to the result, and that the handler still records a result (without an attachment) when run settings aren't available.
- Adapter suite **168/168** green on net9.0 + net10.0; full solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test reports are now automatically attached to individual test results for better visibility in IDEs and CI systems. Report generation failures are silently handled and do not impact test execution.

* **Tests**
  * Added comprehensive test coverage for report attachment functionality with and without report settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->