### PR TITLE
fix(scalefish): three model-selection correctness bugs (clone family, degenerate AICc, stride mis-attribution)

### DIFF
--- a/site/src/pages/docs/2/scalefish.md
+++ b/site/src/pages/docs/2/scalefish.md
@@ -6,7 +6,7 @@ title: ScaleFish
 
 **Scalefish** is a **regression analysis** tool that infers the algorithmic complexity of your test method as the input scale grows.
 
-When enabled, scalefish will discover test cases with scalefish-enabled variables and fit the timing data against a catalog of complexity curves (Linear, NLogN, Quadratic, Cubic, SqrtN, LogLinear, Exponential, Factorial). It ranks the candidates using the **corrected Akaike Information Criterion (AICc)** and reports a confidence-aware classification with a continuous-exponent diagnostic.
+When enabled, scalefish will discover test cases with scalefish-enabled variables and fit the timing data against a catalog of complexity curves (Linear, NLogN, Quadratic, Cubic, SqrtN, Exponential, Factorial). It ranks the candidates using the **corrected Akaike Information Criterion (AICc)** — computed from the per-X replicate spread whenever replicate data is available, so even a 3-value declaration can produce a confident classification — and reports a confidence-aware classification with a continuous-exponent diagnostic.
 
 This outputs a model file and a results file once your run is complete. The model file can be used to make predictions.
 
@@ -49,14 +49,13 @@ Sailfish fits each variable against the following functions and picks the best/n
 | ----------- | ------------- | --------- |
 | Linear      | O(n)          | Good      |
 | NLogN       | O(nLog(n))    | Good      |
-| LogLinear   | O(nlog\_2(n)) | Okay      |
 | Quadratic   | O(n^2)        | Bad       |
 | Cubic       | O(n^3)        | Very Bad  |
 | SqrtN       | O(sqrt(n))    | Very Good |
 | Exponential | O(2^n)        | Very Bad  |
 | Factorial   | O(n!)         | Worst!    |
 
-Note: there is no `Constant` / `O(1)` model and no isolated `Logarithmic` / `O(log n)` model — pure-constant data will still report the closest fit (typically Linear with a near‑zero slope).
+Note: `LogLinear` (O(n·log₂ n)) is no longer fitted — its curve is a constant multiple of NLogN's, so fitting both made every n·log n result tie with its own clone and never register as statistically distinguishable. Models previously saved with a LogLinear classification still load and predict. There is no `Constant` / `O(1)` model and no isolated `Logarithmic` / `O(log n)` model — pure-constant data will still report the closest fit (typically Linear with a near‑zero slope).
 
 If using Sailfish as a test project, you can create a `.sailfish.json` file in the root of your test project (next to your `.csproj` file). This file can hold various configuration settings. When found, SailDiff will be automatically run. If any compatible setting is omitted, a sensible default will be used.
 

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityEstimator.cs
@@ -294,6 +294,17 @@ public class ComplexityEstimator : IComplexityEstimator
     /// <summary>
     /// Fits every candidate family to the measurements and ranks them by AICc, returning the point estimate
     /// (best, runner-up, akaike weight, distinguishability). Returns null when no candidate produced a valid fit.
+    ///
+    /// <para>
+    /// Scoring runs at the replicate level whenever every measurement carries replicate uncertainty
+    /// (see <see cref="ComputeReplicateAicc"/>): the per-X means are compared against each family's
+    /// predictions in units of their standard errors, and the AICc sample size is the <em>total
+    /// replicate count</em> rather than the number of distinct X values. This is what makes a typical
+    /// 3-X-value declaration with 15+ replicates per X classifiable at all — at the means level,
+    /// n = 3 with k = 2 leaves the AICc small-sample correction undefined (n − k − 1 = 0), so every
+    /// family scored +∞ and no result could ever be distinguishable. Without replicate uncertainty the
+    /// scoring falls back to the means-level <see cref="ComputeAicc"/>, preserving prior behaviour.
+    /// </para>
     /// </summary>
     internal static PointEstimate? RankCandidates(ComplexityMeasurement[]? measurements, double distinguishabilityDelta = DistinguishabilityDelta)
     {
@@ -327,12 +338,19 @@ public class ComplexityEstimator : IComplexityEstimator
 
         if (fitnessResults.Count == 0) return null;
 
+        // Replicate-aware likelihood inputs. Gated all-or-nothing (same rule as the fit's variance
+        // weights) so every candidate is scored on the same likelihood.
+        var inverseSquaredSes = TryBuildInverseSquaredStandardErrors(cleaned);
+        var totalReplicates = inverseSquaredSes is null ? 0 : cleaned.Sum(m => m.SampleSize);
+
         var n = cleaned.Length;
         var scored = fitnessResults
             .Select(r => new Scored(
                 r.Function,
                 r.Fitness,
-                ComputeAicc(r.Fitness.Ssd, n, r.Function.FreeParameterCount)))
+                inverseSquaredSes is not null
+                    ? ComputeReplicateAicc(r.Function, cleaned, inverseSquaredSes, totalReplicates, r.Function.FreeParameterCount)
+                    : ComputeAicc(r.Fitness.Ssd, n, r.Function.FreeParameterCount)))
             .OrderBy(s => double.IsFinite(s.Aicc) ? s.Aicc : double.PositiveInfinity)
             .ThenBy(s => s.Fitness.Ssd)
             .ToList();
@@ -501,8 +519,12 @@ public class ComplexityEstimator : IComplexityEstimator
     }
 
     /// <summary>
