### PR TITLE
Engine accuracy hardening: resolution, GC/env isolation, and outlier hygiene

### DIFF
--- a/source/Sailfish/Analysis/SailfishOutlierDetector.cs
+++ b/source/Sailfish/Analysis/SailfishOutlierDetector.cs
@@ -13,7 +13,11 @@ public class SailfishOutlierDetector : ISailfishOutlierDetector
 
     public ProcessedStatisticalTestData DetectOutliers(IReadOnlyList<double> originalData)
     {
-        // Preserve existing behavior of removing both lower and upper outliers
-        return _configurable.DetectOutliers(originalData, OutlierStrategy.RemoveAll);
+        // Trim the upper tail only. In a benchmark the slow samples are the contaminated ones (a GC
+        // pause, a context switch, a page fault); the fast samples are the cleanest estimate of the true
+        // cost, so removing the lower tail (the old RemoveAll behavior) discarded the best data and biased
+        // the central estimate upward. Using one strategy here also keeps the per-run summary and the
+        // SailDiff comparison consistent, since both resolve this same detector.
+        return _configurable.DetectOutliers(originalData, OutlierStrategy.RemoveUpper);
     }
 }

--- a/source/Sailfish/Attributes/SailfishAttribute.cs
+++ b/source/Sailfish/Attributes/SailfishAttribute.cs
@@ -21,8 +21,10 @@ namespace Sailfish.Attributes;
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class SailfishAttribute : Attribute
 {
-    private const int DefaultNumIterations = 3;
-    private const int DefaultNumWarmupIterations = 3;
+    // Defaults raised from 3/3 (too thin to resolve small differences or to engage outlier detection,
+    // which is skipped at N<=3) to BenchmarkDotNet-comparable values. Override per class via the ctor.
+    private const int DefaultNumIterations = 15;
+    private const int DefaultNumWarmupIterations = 10;
 
     internal SailfishAttribute()
     {
@@ -190,8 +192,28 @@ public sealed class SailfishAttribute : Attribute
 
     /// <summary>
     /// Opt-in to settings-driven outlier handling for this class. When false (default),
-    /// the legacy SailfishOutlierDetector path is used to preserve backward compatibility.
+    /// the shared <c>SailfishOutlierDetector</c> path is used (trims the upper tail only).
     /// </summary>
     public bool UseConfigurableOutlierDetection { get; set; } = false;
+
+    /// <summary>
+    /// Force a full GC (collect + wait-for-finalizers + collect) between measured iterations so a
+    /// collection deferred from one iteration does not land in the next iteration's measured window.
+    /// Mirrors BenchmarkDotNet's default behavior. Default true.
+    /// </summary>
+    public bool ForceGcBetweenIterations { get; set; } = true;
+
+    /// <summary>
+    /// Opt-in: apply process-level environment control while this class runs — raises the process
+    /// priority class to <c>High</c> to reduce scheduler preemption noise. Reverted when the class
+    /// completes. Best-effort; ignored if the platform denies the change. Default false.
+    /// </summary>
+    public bool UseEnvironmentControl { get; set; } = false;
+
+    /// <summary>
+    /// Opt-in: pin the process to a single CPU core while this class runs to minimize cross-core
+    /// migration jitter. Reverted when the class completes. Only honored on Windows/Linux. Default false.
+    /// </summary>
+    public bool PinToSingleCore { get; set; } = false;
 
 }

--- a/source/Sailfish/Execution/AdaptiveIterationStrategy.cs
+++ b/source/Sailfish/Execution/AdaptiveIterationStrategy.cs
@@ -229,6 +229,9 @@ internal class AdaptiveIterationStrategy : IIterationStrategy
         CancellationToken cancellationToken)
     {
         await testInstanceContainer.CoreInvoker.IterationSetup(cancellationToken).ConfigureAwait(false);
+        // Settle the heap between iterations (outside the timed region) so a deferred collection
+        // doesn't land in this iteration's measurement.
+        if (testInstanceContainer.ExecutionSettings.ForceGcBetweenIterations) GcSettler.Settle();
         var opi = Math.Max(1, testInstanceContainer.ExecutionSettings.OperationsPerInvoke);
         if (opi > 1)
         {

--- a/source/Sailfish/Execution/EnvironmentControlScope.cs
+++ b/source/Sailfish/Execution/EnvironmentControlScope.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Diagnostics;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Opt-in, best-effort process environment control applied for the duration of a measured class:
+///     raise the process priority (to reduce scheduler preemption) and optionally pin the process to a
+///     single CPU core (to reduce cross-core migration jitter). Every change is captured on construction
+///     and reverted on <see cref="Dispose" />. Any platform denial is swallowed — environment control is
+///     an accuracy aid, never a requirement, so a failure to apply it must never fail a run.
+///     <para>
+///         Note: this complements an eventual out-of-process model. In-process it changes the whole host
+///         (which is why it is opt-in); out-of-process the same control can be applied to the dedicated
+///         child process without affecting the host.
+///     </para>
+/// </summary>
+internal sealed class EnvironmentControlScope : IDisposable
+{
+    private readonly bool _pinAffinity;
+    private readonly bool _raisePriority;
+
+    private bool _affinityChanged;
+    private IntPtr _originalAffinity;
+    private ProcessPriorityClass? _originalPriority;
+
+    public EnvironmentControlScope(bool raiseProcessPriority, bool pinToSingleCore)
+    {
+        _raisePriority = raiseProcessPriority;
+        _pinAffinity = pinToSingleCore;
+        if (_raisePriority) TryRaisePriority();
+        if (_pinAffinity) TryPinAffinity();
+    }
+
+    public bool PriorityRaised => _originalPriority.HasValue;
+    public bool AffinityPinned => _affinityChanged;
+
+    public void Dispose()
+    {
+        try
+        {
+            var p = Process.GetCurrentProcess();
+            // _affinityChanged is only ever set on Windows/Linux, but guard explicitly so the platform
+            // analyzer can prove the ProcessorAffinity access is safe.
+            if (_affinityChanged && (OperatingSystem.IsWindows() || OperatingSystem.IsLinux()))
+                p.ProcessorAffinity = _originalAffinity;
+            if (_originalPriority.HasValue) p.PriorityClass = _originalPriority.Value;
+        }
+        catch
+        {
+            // best-effort revert
+        }
+    }
+
+    private void TryRaisePriority()
+    {
+        try
+        {
+            var p = Process.GetCurrentProcess();
+            var current = p.PriorityClass;
+            // Only raise (never lower) and only from the unprivileged tiers, so we don't stomp a host
+            // that has already chosen High/RealTime.
+            if (current is ProcessPriorityClass.Normal or ProcessPriorityClass.BelowNormal or ProcessPriorityClass.Idle)
+            {
+                p.PriorityClass = ProcessPriorityClass.High;
+                _originalPriority = current;
+            }
+        }
+        catch
+        {
+            _originalPriority = null;
+        }
+    }
+
+    private void TryPinAffinity()
+    {
+        try
+        {
+            // ProcessorAffinity is only supported on Windows and Linux.
+            if (!(OperatingSystem.IsWindows() || OperatingSystem.IsLinux())) return;
+
+            var p = Process.GetCurrentProcess();
+            var original = p.ProcessorAffinity;
+            var mask = (long)original;
+            // Pin to the lowest core currently permitted by the affinity mask.
+            var lowest = mask & -mask;
+            if (lowest == 0) lowest = 1;
+            p.ProcessorAffinity = (IntPtr)lowest;
+            _originalAffinity = original;
+            _affinityChanged = true;
+        }
+        catch
+        {
+            _affinityChanged = false;
+        }
+    }
+}

--- a/source/Sailfish/Execution/ExecutionSettings.cs
+++ b/source/Sailfish/Execution/ExecutionSettings.cs
@@ -46,6 +46,14 @@ public interface IExecutionSettings
     // NEW: Steady-state warmup (opt-in). NumWarmupIterations is the floor; MaxWarmupIterations the cap.
     public bool UseSteadyStateWarmup { get; set; }
     public int MaxWarmupIterations { get; set; }
+
+    // NEW: Contamination control
+    // Force a full GC between measured iterations so a deferred collection doesn't land in the next sample.
+    public bool ForceGcBetweenIterations { get; set; }
+    // Opt-in process-level environment control (raise process priority) for the duration of the run.
+    public bool UseEnvironmentControl { get; set; }
+    // Opt-in: pin the process to a single CPU core for the duration of the run.
+    public bool PinToSingleCore { get; set; }
 }
 
 public class ExecutionSettings : IExecutionSettings
@@ -107,5 +115,10 @@ public class ExecutionSettings : IExecutionSettings
     // NEW: Steady-state warmup (opt-in)
     public bool UseSteadyStateWarmup { get; set; } = false;
     public int MaxWarmupIterations { get; set; } = 50;
+
+    // NEW: Contamination control. GC-settle defaults on (BDN parity); environment control is opt-in.
+    public bool ForceGcBetweenIterations { get; set; } = true;
+    public bool UseEnvironmentControl { get; set; } = false;
+    public bool PinToSingleCore { get; set; } = false;
 
 }

