### PR TITLE
test: deflake steady-state warmup integration tests via injectable warmup timer

### DIFF
--- a/source/Sailfish/Execution/SteadyStateWarmupTimer.cs
+++ b/source/Sailfish/Execution/SteadyStateWarmupTimer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Sailfish.Execution;
+
+/// <summary>
+///     Times a single steady-state warmup invocation. Production uses the wall-clock
+///     <see cref="StopwatchWarmupTimer"/>; tests substitute a scripted source so the warmup
+///     <em>loop logic</em> (floor / window / early-stop / cap) can be exercised deterministically —
+///     real wall-clock durations under CI load carry unbounded jitter, which made any assertion on
+///     "a stable method stops early" inherently flaky.
+/// </summary>
+internal interface ISteadyStateWarmupTimer
+{
+    /// <summary>Invokes <paramref name="invocation"/> once and returns its duration in milliseconds.</summary>
+    Task<double> TimeAsync(Func<Task> invocation);
+}
+
+/// <summary>Wall-clock implementation used in production runs.</summary>
+internal sealed class StopwatchWarmupTimer : ISteadyStateWarmupTimer
+{
+    public async Task<double> TimeAsync(Func<Task> invocation)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        await invocation().ConfigureAwait(false);
+        stopwatch.Stop();
+        return stopwatch.Elapsed.TotalMilliseconds;
+    }
+}

--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -28,6 +27,14 @@ internal class TestCaseIterator : ITestCaseIterator
     private readonly IIterationStrategy _fixedIterationStrategy;
     private readonly IIterationStrategy _adaptiveIterationStrategy;
     private readonly IStatisticalTestExecutor? _statExecutor;
+
+    /// <summary>
+    ///     Duration source for steady-state warmup iterations. Wall-clock by default; tests inject a
+    ///     scripted source so the warmup loop's floor/window/early-stop/cap behaviour can be asserted
+    ///     deterministically instead of depending on host load. Settable test seam (same convention as
+    ///     <see cref="Sailfish.Analysis.ScaleFish.ScaleFishModelFunction.FitnessCalculator"/>).
+    /// </summary>
+    internal ISteadyStateWarmupTimer WarmupTimer { get; set; } = new StopwatchWarmupTimer();
 
     public TestCaseIterator(
         IRunSettings runSettings,
@@ -250,10 +257,10 @@ internal class TestCaseIterator : ITestCaseIterator
                 return CatchAndReturn(testInstanceContainer, ex);
             }
 
-            var sw = Stopwatch.StartNew();
-            await testInstanceContainer.CoreInvoker.ExecutionMethod(cancellationToken, false).ConfigureAwait(false);
-            sw.Stop();
-            durations.Add(sw.Elapsed.TotalMilliseconds);
+            var elapsedMs = await WarmupTimer
+                .TimeAsync(() => testInstanceContainer.CoreInvoker.ExecutionMethod(cancellationToken, false))
+                .ConfigureAwait(false);
+            durations.Add(elapsedMs);
 
             try
             {

--- a/source/Tests.Library/Integration/SteadyStateWarmupIntegrationTests.cs
+++ b/source/Tests.Library/Integration/SteadyStateWarmupIntegrationTests.cs
@@ -10,17 +10,29 @@ using Xunit;
 
 namespace Tests.Library.Integration;
 
+/// <summary>
+/// Exercises the steady-state warmup loop (floor / window / early-stop / cap) end-to-end through
+/// TestCaseIterator, with the warmup durations supplied by a scripted <see cref="ISteadyStateWarmupTimer"/>
+/// rather than the wall clock. The previous version timed a real ~3ms spin-wait, which made "a stable
+/// method stops early" depend on host load: under CI/parallel-suite pressure the spin stretched, the
+/// detector's CV threshold blew out, and the test flaked. The scripted timer still drives the real
+/// invocation path (the method under test is genuinely called for every warmup), but the durations fed
+/// to the detector are deterministic.
+/// </summary>
 public class SteadyStateWarmupIntegrationTests
 {
     private const int Window = SteadyStateWarmupDetector.DefaultWindow; // detector window (effective minimum before a decision)
 
-    private static TestCaseIterator NewIterator()
+    private static TestCaseIterator NewIterator(ISteadyStateWarmupTimer warmupTimer)
     {
         var logger = Substitute.For<ILogger>();
         var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder().Build();
         return new TestCaseIterator(runSettings, logger,
             new FixedIterationStrategy(logger),
-            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()));
+            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()))
+        {
+            WarmupTimer = warmupTimer
+        };
     }
 
     [Fact]