-    /// AIC with small-sample correction for OLS. n is the number of measurements, k the number of free
-    /// parameters (typically 2: scale, bias). Returns +infinity when RSS or n is degenerate.
+    /// Means-level AIC with small-sample correction for OLS. n is the number of (X, mean) points, k the
+    /// number of free parameters (typically 2: scale, bias). Returns +infinity when RSS or n is
+    /// degenerate — in particular for every family when n ≤ k + 1 (e.g. three X values with two
+    /// parameters), where the correction is undefined and no honest means-level selection exists.
+    /// Used as the fallback when measurements carry no replicate uncertainty; otherwise see
+    /// <see cref="ComputeReplicateAicc"/>.
     /// </summary>
     internal static double ComputeAicc(double rss, int n, int k)
     {
@@ -513,6 +535,84 @@ public class ComplexityEstimator : IComplexityEstimator
         var denom = n - k - 1;
         if (denom <= 0) return double.PositiveInfinity;
         return aic + 2.0 * k * (k + 1) / denom;
+    }
+
+    /// <summary>
+    /// Replicate-level AICc under a per-X Gaussian likelihood: y_ij = f(x_i) + ε_ij with
+    /// ε_ij ~ N(0, σ_i²) and σ_i² estimated from the replicate spread at each X. Decomposing the
+    /// replicate residuals into within-X and between-X parts, the within-X term and the
+    /// Σ n_i·ln(2πσ_i²) normalisation are identical for every candidate family, so the
+    /// family-dependent part of −2·logL reduces to the GLS chi-square of the means:
+    /// χ² = Σ_i (ȳ_i − f(x_i))² / SE_i², where SE_i = σ_i / √n_i. AICc = χ² + 2k + 2k(k+1)/(N − k − 1)
+    /// with N = Σ n_i (total replicates). Family-independent constants are dropped, so the absolute
+    /// value is only meaningful in differences (Δ-AICc, Akaike weights) — which is all the estimator
+    /// consumes.
+    ///
+    /// <para>
+    /// This is also the likelihood the weighted fit actually minimised (the fit's 1/SE² weights are a
+    /// normalised version of <paramref name="inverseSquaredSes"/>, and normalisation does not move the
+    /// argmin), repairing the previous mismatch where parameters were chosen by weighted least squares
+    /// but families were ranked on unweighted residuals.
+    /// </para>
+    /// </summary>
+    internal static double ComputeReplicateAicc(
+        ScaleFishModelFunction function,
+        ComplexityMeasurement[] measurements,
+        double[] inverseSquaredSes,
+        int totalReplicates,
+        int k)
+    {
+        var parameters = function.FunctionParameters;
+        if (parameters is null) return double.PositiveInfinity;
+
+        double chiSquare = 0;
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            double predicted;
+            try
+            {
+                predicted = function.Compute(parameters.Bias, parameters.Scale, measurements[i].X);
+            }
+            catch
+            {
+                return double.PositiveInfinity;
+            }
+
+            if (!double.IsFinite(predicted)) return double.PositiveInfinity;
+            var residual = measurements[i].Y - predicted;
+            chiSquare += residual * residual * inverseSquaredSes[i];
+        }
+
+        if (!double.IsFinite(chiSquare)) return double.PositiveInfinity;
+
+        var denom = totalReplicates - k - 1;
+        if (denom <= 0) return double.PositiveInfinity;
+        return chiSquare + 2.0 * k + 2.0 * k * (k + 1) / denom;
+    }
+
+    /// <summary>
+    /// Raw 1/SE_i² for each measurement when every X carries usable replicate uncertainty; null
+    /// otherwise. Mirrors the all-or-nothing gate of
+    /// <see cref="ScaleFishModelFunction.BuildVarianceWeights"/> (which produces the same weights
+    /// normalised to sum to N for the fit) so the fit and the likelihood always agree on whether
+    /// replicate information is in play.
+    /// </summary>
+    private static double[]? TryBuildInverseSquaredStandardErrors(ComplexityMeasurement[] measurements)
+    {
+        if (measurements.Length == 0) return null;
+
+        var result = new double[measurements.Length];
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            if (!measurements[i].HasUncertainty) return null;
+            var se = measurements[i].StandardError;
+            if (se <= 0 || !double.IsFinite(se)) return null;
+            var invSquared = 1.0 / (se * se);
+            if (!double.IsFinite(invSquared)) return null;
+            result[i] = invSquared;
+        }
+
+        return result;
     }
 
     internal static double ComputeAkaikeWeightOfBest(double[] aiccValues)

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityFunctionRegistry.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityFunctionRegistry.cs
@@ -50,11 +50,24 @@ public static class ComplexityFunctionRegistry
     /// </summary>
     public static void Register<T>() where T : ScaleFishModelFunction, new()
     {
+        Register<T>(includeInFitting: true);
+    }
+
+    /// <summary>
+    /// Adds a complexity family to the catalog, optionally excluding it from the estimator's candidate
+    /// set. A family registered with <paramref name="includeInFitting"/> = false can still be
+    /// deserialized from persisted model files (and used for predictions), but is never fitted against
+    /// new measurements. The built-in <see cref="ComplexityFunctions.LogLinear"/> family uses this mode
+    /// because its basis is collinear with <see cref="ComplexityFunctions.NLogN"/> — fitting both would
+    /// make every n·log n classification appear statistically indistinguishable from itself.
+    /// </summary>
+    public static void Register<T>(bool includeInFitting) where T : ScaleFishModelFunction, new()
+    {
         // Use the runtime Name property — that's the string the JSON writer emits and the loader
         // looks up. Using typeof(T).Name would break round-trip for any family whose Name was
         // overridden to something other than the C# type name.
         var name = new T().Name;
-        var entry = new Entry(name, () => new T(), element => element.Deserialize<T>());
+        var entry = new Entry(name, () => new T(), element => element.Deserialize<T>(), includeInFitting);
         lock (SyncRoot)
         {
             Entries.RemoveAll(e => e.Name == name);
@@ -85,15 +98,16 @@ public static class ComplexityFunctionRegistry
     }
 
     /// <summary>
-    /// Returns fresh instances of every registered family. The estimator calls this each fit, so each
-    /// candidate gets its own mutable <see cref="ScaleFishModelFunction.FunctionParameters"/> — no shared
-    /// state across fits or threads.
+    /// Returns fresh instances of every registered family that participates in fitting. The estimator
+    /// calls this each fit, so each candidate gets its own mutable
+    /// <see cref="ScaleFishModelFunction.FunctionParameters"/> — no shared state across fits or threads.
+    /// Families registered as deserialization-only (see <see cref="Register{T}(bool)"/>) are excluded.
     /// </summary>
     public static IReadOnlyList<ScaleFishModelFunction> CreateFitInstances()
     {
         lock (SyncRoot)
         {
-            return Entries.Select(e => e.Factory()).ToList();
+            return Entries.Where(e => e.IncludeInFitting).Select(e => e.Factory()).ToList();
         }
     }
 
@@ -142,11 +156,20 @@ public static class ComplexityFunctionRegistry
         Register<NLogN>();
         Register<Quadratic>();
         Register<Cubic>();
-        Register<LogLinear>();
+        // LogLinear is x·log₂(x) — a constant multiple of NLogN's x·ln(x) basis, so both produce
+        // identical fits. Keeping it in the candidate set made the top two candidates tie whenever
+        // the truth was n·log n (Δ-AICc ≈ 0 ⇒ IsDistinguishable always false, Akaike weight halved,
+        // bootstrap selection-agreement split ~50/50). Registered deserialization-only so persisted
+        // models that classified as LogLinear keep loading and predicting.
+        Register<LogLinear>(includeInFitting: false);
         Register<Exponential>();
         Register<Factorial>();
         Register<SqrtN>();
     }
 