--- a/source/Sailfish/Execution/FixedIterationStrategy.cs
+++ b/source/Sailfish/Execution/FixedIterationStrategy.cs
@@ -66,6 +66,9 @@ internal class FixedIterationStrategy : IIterationStrategy
             try
             {
                 await testInstanceContainer.CoreInvoker.IterationSetup(cancellationToken).ConfigureAwait(false);
+                // Settle the heap between iterations (outside the timed region) so a deferred collection
+                // doesn't land in this iteration's measurement.
+                if (executionSettings.ForceGcBetweenIterations) GcSettler.Settle();
                 var opi = Math.Max(1, executionSettings.OperationsPerInvoke);
                 if (opi > 1)
                 {

--- a/source/Sailfish/Execution/GcSettler.cs
+++ b/source/Sailfish/Execution/GcSettler.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Forces a deterministic garbage collection between measured iterations so that memory pressure
+///     (and any deferred finalization) built up by one iteration does not land inside the next
+///     iteration's measured window and inflate it. This mirrors BenchmarkDotNet, which collects
+///     between iterations by default. Opt-out via <c>ForceGcBetweenIterations = false</c>.
+/// </summary>
+internal static class GcSettler
+{
+    public static void Settle()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+}

--- a/source/Sailfish/Execution/HarnessBaselineCalibrator.cs
+++ b/source/Sailfish/Execution/HarnessBaselineCalibrator.cs
@@ -9,16 +9,29 @@ namespace Sailfish.Execution;
 
 /// <summary>
 ///     Measures the per-invocation overhead of the harness itself by timing an idle invoker
-///     (<see cref="CompiledInvoker.Empty" />) through the exact same loop the workload runs in:
-///     stopwatch around <c>await invoke(ct)</c>. Because the idle invoker has the identical delegate
-///     shape to a compiled workload invoker, the resulting baseline is structurally identical to the
-///     measured path, so subtracting it cancels dispatch/await/timer overhead almost exactly rather
-///     than approximating it (the way BenchmarkDotNet subtracts its generated overhead loop).
+///     (<see cref="CompiledInvoker.Empty" />) through the exact same loop the workload runs in.
+///     Because the idle invoker has the identical delegate shape to a compiled workload invoker, the
+///     resulting baseline is structurally identical to the measured path, so subtracting it cancels
+///     dispatch/await/timer overhead almost exactly rather than approximating it (the way
+///     BenchmarkDotNet subtracts its generated overhead loop).
+///     <para>
+///         Each timed sample runs a <b>batch</b> of idle invocations and divides by the batch size.
+///         Timing a single idle call (the previous approach) quantizes to 0/1 tick on the common coarse
+///         timers — Windows QPC (~100 ns/tick) and Apple Silicon (~41.7 ns effective) — so the median
+///         collapsed to ~0 and the reported "overhead" was timer quantization noise, not a measurement.
+///         Batching recovers per-call overhead well below a single tick, the same technique
+///         BenchmarkDotNet uses for its overhead loop.
+///     </para>
 /// </summary>
 internal class HarnessBaselineCalibrator
 {
     private const int WarmupCount = 16;
     private const int SampleCount = 64;
+
+    // Idle invocations per timed sample. Large enough that the aggregate window sits well above the
+    // timer floor (e.g. 1024 * ~1.5 ns ≈ 1.5 µs, ~15 ticks on a 100 ns clock) so dividing back out
+    // yields sub-tick per-call resolution.
+    private const int BatchSize = 1024;
 
     // Exposed for diagnostics consumers
     internal static int Warmups => WarmupCount;
@@ -33,39 +46,45 @@ internal class HarnessBaselineCalibrator
     {
         if (idleInvoker is null) throw new ArgumentNullException(nameof(idleInvoker));
 
-        // Warmup JIT/infra
+        // Warmup JIT/infra with full batches
         for (var i = 0; i < WarmupCount; i++)
         {
-            await idleInvoker(cancellationToken).ConfigureAwait(false);
+            for (var j = 0; j < BatchSize; j++)
+            {
+                await idleInvoker(cancellationToken).ConfigureAwait(false);
+            }
         }
 
-        // Measure N samples
-        var samples = new List<long>(SampleCount);
+        // Measure N batches; each yields a per-call overhead in (fractional) ticks
+        var samples = new List<double>(SampleCount);
         for (var i = 0; i < SampleCount; i++)
         {
             var sw = Stopwatch.StartNew();
-            await idleInvoker(cancellationToken).ConfigureAwait(false);
+            for (var j = 0; j < BatchSize; j++)
+            {
+                await idleInvoker(cancellationToken).ConfigureAwait(false);
+            }
             sw.Stop();
-            samples.Add(sw.ElapsedTicks);
+            samples.Add((double)sw.ElapsedTicks / BatchSize);
         }
 
         var median = Median(samples);
 
-        // Clamp to int range and non-negative
-        if (median < 0) median = 0;
-        if (median > int.MaxValue) median = int.MaxValue;
-        return (int)median;
+        // Round to whole ticks and clamp non-negative. Genuinely sub-tick overhead now rounds to 0
+        // (it is below what any single sample can resolve, so subtracting nothing is correct) instead
+        // of producing the random 0/1 result single-shot timing used to give.
+        var rounded = (long)Math.Round(median, MidpointRounding.AwayFromZero);
+        if (rounded < 0) rounded = 0;
+        if (rounded > int.MaxValue) rounded = int.MaxValue;
+        return (int)rounded;
     }
 
-    private static long Median(IReadOnlyList<long> values)
+    private static double Median(IReadOnlyList<double> values)
     {
         if (values.Count == 0) return 0;
         var ordered = values.OrderBy(v => v).ToArray();
         var n = ordered.Length;
         if (n % 2 == 1) return ordered[n / 2];
-        var a = ordered[(n / 2) - 1];
-        var b = ordered[n / 2];
-        // average two middles safely
-        return a + ((b - a) / 2);
+        return 0.5 * (ordered[(n / 2) - 1] + ordered[n / 2]);
     }
 }

--- a/source/Sailfish/Execution/IterationPerformance.cs
+++ b/source/Sailfish/Execution/IterationPerformance.cs
@@ -5,6 +5,13 @@ namespace Sailfish.Execution;
 public class IterationPerformance
 {
     public IterationPerformance(DateTimeOffset startTime, DateTimeOffset endTime, long elapsedTicks)
+        : this(startTime, endTime, (double)elapsedTicks)
+    {
+    }
+
+    // Precise per-operation path: the timer divides the batch (OperationsPerInvoke) in floating point,
+    // so the recorded value keeps sub-tick resolution instead of truncating to a whole Stopwatch tick.
+    internal IterationPerformance(DateTimeOffset startTime, DateTimeOffset endTime, double elapsedTicks)
     {
         StartTime = startTime;
         StopTime = endTime;
@@ -13,7 +20,7 @@ public class IterationPerformance
 
     public DateTimeOffset StartTime { get; }
     public DateTimeOffset StopTime { get; }
-    private long ElapsedTicks { get; set; }
+    private double ElapsedTicks { get; set; }
 
     // Tracks how many times this iteration's overhead subtraction was capped by the 80% guardrail
     public int CappedCount { get; private set; }
@@ -25,8 +32,9 @@ public class IterationPerformance
 
     public void ApplyOverheadEstimate(int overheadEstimate)
     {
-        // Cap subtraction to at most 80% of this iteration's ticks to avoid oversubtraction on microbenchmarks
-        var maxSubtract = (int)Math.Floor(ElapsedTicks * 0.8);
+        // Cap subtraction to at most 80% of this iteration's ticks to avoid oversubtraction on microbenchmarks.
+        // Work in floating point so a sub-tick per-operation duration is not rounded before subtraction.
+        var maxSubtract = ElapsedTicks * 0.8;
         if (maxSubtract < 0) maxSubtract = 0;
         if (overheadEstimate > maxSubtract) CappedCount++;
         var subtract = Math.Min(overheadEstimate, maxSubtract);

--- a/source/Sailfish/Execution/PerformanceTimer.cs
+++ b/source/Sailfish/Execution/PerformanceTimer.cs
@@ -60,7 +60,9 @@ public sealed class PerformanceTimer
     public void StartSailfishMethodExecutionTimer()
     {
         if (_iterationTimer.IsRunning) return;
-        _executionIterationStart = DateTimeOffset.Now;
+        // UtcNow avoids the timezone resolution that DateTimeOffset.Now performs on every iteration;
+        // this timestamp is captured outside the measured region and only records wall-clock metadata.
+        _executionIterationStart = DateTimeOffset.UtcNow;
         _iterationTimer.Start();
     }
 
@@ -68,14 +70,16 @@ public sealed class PerformanceTimer
     {
         if (!_iterationTimer.IsRunning) return;
         _iterationTimer.Stop();
-        var executionIterationStop = DateTimeOffset.Now;
+        var executionIterationStop = DateTimeOffset.UtcNow;
         // Normalize to per-operation time. When a measured iteration batches N invocations
         // (OperationsPerInvoke), divide the aggregate by N so the recorded sample is the cost of a
         // single operation. This keeps reported statistics per-operation and comparable across
         // methods and runs regardless of batch size. Dividing here (before overhead subtraction)
         // is required: the overhead estimate is per-call, so it must be subtracted from a per-op value.
         var ops = operationsPerInvoke < 1 ? 1 : operationsPerInvoke;
-        var perOperationTicks = _iterationTimer.ElapsedTicks / ops;
+        // Divide the batch in floating point so the per-operation duration keeps sub-tick resolution
+        // (integer division truncated toward zero, biasing every batched sample slightly low).
+        var perOperationTicks = (double)_iterationTimer.ElapsedTicks / ops;
         ExecutionIterationPerformances.Add(new IterationPerformance(_executionIterationStart, executionIterationStop, perOperationTicks));
         _iterationTimer.Reset();
     }

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,6 +57,18 @@ internal class TestCaseIterator : ITestCaseIterator
             return await trawlEngine.RunAsync(testInstanceContainer, trawlAttribute, cancellationToken).ConfigureAwait(false);
         }
 
+        var executionSettings = testInstanceContainer.ExecutionSettings;
+
+        // Opt-in process environment control (raise priority / pin affinity) covering warmup +
+        // measurement for this class. Best-effort and auto-reverted on dispose; never required.
+        using var envScope = executionSettings.UseEnvironmentControl || executionSettings.PinToSingleCore
+            ? new EnvironmentControlScope(executionSettings.UseEnvironmentControl, executionSettings.PinToSingleCore)
+            : null;
+        if (envScope?.PriorityRaised == true)
+            _logger.Log(LogLevel.Information, "      ---- Environment control: raised process priority");
+        if (envScope?.AffinityPinned == true)
+            _logger.Log(LogLevel.Information, "      ---- Environment control: pinned process to a single core");
+
         var calibrator = new HarnessBaselineCalibrator();
         var warmupResult = await WarmupIterations(testInstanceContainer, cancellationToken);
         if (!warmupResult.IsSuccess) return warmupResult;
@@ -67,7 +80,6 @@ internal class TestCaseIterator : ITestCaseIterator
         }
 
         // Determine which strategy to use
-        var executionSettings = testInstanceContainer.ExecutionSettings;
         var useAdaptive = executionSettings.UseAdaptiveSampling;
 
         var strategy = useAdaptive ? _adaptiveIterationStrategy : _fixedIterationStrategy;
@@ -128,6 +140,8 @@ internal class TestCaseIterator : ITestCaseIterator
             return CatchAndReturn(testInstanceContainer,
                 new Exception(iterationResult.ErrorMessage ?? "Iteration failed"));
         }
+
+        WarnIfQuantized(testInstanceContainer, executionSettings);
 
         // Log convergence information for adaptive sampling
         if (useAdaptive && iterationResult.ConvergedEarly)
@@ -268,6 +282,22 @@ internal class TestCaseIterator : ITestCaseIterator
         return new TestCaseExecutionResult(testInstanceContainer);
     }
 
+
+    // Surfaces sub-resolution measurement: when the recorded samples have collapsed onto a couple of
+    // discrete timer values, the operation is at or below the timer's effective granularity and small
+    // differences cannot be resolved. Only relevant when not already batching (OperationsPerInvoke == 1
+    // and no target iteration duration set).
+    private void WarnIfQuantized(TestInstanceContainer container, IExecutionSettings settings)
+    {
+        if (settings.OperationsPerInvoke > 1 || settings.TargetIterationDuration > TimeSpan.Zero) return;
+        var samples = container.CoreInvoker.GetPerformanceResults().ExecutionIterationPerformances;
+        if (samples.Count < 4) return;
+        var distinct = samples.Select(p => p.GetDurationFromTicks().NanoSeconds.Duration).Distinct().Count();
+        if (distinct > 2) return;
+        _logger.Log(LogLevel.Warning,
+            "      ---- Measured samples collapsed to {Distinct} distinct timer value(s): this operation is at or below the timer's effective resolution, so small differences cannot be resolved. Set OperationsPerInvoke or TargetIterationDurationMs to batch invocations into a measurable window.",
+            distinct);
+    }
 
     private TestCaseExecutionResult CatchAndReturn(TestInstanceContainer testProvider, Exception ex)
     {

--- a/source/Sailfish/Execution/TickAutoConverter.cs
+++ b/source/Sailfish/Execution/TickAutoConverter.cs
@@ -4,38 +4,46 @@ namespace Sailfish.Execution;
 
 public static class TickAutoConverter
 {
-    private static DurationConversion ConvertToNanoseconds(long elapsedTicks)
+    private static DurationConversion ConvertToNanoseconds(double elapsedTicks)
     {
         var result = ConvertToSeconds(elapsedTicks).Duration * 1_000_000_000;
         return new DurationConversion(result);
     }
 
-    private static DurationConversion ConvertToMicroseconds(long elapsedTicks)
+    private static DurationConversion ConvertToMicroseconds(double elapsedTicks)
     {
         var result = ConvertToSeconds(elapsedTicks).Duration * 1_000_000;
         return new DurationConversion(result);
     }
 
-    private static DurationConversion ConvertToMilliseconds(long elapsedTicks)
+    private static DurationConversion ConvertToMilliseconds(double elapsedTicks)
     {
         var result = ConvertToSeconds(elapsedTicks).Duration * 1_000;
         return new DurationConversion(result);
     }
 
-    private static DurationConversion ConvertToSeconds(long elapsedTicks)
+    private static DurationConversion ConvertToSeconds(double elapsedTicks)
     {
-        var result = elapsedTicks / (double)Stopwatch.Frequency;
+        var result = elapsedTicks / Stopwatch.Frequency;
         return new DurationConversion(result);
     }
 
 
-    private static DurationConversion ConvertToMinutes(long elapsedTicks)
+    private static DurationConversion ConvertToMinutes(double elapsedTicks)
     {
-        var result = (long)(ConvertToSeconds(elapsedTicks).Duration / 60.0);
+        var result = ConvertToSeconds(elapsedTicks).Duration / 60.0;
         return new DurationConversion(result);
     }
 
     public static TimeResult ConvertToTime(long elapsedTicks)
+    {
+        return ConvertToTime((double)elapsedTicks);
+    }
+
+    // Sub-tick precision is preserved: OperationsPerInvoke normalization (batch ticks / N) and
+    // overhead subtraction operate in floating point, so a per-operation duration is never quantized
+    // to a whole Stopwatch tick before it reaches the statistics layer.
+    public static TimeResult ConvertToTime(double elapsedTicks)
     {
         return new TimeResult(
             ConvertToNanoseconds(elapsedTicks),

--- a/source/Sailfish/Execution/Tuning/OperationsPerInvokeTuner.cs
+++ b/source/Sailfish/Execution/Tuning/OperationsPerInvokeTuner.cs
@@ -1,8 +1,6 @@
 using Sailfish.Logging;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,9 +9,11 @@ namespace Sailfish.Execution.Tuning;
 internal class OperationsPerInvokeTuner
 {
     private const int WarmupCount = 3;
-    private const int SampleCount = 5;
     private const int MaxRefinements = 2;
     private const int MaxOpsPerInvoke = 1_000_000;
+
+    // The aggregate estimate window must be large enough to time reliably above the Stopwatch floor.
+    private const double MinMeasurableMs = 2.0;
 
     public async Task<int> TuneAsync(
         TestInstanceContainer container,
@@ -32,20 +32,25 @@ internal class OperationsPerInvokeTuner
             await container.CoreInvoker.ExecutionMethod(cancellationToken, timed: false).ConfigureAwait(false);
         }
 
-        // Measure single-operation time across a few samples, take median
-        var perOpSamplesMs = new List<double>(SampleCount);
-        for (var i = 0; i < SampleCount; i++)
+        // Estimate per-operation time from a BATCH, not a single call. Timing one fast invocation
+        // quantizes to ~0 on coarse timers, which previously made the tuner give up (return OPI=1) for
+        // exactly the sub-microsecond operations that most need batching. Grow the batch geometrically
+        // until the aggregate window is large enough to time reliably, then divide back out.
+        var batch = 1;
+        var batchMs = 0.0;
+        while (true)
         {
-            var sw = Stopwatch.StartNew();
-            await container.CoreInvoker.ExecutionMethod(cancellationToken, timed: false).ConfigureAwait(false);
-            sw.Stop();
-            perOpSamplesMs.Add(sw.Elapsed.TotalMilliseconds);
+            batchMs = await MeasureAggregateAsync(container, batch, cancellationToken).ConfigureAwait(false);
+            if (batchMs >= MinMeasurableMs || batch >= MaxOpsPerInvoke) break;
+            var next = batch * 4;
+            if (next <= batch) break; // overflow guard
+            batch = Math.Min(next, MaxOpsPerInvoke);
         }
 
-        var perOpMs = Median(perOpSamplesMs);
+        var perOpMs = batchMs / batch;
         if (perOpMs <= 0)
         {
-            // Extremely fast operation; fall back to a small batch
+            // Even the largest batch was unmeasurable; fall back to the configured value.
             return Math.Max(1, container.ExecutionSettings.OperationsPerInvoke);
         }
 
@@ -72,7 +77,7 @@ internal class OperationsPerInvokeTuner
         }
 
         logger.Log(LogLevel.Information,
-            "      ---- Auto-tuned OperationsPerInvoke: perOp={PerOpMs:F3}ms, target={TargetMs:F1}ms -> OPI={OPI}",
+            "      ---- Auto-tuned OperationsPerInvoke: perOp={PerOpMs:F6}ms, target={TargetMs:F1}ms -> OPI={OPI}",
             perOpMs, targetMs, ops);
 
         return ops;
@@ -88,16 +93,4 @@ internal class OperationsPerInvokeTuner
         sw.Stop();
         return sw.Elapsed.TotalMilliseconds;
     }
-
-    private static double Median(IReadOnlyList<double> values)
-    {
-        if (values.Count == 0) return 0;
-        var ordered = values.OrderBy(v => v).ToArray();
-        var n = ordered.Length;
-        if (n % 2 == 1) return ordered[n / 2];
-        var a = ordered[(n / 2) - 1];
-        var b = ordered[n / 2];
-        return a + ((b - a) / 2.0);
-    }
 }
-

--- a/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
+++ b/source/Sailfish/Extensions/Methods/ExecutionExtensionMethods.cs
@@ -50,7 +50,12 @@ internal static class ExecutionExtensionMethods
 
             // NEW: Steady-state warmup
             UseSteadyStateWarmup = sailfishAttribute.UseSteadyStateWarmup,
-            MaxWarmupIterations = sailfishAttribute.MaxWarmupIterations
+            MaxWarmupIterations = sailfishAttribute.MaxWarmupIterations,
+
+            // NEW: Contamination control
+            ForceGcBetweenIterations = sailfishAttribute.ForceGcBetweenIterations,
+            UseEnvironmentControl = sailfishAttribute.UseEnvironmentControl,
+            PinToSingleCore = sailfishAttribute.PinToSingleCore
         };
     }
 

--- a/source/Tests.Library/Analysis/SailfishOutlierDetectorTests.cs
+++ b/source/Tests.Library/Analysis/SailfishOutlierDetectorTests.cs
@@ -147,7 +147,9 @@ public class SailfishOutlierDetectorTests
         result.OriginalData.Length.ShouldBe(8);
         result.LowerOutliers.ShouldNotBeEmpty();
         result.TotalNumOutliers.ShouldBeGreaterThan(0);
-        result.DataWithOutliersRemoved.Length.ShouldBeLessThan(result.OriginalData.Length);
+        // Upper-only default: lower outliers are detected but retained (not removed), since the fastest
+        // samples are the cleanest estimate of the true cost.
+        result.DataWithOutliersRemoved.Length.ShouldBe(result.OriginalData.Length);
     }
 
     [Fact]