@@ -28,11 +40,11 @@ public class SteadyStateWarmupIntegrationTests
     {
         const int sampleSize = 2;
         const int maxWarmup = 50;
-        var instance = new CountingStableWork(3); // stable ~3ms/call
-        var method = typeof(CountingStableWork).GetMethod(nameof(CountingStableWork.Run))!;
+        var instance = new CountingWork();
+        var method = typeof(CountingWork).GetMethod(nameof(CountingWork.Run))!;
         var settings = new ExecutionSettings
         {
-            NumWarmupIterations = 2, // floor
+            NumWarmupIterations = 2, // floor below the window — the window governs the minimum
             SampleSize = sampleSize,
             UseSteadyStateWarmup = true,
             MaxWarmupIterations = maxWarmup,
@@ -40,12 +52,14 @@ public class SteadyStateWarmupIntegrationTests
         };
         var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
 
-        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+        // Perfectly stable durations: zero drift, zero CV — steady at the first possible decision.
+        var result = await NewIterator(new ScriptedWarmupTimer(_ => 3.0))
+            .Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
 
         result.IsSuccess.ShouldBeTrue();
         var warmups = instance.Calls - sampleSize; // total invocations minus measured samples
-        warmups.ShouldBeGreaterThanOrEqualTo(Window); // can't decide before the window fills
-        warmups.ShouldBeLessThan(maxWarmup);          // stopped early — did not hit the cap
+        warmups.ShouldBe(Window, "a perfectly stable signal must be declared steady at the first decision point");
+        warmups.ShouldBeLessThan(maxWarmup); // stopped early — did not hit the cap
     }
 
     [Fact]
@@ -53,8 +67,8 @@ public class SteadyStateWarmupIntegrationTests
     {
         const int sampleSize = 2;
         const int floor = 12; // floor > window, so the floor governs the minimum
-        var instance = new CountingStableWork(3);
-        var method = typeof(CountingStableWork).GetMethod(nameof(CountingStableWork.Run))!;
+        var instance = new CountingWork();
+        var method = typeof(CountingWork).GetMethod(nameof(CountingWork.Run))!;
         var settings = new ExecutionSettings
         {
             NumWarmupIterations = floor,
@@ -65,28 +79,72 @@ public class SteadyStateWarmupIntegrationTests
         };
         var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
 
-        var result = await NewIterator().Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+        var result = await NewIterator(new ScriptedWarmupTimer(_ => 3.0))
+            .Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
 
         result.IsSuccess.ShouldBeTrue();
         var warmups = instance.Calls - sampleSize;
-        warmups.ShouldBeGreaterThanOrEqualTo(floor); // never stops before the configured floor
+        // Even a perfectly stable signal must not stop before the configured floor; with stable
+        // durations the first permitted decision succeeds, so the floor is also the stopping point.
+        warmups.ShouldBe(floor);
     }
 