-    private sealed record Entry(string Name, Func<ScaleFishModelFunction> Factory, Func<JsonElement, ScaleFishModelFunction?> Deserializer);
+    private sealed record Entry(
+        string Name,
+        Func<ScaleFishModelFunction> Factory,
+        Func<JsonElement, ScaleFishModelFunction?> Deserializer,
+        bool IncludeInFitting);
 }

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityFunctions/LogLinear.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityFunctions/LogLinear.cs
@@ -2,6 +2,15 @@ using System;
 
 namespace Sailfish.Analysis.ScaleFish.ComplexityFunctions;
 
+/// <summary>
+/// n·log₂(n) family. <strong>Deserialization-only:</strong> log₂(x) = ln(x)/ln(2), so this basis is a
+/// constant multiple of <see cref="NLogN"/>'s and ordinary least squares produces identical fits for
+/// both (the constant is absorbed into <c>scale</c>). The estimator therefore fits only
+/// <see cref="NLogN"/>; this class remains registered so persisted models that classified as LogLinear
+/// keep loading and predicting. To force it back into the candidate set, call
+/// <c>ComplexityFunctionRegistry.Register&lt;LogLinear&gt;()</c> — at the cost of n·log n results never
+/// being statistically distinguishable from their own clone.
+/// </summary>
 public class LogLinear : ScaleFishModelFunction
 {
     public override string Name { get; set; } = nameof(LogLinear);

--- a/source/Sailfish/Analysis/ScaleFish/ComplexityReferences.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityReferences.cs
@@ -5,7 +5,7 @@ namespace Sailfish.Analysis.ScaleFish;
 /// <summary>
 /// Returns the catalog of complexity families considered by the estimator. As of phase-2 hardening this
 /// delegates to <see cref="ComplexityFunctionRegistry"/>, which built-in families auto-populate and user
-/// code can extend via <see cref="ComplexityFunctionRegistry.Register{T}"/>.
+/// code can extend via <see cref="ComplexityFunctionRegistry.Register{T}()"/>.
 /// </summary>
 public static class ComplexityReferences
 {

--- a/source/Sailfish/Analysis/ScaleFish/ScaleFishModel.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScaleFishModel.cs
@@ -50,7 +50,11 @@ public class ScaleFishModel
 
     /// <summary>
     /// Corrected Akaike Information Criterion (AICc) of the best-fitting family. Lower is better.
-    /// NaN when not computed (e.g. older deserialised models).
+    /// NaN when not computed (e.g. older deserialised models). When the measurements carried replicate
+    /// uncertainty this is the replicate-level (GLS chi-square) AICc; otherwise it is the means-level
+    /// OLS AICc. Family-independent constants are dropped in both forms, so only differences between
+    /// candidates (Δ-AICc, Akaike weights) are meaningful — absolute values are not comparable across
+    /// runs or Sailfish versions.
     /// </summary>
     public double BestAicc { get; init; }
 
@@ -73,7 +77,8 @@ public class ScaleFishModel
     public bool IsDistinguishable { get; init; }
 
     /// <summary>
-    /// The number of (X, Y) measurements used to fit the model. 0 when not recorded.
+    /// The number of (X, Y) mean points used to fit the model — i.e. the number of distinct X values,
+    /// not the total replicate count. 0 when not recorded.
     /// </summary>
     public int SampleSize { get; init; }
 

--- a/source/Sailfish/Analysis/ScaleFish/ScalefishObservationCompiler.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ScalefishObservationCompiler.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using Sailfish.Attributes;
+using Sailfish.Contracts.Public.Models;
 using Sailfish.Execution;
 
 namespace Sailfish.Analysis.ScaleFish;
@@ -37,51 +40,116 @@ internal class ScalefishObservationCompiler : IScalefishObservationCompiler
 
         var observations = new List<ScaleFishObservation>();
         foreach (var testCaseGroup in testCaseGroups)
-        foreach (var (complexityCase, caseIndex) in complexityCases.Zip(Enumerable.Range(0, complexityCases.Count)))
+        foreach (var complexityCase in complexityCases)
         {
-            var complexityMeasurements = ComputeComplexityMeasurements(caseIndex, complexityCase, complexityCases, testCaseGroup);
+            var complexityMeasurements = ComputeComplexityMeasurements(complexityCase, testCaseGroup);
             observations.Add(new ScaleFishObservation(testCaseGroup.TestCaseMethodName, complexityCase.ComplexityPropertyName, [.. complexityMeasurements]));
         }
 
         return new ObservationSetFromSummaries(testClassSummary.TestClass.FullName ?? $"Unknown-Namespace-{testClassSummary.TestClass.Name}", observations);
     }
 
-    // a bit mind bending here
+    /// <summary>
+    /// Selects, for one complexity property, the series of test cases where only that property varies —
+    /// every other variable (ScaleFish or not) held at a fixed combination — and converts it into
+    /// (X, mean, stddev, raw samples) measurements ordered by the property's declared values.
+    ///
+    /// <para>
+    /// Selection is by the variable <em>values</em> recorded on each case's <see cref="TestCaseId"/>.
+    /// The previous implementation indexed positionally into the group with stride arithmetic derived
+    /// from the complexity-property counts, which (a) used the wrong stride for middle properties whose
+    /// value count was small (it compared the property's index against its own value count rather than
+    /// the property count), (b) silently mis-attributed measurements whenever a non-ScaleFish variable
+    /// participated in the cartesian product, and (c) shifted off-by-one-or-more whenever a failed case
+    /// had been filtered out of the group.
+    /// </para>
+    /// </summary>
     private static List<ComplexityMeasurement> ComputeComplexityMeasurements(
-        int testCaseGroupIndex,
         ComplexityCase complexityCase,
-        IEnumerable<ComplexityCase> complexityCases,
         TestCaseComplexityGroup testCaseGroup)
     {
-        var step = testCaseGroupIndex < complexityCase.VariableCount - 1
-            ? complexityCases
-                .Skip(testCaseGroupIndex + 1)
-                .Select(x => x.VariableCount)
-                .Aggregate(1, (a, b) => a * b)
-            : 1;
+        // Annotate each successful case with this property's value and a key identifying the values of
+        // every other variable on the case. Cases within one key differ only in this property.
+        var annotated = new List<(ICompiledTestCaseResult Result, int Value, string SeriesKey)>(testCaseGroup.TestCaseGroup.Count);
+        foreach (var result in testCaseGroup.TestCaseGroup)
+        {
+            var variables = result.TestCaseId?.TestCaseVariables?.Variables;
+            if (variables is null) continue;
 
-        var indices = Enumerable.Range(0, complexityCase.VariableCount).Select(j => j * step).ToList();
-        var testResult = indices.Select(idx => testCaseGroup.TestCaseGroup[idx]).ToList();
-
-        var complexityMeasurements = complexityCase
-            .Variables
-            .Zip(testResult.Select(x => x.PerformanceRunResult!))
-            .Select(pair =>
+            int? ownValue = null;
+            var seriesKey = new StringBuilder();
+            foreach (var variable in variables)
             {
-                // The bootstrap and weighted-fit paths assume `SampleSize` matches the length of
-                // `RawSamples`. `PerformanceRunResult.SampleSize` is the *original* count (pre-outlier
-                // removal), while `DataWithOutliersRemoved` is what we actually carry as the raw vector.
-                // Use the cleaned vector's length so StandardError = StdDev / √N stays honest.
-                var cleaned = pair.Second.DataWithOutliersRemoved;
-                var effectiveN = cleaned?.Length ?? pair.Second.SampleSize;
-                return new ComplexityMeasurement(
-                    pair.First,
-                    pair.Second.Mean,
-                    pair.Second.StdDev,
-                    effectiveN,
-                    cleaned);
-            })
-            .ToList();
+                if (variable.Name == complexityCase.ComplexityPropertyName)
+                {
+                    if (TryReadIntVariable(variable.Value, out var parsed)) ownValue = parsed;
+                    continue;
+                }
+
+                seriesKey.Append(variable.Name).Append('=').Append(variable.Value?.ToString() ?? string.Empty).Append(';');
+            }
+
+            if (ownValue is null) continue;
+            annotated.Add((result, ownValue.Value, seriesKey.ToString()));
+        }
+
+        if (annotated.Count == 0) return [];
+
+        var declaredValues = complexityCase.Variables;
+
+        // Choose the baseline series: the fixed-other-variables slice covering the most declared values
+        // of this property. Ties resolve to the slice that appears first in the group, so the choice is
+        // deterministic for a given result set. (GroupBy preserves first-appearance key order and
+        // OrderByDescending is stable.)
+        var series = annotated
+            .GroupBy(a => a.SeriesKey)
+            .OrderByDescending(g => g.Select(a => a.Value).Distinct().Count(declaredValues.Contains))
+            .First();
+
+        // First occurrence wins if duplicate (property, value) cases exist within the series.
+        var resultByValue = new Dictionary<int, ICompiledTestCaseResult>();
+        foreach (var (result, value, _) in series) resultByValue.TryAdd(value, result);
+
+        var complexityMeasurements = new List<ComplexityMeasurement>(declaredValues.Count);
+        foreach (var declaredValue in declaredValues)
+        {
+            if (!resultByValue.TryGetValue(declaredValue, out var result)) continue;
+            var performanceRunResult = result.PerformanceRunResult;
+            if (performanceRunResult is null) continue;
+
+            // The bootstrap and weighted-fit paths assume `SampleSize` matches the length of
+            // `RawSamples`. `PerformanceRunResult.SampleSize` is the *original* count (pre-outlier
+            // removal), while `DataWithOutliersRemoved` is what we actually carry as the raw vector.
+            // Use the cleaned vector's length so StandardError = StdDev / √N stays honest.
+            var cleaned = performanceRunResult.DataWithOutliersRemoved;
+            var effectiveN = cleaned?.Length ?? performanceRunResult.SampleSize;
+            complexityMeasurements.Add(new ComplexityMeasurement(
+                declaredValue,
+                performanceRunResult.Mean,
+                performanceRunResult.StdDev,
+                effectiveN,
+                cleaned));
+        }
+
         return complexityMeasurements;
+    }
+
+    /// <summary>
+    /// Reads a complexity-variable value from a <see cref="TestCaseVariable.Value"/>. Live runs carry
+    /// the boxed int from the attribute; tracking-file round-trips can surface the value as a string or
+    /// a JsonElement, so anything else falls back to an invariant-culture parse of its string form.
+    /// </summary>
+    private static bool TryReadIntVariable(object? value, out int parsed)
+    {
+        switch (value)
+        {
+            case int i:
+                parsed = i;
+                return true;
+            case string s:
+                return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+            default:
+                return int.TryParse(value?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+        }
     }
 }

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishConvergenceStressTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishConvergenceStressTests.cs
@@ -42,12 +42,10 @@ public class ScaleFishConvergenceStressTests
             winnerCounts[result.ScaleFishModelFunction.Name] = current + 1;
         }
 