@@ -292,7 +294,9 @@ public class SailfishOutlierDetectorTests
 
         // Assert
         result.ShouldNotBeNull();
-        var totalProcessed = result.DataWithOutliersRemoved.Length + result.TotalNumOutliers;
+        // Upper-only default: only upper outliers are removed from the cleaned set; lower outliers are
+        // detected but retained. So cleaned + upper-outliers == original.
+        var totalProcessed = result.DataWithOutliersRemoved.Length + result.UpperOutliers.Count();
         totalProcessed.ShouldBe(result.OriginalData.Length);
     }
 

--- a/source/Tests.Library/AttributeCollection/SailfishAttributeCoreTests.cs
+++ b/source/Tests.Library/AttributeCollection/SailfishAttributeCoreTests.cs
@@ -16,8 +16,8 @@ public class SailfishAttributeCoreTests
         ctor.ShouldNotBeNull();
         var attr = (SailfishAttribute)ctor!.Invoke(null);
 
-        attr.SampleSize.ShouldBe(3);
-        attr.NumWarmupIterations.ShouldBe(3);
+        attr.SampleSize.ShouldBe(15);
+        attr.NumWarmupIterations.ShouldBe(10);
         attr.Disabled.ShouldBeFalse();
         attr.DisableOverheadEstimation.ShouldBeFalse();
         attr.UseAdaptiveSampling.ShouldBeFalse();