-    private sealed class CountingStableWork
+    [Fact]
+    public async Task SteadyStateWarmup_UnstableMethod_HitsCap()
     {
-        private readonly int _ms;
+        // The counterpart guarantee — previously untestable with wall-clock timing: a signal that
+        // never stabilises (alternating 3ms / 30ms ⇒ CV far above the detector threshold at every
+        // window) must run warmup all the way to the cap, never declaring steady state.
+        const int sampleSize = 2;
+        const int maxWarmup = 20;
+        var instance = new CountingWork();
+        var method = typeof(CountingWork).GetMethod(nameof(CountingWork.Run))!;
+        var settings = new ExecutionSettings
+        {
+            NumWarmupIterations = 2,
+            SampleSize = sampleSize,
+            UseSteadyStateWarmup = true,
+            MaxWarmupIterations = maxWarmup,
+            UseAdaptiveSampling = false
+        };
+        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+
+        var result = await NewIterator(new ScriptedWarmupTimer(i => i % 2 == 0 ? 3.0 : 30.0))
+            .Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        var warmups = instance.Calls - sampleSize;
+        warmups.ShouldBe(maxWarmup, "an unstable signal must never be declared steady before the cap");
+    }
+
+    /// <summary>
+    /// Drives the real invocation (so call counting stays honest) but reports scripted durations,
+    /// decoupling the warmup decision from host load.
+    /// </summary>
+    private sealed class ScriptedWarmupTimer : ISteadyStateWarmupTimer
+    {
+        private readonly Func<int, double> _durationForInvocation;
+        private int _invocationIndex;
+
+        public ScriptedWarmupTimer(Func<int, double> durationForInvocation)
+        {
+            _durationForInvocation = durationForInvocation;
+        }
+
+        public async Task<double> TimeAsync(Func<Task> invocation)
+        {
+            await invocation().ConfigureAwait(false);
+            return _durationForInvocation(_invocationIndex++);
+        }
+    }
+
+    private sealed class CountingWork
+    {
         public int Calls;
-        public CountingStableWork(int ms) => _ms = ms;
 
         public Task Run(CancellationToken ct)
         {
             Calls++;
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            while (sw.ElapsedMilliseconds < _ms)
-            {
-                if (ct.IsCancellationRequested) break;
-                Thread.SpinWait(1000);
-            }
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary

`SteadyStateWarmup_StableMethod_StopsEarly` has been the suite's recurring load-flake since it was flagged during [#322](https://github.com/paulegradie/Sailfish/pull/322): it timed a real ~3ms spin-wait and asserted the stability detector fired before the warmup cap. Under load (concurrent net9+net10 suite runs locally, GitHub Actions runners) the spin stretched arbitrarily, the detector's CV threshold blew out, and the test hit the cap — it has needed `gh run rerun --failed` on multiple PRs (most recently [#325](https://github.com/paulegradie/Sailfish/pull/325)).

## Change

- **`ISteadyStateWarmupTimer`** (internal): the steady-state warmup loop now sources per-iteration durations through this seam. Production behaviour is byte-identical — `StopwatchWarmupTimer` wraps the same `Stopwatch.StartNew()`/`Elapsed.TotalMilliseconds` the loop used inline. Settable internal property on `TestCaseIterator`, same convention as the existing `ScaleFishModelFunction.FitnessCalculator` test seam.
- **Integration tests rewritten** to inject a scripted timer that still drives the real invocation path (the method under test is genuinely called for every warmup — call counting stays honest) while the detector sees deterministic durations. The assertions tighten from inequalities to exact contracts:
  - stable signal → stops at the first decision point (`warmups == window`)
  - floor above the window → floor governs (`warmups == floor`)
  - **new:** unstable signal (alternating 3/30 ms — CV permanently above threshold) → never declares steady, runs to the cap (`warmups == cap`). This counterpart guarantee was untestable with wall-clock timing.
- The test class drops from ~1.5 s of real spinning to ~90 ms.

## Verification

The reproduction condition is the full Tests.Library suite with both TFMs running concurrently. Three consecutive rounds: the warmup tests passed **every round on both TFMs** (previously flaked in roughly 3 of 4 such runs today), plus repeated isolation runs. Sailfish builds with zero warnings.

One unrelated observation from the stress rounds: `ScaleFishParallelBootstrapTests.RepeatedParallelRuns_AreIdentical` flaked once under the same concurrent load — `ScaleFishRegistryTests` mutates the global `ComplexityFunctionRegistry` while collections run fully parallel, which can race any test that assumes a stable candidate catalog. Pre-existing and out of scope here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened warmup timing measurements to ensure more consistent and deterministic test execution in CI environments using scripted timing patterns

* **Refactor**
  * Refactored internal timing abstraction to support more flexible and reliable benchmark measurement capabilities with improved warmup detection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->