+        // Exact-name expectation: the LogLinear clone is deserialization-only, so each family's data
+        // has exactly one correct winner.
         var expected = familyType.Name;
-        var equivalents = expected == nameof(NLogN) || expected == nameof(LogLinear)
-            ? new HashSet<string> { nameof(NLogN), nameof(LogLinear) }
-            : new HashSet<string> { expected };
-
-        var wins = winnerCounts.Where(kv => equivalents.Contains(kv.Key)).Sum(kv => kv.Value);
+        winnerCounts.TryGetValue(expected, out var wins);
         wins.ShouldBe(
             seeds,
             $"{expected}: expected {seeds}/{seeds}, got: {string.Join(", ", winnerCounts.Select(kv => $"{kv.Key}={kv.Value}"))}");

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishConvergenceTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishConvergenceTests.cs
@@ -35,9 +35,14 @@ public class ScaleFishConvergenceTests
     }
 
     [Fact]
-    public void EstimatorFindsCorrectComplexity_LogLinear()
+    public void EstimatorFindsCorrectComplexity_LogLinearData_ClassifiesAsNLogN()
     {
-        Assert<LogLinear>();
+        // LogLinear's x·log₂(x) basis is a constant multiple of NLogN's x·ln(x); the constant is
+        // absorbed into the fitted scale, so the canonical NLogN family is the correct (and only)
+        // n·log n candidate now that the collinear clone is deserialization-only.
+        var estimation = new ComplexityEstimator().EstimateComplexity(GetMeasurements<LogLinear>());
+        estimation.ShouldNotBeNull();
+        estimation.ScaleFishModelFunction.Name.ShouldBe(nameof(NLogN));
     }
 
     [Fact]

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishModelSelectionTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishModelSelectionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
+using Sailfish.Analysis.ScaleFish.CurveFitting;
 using Shouldly;
 using Xunit;
 