@@ -29,8 +29,8 @@ public class SailfishAttributeCoreTests
     public void PublicConstructor_DefaultsAndSetters_Work()
     {
         var attr = new SailfishAttribute();
-        attr.SampleSize.ShouldBe(3);
-        attr.NumWarmupIterations.ShouldBe(3);
+        attr.SampleSize.ShouldBe(15);
+        attr.NumWarmupIterations.ShouldBe(10);
         attr.Disabled.ShouldBeFalse();
 
         // Set a few knobs

--- a/source/Tests.Library/Contracts/OutlierConfigurationIntegrationTests.cs
+++ b/source/Tests.Library/Contracts/OutlierConfigurationIntegrationTests.cs
@@ -26,20 +26,21 @@ public class OutlierConfigurationIntegrationTests
     private static TestCaseId MakeTestId() => new(new TestCaseName(["C","M"]), new TestCaseVariables([]));
 
     [Fact]
-    public void Legacy_RemoveAll_Is_Default_When_OptIn_Flag_Is_False()
+    public void Default_Path_Removes_Upper_Only_When_OptIn_Flag_Is_False()
     {
         // Arrange: baseline cluster around 10ms, with clear lower and upper outliers
         var timer = TimerFromMs(0.0, 9.0, 10.0, 10.5, 11.0, 1000.0);
         var settings = new ExecutionSettings(asCsv: false, asConsole: false, asMarkdown: false, sampleSize: 6, numWarmupIterations: 0)
         {
-            UseConfigurableOutlierDetection = false // legacy path -> RemoveAll
+            UseConfigurableOutlierDetection = false // default shared path -> RemoveUpper
         };
 
         // Act
         var pr = PerformanceRunResult.ConvertFromPerfTimer(MakeTestId(), timer, settings);
 
-        // Assert: both extremes removed
-        pr.DataWithOutliersRemoved.ShouldNotContain(0.0);
+        // Assert: the slow (upper) sample is removed; the fast (lower) sample is detected but retained,
+        // because the fastest samples are the cleanest estimate of the true cost.
+        pr.DataWithOutliersRemoved.ShouldContain(0.0);
         pr.DataWithOutliersRemoved.ShouldNotContain(1000.0);
         pr.LowerOutliers.ShouldContain(0.0);
         pr.UpperOutliers.ShouldContain(1000.0);

--- a/source/Tests.Library/Execution/OperationsPerInvokeTunerTests.cs
+++ b/source/Tests.Library/Execution/OperationsPerInvokeTunerTests.cs
@@ -7,7 +7,6 @@ using Sailfish.Execution.Tuning;
 using Sailfish.Logging;
 using Shouldly;
 using Xunit;
-using System.Reflection;
 
 
 namespace Tests.Library.Execution;
@@ -88,24 +87,6 @@ public class OperationsPerInvokeTunerTests
             }
             return Task.CompletedTask;
         }
-    }
-
-    [Fact]
-    public void Median_EvenCount_ReturnsAverage()
-    {
-        var values = new System.Collections.Generic.List<double> { 1.0, 3.0 };
-        var mi = typeof(OperationsPerInvokeTuner).GetMethod("Median", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (double)mi.Invoke(null, new object[] { values })!;
-        result.ShouldBe(2.0, 1e-9);
-    }
-
-    [Fact]
-    public void Median_Empty_ReturnsZero()
-    {
-        var values = new System.Collections.Generic.List<double>();
-        var mi = typeof(OperationsPerInvokeTuner).GetMethod("Median", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (double)mi.Invoke(null, new object[] { values })!;
-        result.ShouldBe(0.0, 1e-9);
     }
 
 }

--- a/source/Tests.Library/ExtensionMethods/ExecutionExtensionMethodsTests.cs
+++ b/source/Tests.Library/ExtensionMethods/ExecutionExtensionMethodsTests.cs
@@ -67,8 +67,8 @@ public class ExecutionExtensionMethodsTests
         result.AsCsv.ShouldBeFalse();
         result.AsMarkdown.ShouldBeFalse();
         result.AsConsole.ShouldBeTrue(); // Default when no SuppressConsoleAttribute
-        result.SampleSize.ShouldBe(3); // Default from SailfishAttribute
-        result.NumWarmupIterations.ShouldBe(3); // Default from SailfishAttribute
+        result.SampleSize.ShouldBe(15); // Default from SailfishAttribute
+        result.NumWarmupIterations.ShouldBe(10); // Default from SailfishAttribute
     }
 
     [Fact]