@@ -98,5 +99,110 @@ public class ScaleFishModelSelectionTests
         new ComplexityEstimator()
             .EstimateComplexity(Array.Empty<ComplexityMeasurement>())
             .ShouldBeNull();
+    }
+
+    [Fact]
+    public void NLogNData_WithReplicates_IsDistinguishable()
+    {
+        // Regression for the LogLinear clone: with both x·ln(x) and x·log₂(x) in the candidate set,
+        // n·log n data always produced ΔAICc ≈ 0 between the two identical fits, so this could never
+        // be distinguishable no matter how clean the data.
+        var nlogn = new NLogN();
+        var rng = new Random(7);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => nlogn.Compute(0.0, 1.0, x),
+            ScaleFishTestHelpers.LogSpacedX(8, 1024, 6),
+            sampleSize: 30,
+            relativeNoise: 0.05,
+            rng);
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+
+        result.ShouldNotBeNull();
+        result.ScaleFishModelFunction.Name.ShouldBe(nameof(NLogN));
+        result.IsDistinguishable.ShouldBeTrue("n·log n no longer ties with its own collinear clone");
+    }
+
+    [Fact]
+    public void ThreeXValues_WithReplicates_CanDistinguish()
+    {
+        // Regression for means-level AICc degeneracy: with n = 3 X values and k = 2 parameters the
+        // small-sample correction divides by n − k − 1 = 0, so every family scored +∞, the Akaike
+        // weight was NaN, and no 3-value declaration could ever be distinguishable. Replicate-level
+        // scoring uses N = Σ replicates, so the information in the per-X spread finally counts.
+        var quadratic = new Quadratic();
+        var rng = new Random(11);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => quadratic.Compute(0.0, 1.0, x),
+            new[] { 10, 100, 1000 },
+            sampleSize: 15,
+            relativeNoise: 0.05,
+            rng);
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+
+        result.ShouldNotBeNull();
+        result.ScaleFishModelFunction.Name.ShouldBe(nameof(Quadratic));
+        result.IsDistinguishable.ShouldBeTrue();
+        double.IsFinite(result.BestAicc).ShouldBeTrue();
+        double.IsFinite(result.AkaikeWeight).ShouldBeTrue();
+        result.AkaikeWeight.ShouldBeGreaterThan(0.5);
+    }
+
+    [Fact]
+    public void ThreeXValues_MeansOnly_RemainsIndistinguishable()
+    {
+        // Without replicate uncertainty there is no honest way to select among two-parameter
+        // families from three means; the means-level fallback keeps reporting that.
+        var quadratic = new Quadratic();
+        var measurements = ScaleFishTestHelpers.BuildExact(quadratic, new[] { 10, 100, 1000 });
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+
+        result.ShouldNotBeNull();
+        result.IsDistinguishable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReplicateAicc_LowerForBetterFittingParameters()
+    {
+        var measurements = new[]
+        {
+            new ComplexityMeasurement(10, 20, stdDev: 1.0, sampleSize: 10),
+            new ComplexityMeasurement(20, 40, stdDev: 1.0, sampleSize: 10),
+            new ComplexityMeasurement(40, 80, stdDev: 1.0, sampleSize: 10)
+        };
+        var inverseSquaredSes = new[] { 10.0, 10.0, 10.0 }; // SE = 1/√10 ⇒ 1/SE² = 10
+
+        var exact = new Linear { FunctionParameters = new FittedCurve(scale: 2.0, bias: 0.0) };
+        var off = new Linear { FunctionParameters = new FittedCurve(scale: 2.5, bias: 0.0) };
+
+        var exactAicc = ComplexityEstimator.ComputeReplicateAicc(exact, measurements, inverseSquaredSes, totalReplicates: 30, k: 2);
+        var offAicc = ComplexityEstimator.ComputeReplicateAicc(off, measurements, inverseSquaredSes, totalReplicates: 30, k: 2);
+
+        exactAicc.ShouldBeLessThan(offAicc);
+        // Perfect fit ⇒ χ² = 0 ⇒ AICc reduces to the parameter penalty: 2k + 2k(k+1)/(N−k−1).
+        exactAicc.ShouldBe(4.0 + 12.0 / 27.0, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void ReplicateAicc_DegenerateInputs_ReturnInfinity()
+    {
+        var measurements = new[]
+        {
+            new ComplexityMeasurement(10, 20, stdDev: 1.0, sampleSize: 1),
+            new ComplexityMeasurement(20, 40, stdDev: 1.0, sampleSize: 1)
+        };
+        var inverseSquaredSes = new[] { 1.0, 1.0 };
+
+        // Unfitted function abstains.
+        var unfitted = new Linear();
+        ComplexityEstimator.ComputeReplicateAicc(unfitted, measurements, inverseSquaredSes, totalReplicates: 2, k: 2)
+            .ShouldBe(double.PositiveInfinity);
+
+        // Total replicates ≤ k + 1 leaves the small-sample correction undefined.
+        var fitted = new Linear { FunctionParameters = new FittedCurve(scale: 2.0, bias: 0.0) };
+        ComplexityEstimator.ComputeReplicateAicc(fitted, measurements, inverseSquaredSes, totalReplicates: 3, k: 2)
+            .ShouldBe(double.PositiveInfinity);
     }
 }

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishNoisyConvergenceTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishNoisyConvergenceTests.cs
@@ -96,30 +96,13 @@ public class ScaleFishNoisyConvergenceTests
             winnerCounts[name] = current + 1;
         }
 
+        // Exact-name expectation: the LogLinear clone (x·log₂x, collinear with NLogN's x·ln x) is
+        // deserialization-only now, so n·log n data has exactly one correct winner.
         var expected = typeof(TFamily).Name;
-        var equivalents = EquivalentFamilies(expected);
+        winnerCounts.TryGetValue(expected, out var wins);
 
-        var validWins = winnerCounts
-            .Where(kv => equivalents.Contains(kv.Key))
-            .Sum(kv => kv.Value);
-
-        validWins.ShouldBe(
+        wins.ShouldBe(
             Seeds,
-            $"Expected {expected} (or equivalent) to win every seed, got: {string.Join(", ", winnerCounts.Select(kv => $"{kv.Key}={kv.Value}"))}");
-    }
-
-    /// <summary>
-    /// Returns the set of family names that are mathematically equivalent up to the scale parameter.
-    /// NLogN (natural log) and LogLinear (log base 2) differ only by the constant ln(2), which the fit
-    /// absorbs into <c>scale</c>; either is the correct answer for the other's data.
-    /// </summary>
-    private static System.Collections.Generic.HashSet<string> EquivalentFamilies(string name)
-    {
-        return name switch
-        {
-            nameof(NLogN) => new() { nameof(NLogN), nameof(LogLinear) },
-            nameof(LogLinear) => new() { nameof(NLogN), nameof(LogLinear) },
-            _ => new() { name }
-        };
+            $"Expected {expected} to win every seed, got: {string.Join(", ", winnerCounts.Select(kv => $"{kv.Key}={kv.Value}"))}");
     }
 }

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishRegistryTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishRegistryTests.cs
@@ -31,6 +31,38 @@ public class ScaleFishRegistryTests
     }
 
     [Fact]