--- a/source/Tests.Library/ExtensionMethods/InvocationReflectionExtensionMethodsTests.cs
+++ b/source/Tests.Library/ExtensionMethods/InvocationReflectionExtensionMethodsTests.cs
@@ -214,7 +214,7 @@ public class InvocationReflectionExtensionMethodsTests
         var result = type.GetWarmupIterations();
 
         // Assert
-        result.ShouldBe(3); // Default value
+        result.ShouldBe(10); // Default value
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Follow-up to the pre-OOP engine accuracy review. The compiled-delegate work (#254) closed the invocation-overhead gap, so the accuracy ceiling is now set by measurement **resolution and sampling**, not dispatch. These fixes address that ceiling *in process* — which is where the leverage is, since out-of-process buys isolation but **not** finer timer resolution, more samples, warmup, GC-between-iterations, or batching.

Policy: **Sensible Hybrid** — flip the low-risk, clearly-better defaults; keep runtime-variable features (full adaptive sampling, unbounded steady-state warmup) opt-in.

## What changed

**Resolution / precision**
- Per-operation duration is carried as a `double` end-to-end. `OperationsPerInvoke` normalization now divides in floating point (integer division truncated toward zero, biasing every batched sample low); overhead subtraction is in double too.
- `HarnessBaselineCalibrator` times a **batch of 1024** idle invocations per sample and divides, recovering per-call overhead below one tick. Single-shot timing medianed to ~0 on coarse timers (QPC ~100 ns, Apple Silicon ~41.7 ns effective), so the old "overhead" — and the drift/guardrail diagnostics built on it — was timer noise. (E2E now reports a real ~8-tick baseline.)
- `OperationsPerInvokeTuner` estimates per-op time from a geometrically grown batch instead of single calls, so it no longer returns `OPI=1` for the sub-µs ops that most need batching.

**Contamination control**
- Full GC (collect + wait-for-finalizers + collect) between measured iterations, **outside** the timed region, so a deferred collection can't land in the next sample. **Default on** (BDN parity); opt out via `ForceGcBetweenIterations=false`. Wired into both iteration strategies.
- `EnvironmentControlScope`: opt-in raise of process priority + optional single-core pin, auto-reverted, best-effort (`UseEnvironmentControl` / `PinToSingleCore`).
- A warning when samples collapse to ≤2 distinct timer values while not batching, pointing the user at `OperationsPerInvoke` / `TargetIterationDurationMs`.

**Statistical hygiene**
- Default outlier trimming is now **upper-tail only** (`RemoveUpper`) instead of both tails. The fast samples are the cleanest estimate of true cost; trimming the lower tail discarded the best data and biased the central estimate upward. This is the shared detector for both the per-run summary and SailDiff, so the two are now consistent.

## ⚠️ Behavioral changes for existing users
- **Default sample size 3→15, warmup 3→10.** Explicit per-class `[Sailfish(SampleSize: …)]` still wins.
- **GC between iterations on by default** (slightly longer runs, cleaner samples).
- **Default outlier trimming** changed from both-tail to upper-tail.

All three are one-line tweaks if you want them gentler.

## Notes
- Thread priority is intentionally **not** modified — unsafe under async (the loop can resume on a pooled thread). Process priority + affinity cover the benefit reliably.
- `EnableDefaultDiagnosers` left as-is (no diagnoser impl; out of accuracy scope).

## Verification
- Builds clean on **net9.0 + net10.0** (0 errors).
- **Tests.Library 1676** + **Tests.TestAdapter 168** green on both TFMs; **Tests.Analyzers 107** green.
- ConsoleAppDemo end-to-end: valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optional environment control during benchmarks: raise process priority and/or pin to single CPU core
  * Automatic garbage collection settling between iterations (enabled by default)
  * Sub-tick precision for timing measurements
  * Timing resolution warnings when measurements show insufficient resolution
  * Improved operations-per-invoke tuning using batch-based approach

* **Changes**
  * Default sample size increased from 3 to 15; default warmup iterations increased from 3 to 10
  * Outlier detection now removes only upper tail (preserves lower tail)
  * Enhanced measurement precision using floating-point arithmetic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->