+    public void LogLinear_IsDeserializationOnly()
+    {
+        // Registered (old model files keep loading)…
+        ComplexityFunctionRegistry.IsRegistered(nameof(LogLinear)).ShouldBeTrue();
+        var elem = System.Text.Json.JsonSerializer.SerializeToElement(new LogLinear());
+        ComplexityFunctionRegistry.Deserialize(nameof(LogLinear), elem).ShouldNotBeNull();
+
+        // …but never a fit candidate: its basis is a constant multiple of NLogN's, and fitting both
+        // made every n·log n classification tie with its own clone (never distinguishable).
+        ComplexityFunctionRegistry.CreateFitInstances()
+            .Any(f => f.Name == nameof(LogLinear))
+            .ShouldBeFalse("LogLinear is collinear with NLogN and must not participate in fitting");
+    }
+
+    [Fact]
+    public void Register_LogLinear_OptsBackIntoFitting()
+    {
+        try
+        {
+            // The escape hatch: explicit registration restores the family as a fit candidate.
+            ComplexityFunctionRegistry.Register<LogLinear>();
+            ComplexityFunctionRegistry.CreateFitInstances()
+                .Any(f => f.Name == nameof(LogLinear))
+                .ShouldBeTrue();
+        }
+        finally
+        {
+            ComplexityFunctionRegistry.ResetToBuiltIns();
+        }
+    }
+
+    [Fact]
     public void Register_NewFamily_IncludedInFitCatalog()
     {
         try

--- a/source/Tests.Library/Analysis/ScaleFish/ScalefishObservationCompilerTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScalefishObservationCompilerTests.cs
@@ -237,10 +237,138 @@ public class ScalefishObservationCompilerTests
         return summary;
     }
 
+    [Fact]
+    public void CompileObservationSet_PairsMeasurementsWithDeclaredValues_RegardlessOfResultOrder()
+    {
+        // Results arrive in reverse declaration order. Positional indexing would pair X=1 with the
+        // N=3 measurement; value-based selection must pair each X with its own case's mean.
+        var summary = Substitute.For<IClassExecutionSummary>();
+        summary.TestClass.Returns(typeof(TestClassWithComplexityVariables));
+        var testCaseResults = new List<ICompiledTestCaseResult>
+        {
+            CreateTestCaseResult("TestMethod", 3, 300.0),
+            CreateTestCaseResult("TestMethod", 1, 100.0),
+            CreateTestCaseResult("TestMethod", 2, 200.0)
+        };
+        summary.CompiledTestCaseResults.Returns(testCaseResults);
+        summary.FilterForSuccessfulTestCases().Returns(summary);
+
+        var result = _compiler.CompileObservationSet(summary);
+
+        result.ShouldNotBeNull();
+        var measurements = result.Observations.Single().ComplexityMeasurements;
+        measurements.Select(m => (m.X, m.Y)).ShouldBe(new[] { (1.0, 100.0), (2.0, 200.0), (3.0, 300.0) });
+    }
+
+    [Fact]
+    public void CompileObservationSet_MiddleComplexityVariable_GetsItsOwnSeries()
+    {
+        // Regression: the old stride arithmetic compared a property's index against its own value
+        // count (`index < VariableCount - 1`) instead of the property count. The ScaleFish attribute
+        // requires ≥ 3 values, so the first affected position is property index 2 with exactly 3
+        // values and at least one property after it: C's stride degenerated to 1 and its "series"
+        // actually varied D. Each property's measurements must vary only that property, with every
+        // other property held at its first declared value.
+        var summary = Substitute.For<IClassExecutionSummary>();
+        summary.TestClass.Returns(typeof(TestClassWithFourComplexityVariables));
+
+        var testCaseResults = new List<ICompiledTestCaseResult>();
+        foreach (var a in new[] { 1, 2, 3 })
+        foreach (var b in new[] { 10, 20, 30 })
+        foreach (var c in new[] { 100, 200, 300 })
+        foreach (var d in new[] { 1000, 2000, 3000 })
+            testCaseResults.Add(CreateTestCaseResult(
+                "TestMethod",
+                [
+                    new TestCaseVariable("A", a),
+                    new TestCaseVariable("B", b),
+                    new TestCaseVariable("C", c),
+                    new TestCaseVariable("D", d)
+                ],
+                EncodedMean(a, b, c, d)));
+
+        summary.CompiledTestCaseResults.Returns(testCaseResults);
+        summary.FilterForSuccessfulTestCases().Returns(summary);
+
+        var result = _compiler.CompileObservationSet(summary);
+
+        result.ShouldNotBeNull();
+        var byProperty = result.Observations.ToDictionary(o => o.PropertyName, o => o.ComplexityMeasurements);
+
+        byProperty["A"].Select(m => (m.X, m.Y))
+            .ShouldBe(new[] { 1, 2, 3 }.Select(a => ((double)a, EncodedMean(a, 10, 100, 1000))));
+        byProperty["B"].Select(m => (m.X, m.Y))
+            .ShouldBe(new[] { 10, 20, 30 }.Select(b => ((double)b, EncodedMean(1, b, 100, 1000))));
+        byProperty["C"].Select(m => (m.X, m.Y))
+            .ShouldBe(new[] { 100, 200, 300 }.Select(c => ((double)c, EncodedMean(1, 10, c, 1000))));
+        byProperty["D"].Select(m => (m.X, m.Y))
+            .ShouldBe(new[] { 1000, 2000, 3000 }.Select(d => ((double)d, EncodedMean(1, 10, 100, d))));
+    }
+
+    [Fact]
+    public void CompileObservationSet_NonComplexityVariable_HeldFixedAcrossTheSeries()
+    {
+        // A plain (non-scaleFish) variable participates in the cartesian product. The complexity
+        // series must hold it at a single value rather than mixing measurements across its values.
+        var summary = Substitute.For<IClassExecutionSummary>();
+        summary.TestClass.Returns(typeof(TestClassWithMixedVariables));
+
+        var testCaseResults = new List<ICompiledTestCaseResult>();
+        foreach (var size in new[] { 1, 2, 3 })
+        foreach (var mode in new[] { "alpha", "beta" })
+            testCaseResults.Add(CreateTestCaseResult(
+                "TestMethod",
+                [new TestCaseVariable("Mode", mode), new TestCaseVariable("Size", size)],
+                size * 100.0 + (mode == "alpha" ? 0.0 : 1.0)));
+
+        summary.CompiledTestCaseResults.Returns(testCaseResults);
+        summary.FilterForSuccessfulTestCases().Returns(summary);
+
+        var result = _compiler.CompileObservationSet(summary);
+
+        result.ShouldNotBeNull();
+        var measurements = result.Observations.Single(o => o.PropertyName == "Size").ComplexityMeasurements;
+        measurements.Select(m => (m.X, m.Y)).ShouldBe(new[] { (1.0, 100.0), (2.0, 200.0), (3.0, 300.0) });
+    }
+
+    [Fact]
+    public void CompileObservationSet_FilteredFailedCase_DoesNotShiftAttribution()
+    {
+        // The N=2 case failed and was filtered out. Positional indexing would walk off the end or
+        // shift every later measurement onto the wrong X; value-based selection just omits the gap.
+        var summary = Substitute.For<IClassExecutionSummary>();
+        summary.TestClass.Returns(typeof(TestClassWithComplexityVariables));
+        var testCaseResults = new List<ICompiledTestCaseResult>
+        {
+            CreateTestCaseResult("TestMethod", 1, 100.0),
+            CreateTestCaseResult("TestMethod", 3, 300.0)
+        };
+        summary.CompiledTestCaseResults.Returns(testCaseResults);
+        summary.FilterForSuccessfulTestCases().Returns(summary);
+
+        var result = _compiler.CompileObservationSet(summary);
+
+        result.ShouldNotBeNull();
+        var measurements = result.Observations.Single().ComplexityMeasurements;
+        measurements.Select(m => (m.X, m.Y)).ShouldBe(new[] { (1.0, 100.0), (3.0, 300.0) });
+    }
+
+    private static double EncodedMean(int a, int b, int c, int d) =>
+        a * 1_000_000_000.0 + b * 1_000_000.0 + c * 1_000.0 + d;
+
     private static ICompiledTestCaseResult CreateTestCaseResult(string methodName, int variableValue, double meanTime)
+    {
+        return CreateTestCaseResult(methodName, [new TestCaseVariable("N", variableValue)], meanTime);
+    }
+
+    private static ICompiledTestCaseResult CreateTestCaseResult(
+        string methodName,
+        IEnumerable<TestCaseVariable> variables,
+        double meanTime)
     {
         var testCaseId = TestCaseIdBuilder.Create()
             .WithTestCaseName(methodName)
+            .WithTestCaseVariables(variables)
             .Build();
 
         var performanceResult = PerformanceRunResultBuilder.Create()
@@ -265,6 +393,33 @@ public class ScalefishObservationCompilerTests
     {
         [SailfishVariable(true, 1, 2, 3)]
         public int N { get; set; }
+    }
+
+    private class TestClassWithFourComplexityVariables
+    {
+        [SailfishVariable(true, 1, 2, 3)]
+        public int A { get; set; }
+
+        [SailfishVariable(true, 10, 20, 30)]
+        public int B { get; set; }
+
+        // Three values (the attribute minimum) at property index 2: the old
+        // `index < own-value-count - 1` stride condition degenerated to stride 1 here,
+        // attributing D-varying cases to C.
+        [SailfishVariable(true, 100, 200, 300)]
+        public int C { get; set; }
+
+        [SailfishVariable(true, 1000, 2000, 3000)]
+        public int D { get; set; }
+    }
+
+    private class TestClassWithMixedVariables
+    {
+        [SailfishVariable(true, 1, 2, 3)]
+        public int Size { get; set; }
+
+        [SailfishVariable("alpha", "beta")]
+        public string Mode { get; set; } = string.Empty;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the three highest-ranked correctness bugs from the ScaleFish/SailDiff intelligence review. All three sit in the model-selection layer, all three silently degraded every ScaleFish classification, and none required an API break.

### 1. `LogLinear` was a collinear clone of `NLogN` — n·log n results could never be distinguishable

`LogLinear`'s basis `x·log₂(x)` is a constant multiple of `NLogN`'s `x·ln(x)` (log₂x = ln x / ln 2), so OLS produced *identical* fits and identical AICc for both. Whenever the true complexity was n·log n:

- Δ-AICc between best and runner-up ≈ 0 ⇒ `IsDistinguishable` was **always false**, no matter how clean the data
- the Akaike weight was capped near 0.5 (two clones split the evidence)
- bootstrap `selectionAgreement` split ~50/50 on floating-point noise, reading "unstable" on perfect data
- `SuggestedNextN` fired pointlessly — no probe extension can separate two identical curves

**Fix:** `LogLinear` is registered **deserialization-only**. Persisted models that classified as LogLinear keep loading and predicting; `ComplexityFunctionRegistry.Register<LogLinear>()` opts it back into fitting if anyone really wants it. Docs table updated.

### 2. Means-level AICc was degenerate for the common 3-value declaration

AICc used `n = #X values` with `k = 2`, so a 3-value `[SailfishVariable(scaleFish: true, …)]` (the documented minimum, used by `AllTheFeatures.cs`) made the small-sample correction divide by `n − k − 1 = 0`: **every family scored +∞**, the Akaike weight was NaN, and the result was permanently indistinguishable — while 15+ replicates per X sat unused in the likelihood. The ranking also used *unweighted* residuals even when the fit itself was variance-weighted (fit and ranking optimized different objectives).

**Fix:** when every X carries replicate uncertainty, candidates are scored with the replicate-level GLS likelihood: χ² = Σ (ȳᵢ − f(xᵢ))²/SEᵢ², AICc = χ² + 2k + 2k(k+1)/(N−k−1) with **N = total replicates**. This is exactly the likelihood the weighted fit minimises (normalization doesn't move the argmin), so fit and ranking finally agree. Means-only data (deserialized tracking, synthetic exact data) falls back to the previous means-level AICc unchanged.

### 3. Observation compiler attributed measurements to the wrong cases

`ComputeComplexityMeasurements` selected cases by positional stride arithmetic, and its stride condition compared a property's **index** against its **own value count** (`testCaseGroupIndex < complexityCase.VariableCount - 1`). Consequences:

- with ≥3 scaleFish variables, a middle property at index ≥ 2 with the minimum 3 values got stride 1 — its "series" actually varied the *next* property
- any non-scaleFish variable in the cartesian product mis-indexed every series
- a failed (filtered) case shifted every subsequent measurement onto the wrong X

**Fix:** selection is now by the variable **values** recorded on each case's `TestCaseId` — pick the fixed-other-variables slice with the best coverage of the declared values (deterministic tie-break), pair each declared value with its own case. Order-independent, mixed-variable-safe, and gap-tolerant.

## Verification

- Every new regression test was run against the **old** implementation and fails there; all pass on the fix (4 compiler tests, the NLogN-distinguishability test, the 3-X-replicates test)
- Full suites green on net9.0 + net10.0: Tests.Library 1673/1673, Tests.TestAdapter 168/168, Tests.Analyzers 107/107 (one unrelated known load-flake, `SteadyStateWarmup_StableMethod_StopsEarly`, passes in isolation)
- Solution builds with 0 warnings
- End-to-end via `ScaleFishDemo` (real measured `Task.Delay` workloads): the `NLogN` method now reports **BestFit NLogN, runner-up Linear, Distinguishable yes, Akaike weight 1.000, CV agree 1.00** — previously structurally impossible — and the loaded model recovered `f(x) = 12.4982x + 4.3468` against a true `12.5·N + 3` workload

## Behaviour notes (no API break)

- Data that used to classify as `LogLinear` now reports `NLogN` (same curve, scale absorbs the ln 2)
- `BestAicc`/`NextBestAicc` absolute values change scale under replicate scoring; they were only ever meaningful as differences (Δ-AICc, weights) — docs updated to say so
- New overload `ComplexityFunctionRegistry.Register<T>(bool includeInFitting)` (additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced complexity estimation with support for replicate-aware model selection, improving accuracy when measurement replicates are available.

* **Improvements**
  * Refined observation compilation with improved variable/value matching logic.
  * LogLinear complexity function now registered as deserialization-only by default.

* **Documentation**
  * Clarified AICc calculation documentation and sample size definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->