### PR TITLE
test: isolate ComplexityFunctionRegistry mutations from parallel test flows

### DIFF
--- a/source/Sailfish/Analysis/ScaleFish/ComplexityFunctionRegistry.cs
+++ b/source/Sailfish/Analysis/ScaleFish/ComplexityFunctionRegistry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
 
 namespace Sailfish.Analysis.ScaleFish;
@@ -26,11 +27,29 @@ namespace Sailfish.Analysis.ScaleFish;
 /// ComplexityFunctionRegistry.Register&lt;LogLog&gt;();
 /// </code>
 /// </para>
+///
+/// <para>
+/// The catalog is process-global. Code that needs to mutate it temporarily — above all tests, which
+/// may run in parallel with other tests reading the catalog — should do so inside
+/// <see cref="BeginIsolatedScope"/>, which confines every registry operation on the current async
+/// flow to a private copy.
+/// </para>
 /// </summary>
 public static class ComplexityFunctionRegistry
 {
     private static readonly object SyncRoot = new();
-    private static readonly List<Entry> Entries = new();
+    private static readonly List<Entry> GlobalEntries = new();
+
+    /// <summary>
+    /// When set on the current async flow, all registry operations target this list instead of
+    /// <see cref="GlobalEntries"/>. See <see cref="BeginIsolatedScope"/>.
+    /// </summary>
+    private static readonly AsyncLocal<List<Entry>?> ScopedEntries = new();
+
+    private static List<Entry> CurrentEntries => ScopedEntries.Value ?? GlobalEntries;
+
+    /// <summary>True when the current async flow is inside <see cref="BeginIsolatedScope"/>. Diagnostic.</summary>
+    internal static bool IsScopeActive => ScopedEntries.Value is not null;
 
     static ComplexityFunctionRegistry()
     {
@@ -70,8 +89,9 @@ public static class ComplexityFunctionRegistry
         var entry = new Entry(name, () => new T(), element => element.Deserialize<T>(), includeInFitting);
         lock (SyncRoot)
         {
-            Entries.RemoveAll(e => e.Name == name);
-            Entries.Add(entry);
+            var entries = CurrentEntries;
+            entries.RemoveAll(e => e.Name == name);
+            entries.Add(entry);
         }
     }
 
@@ -82,7 +102,7 @@ public static class ComplexityFunctionRegistry
     {
         lock (SyncRoot)
         {
-            return Entries.RemoveAll(e => e.Name == name) > 0;
+            return CurrentEntries.RemoveAll(e => e.Name == name) > 0;
         }
     }
 
@@ -93,7 +113,7 @@ public static class ComplexityFunctionRegistry
     {
         lock (SyncRoot)
         {
-            return Entries.Any(e => e.Name == name);
+            return CurrentEntries.Any(e => e.Name == name);
         }
     }
 
@@ -107,7 +127,7 @@ public static class ComplexityFunctionRegistry
     {
         lock (SyncRoot)
         {
-            return Entries.Where(e => e.IncludeInFitting).Select(e => e.Factory()).ToList();
+            return CurrentEntries.Where(e => e.IncludeInFitting).Select(e => e.Factory()).ToList();
         }
     }
 
@@ -120,7 +140,7 @@ public static class ComplexityFunctionRegistry
         Entry? entry;
         lock (SyncRoot)
         {
-            entry = Entries.FirstOrDefault(e => e.Name == name);
+            entry = CurrentEntries.FirstOrDefault(e => e.Name == name);
         }
         if (entry is null) return null;
         return entry.Deserializer(element);
@@ -133,21 +153,52 @@ public static class ComplexityFunctionRegistry
     {
         lock (SyncRoot)
         {
-            return Entries.Select(e => e.Name).ToList();
+            return CurrentEntries.Select(e => e.Name).ToList();
         }
     }
 
     /// <summary>
-    /// Removes any custom registrations and restores the built-in catalog to its default state.
-    /// Intended for test cleanup — production code should not call this.
+    /// Removes any custom registrations and restores the built-in catalog to its default state. Applies
+    /// to the catalog the current async flow sees: inside <see cref="BeginIsolatedScope"/> it resets the
+    /// scope's private copy; otherwise the process-global catalog. Prefer an isolated scope for test
+    /// cleanup — resetting the global catalog from a test races every concurrently-running test that
+    /// reads it.
     /// </summary>
     public static void ResetToBuiltIns()
     {
         lock (SyncRoot)
         {
-            Entries.Clear();
+            CurrentEntries.Clear();
         }
         RegisterBuiltIns();
+    }
+
+    /// <summary>
+    /// Begins an isolated registry scope on the current async flow: the catalog is copied, and every
+    /// registry operation performed while the scope is active — registrations, unregistrations, resets,
+    /// and reads — applies to that private copy. Other threads and async flows (e.g. other tests running
+    /// in parallel) continue to see the unmodified catalog; disposing restores whatever the flow saw
+    /// before. Scopes nest.
+    ///
+    /// <para>
+    /// This exists because the catalog is process-global mutable state: a test that registers a custom
+    /// family while another test concurrently fits measurements would otherwise race — the second test's
+    /// candidate set silently changes mid-run. Wrap any temporary registration in a scope:
+    /// <code>
+    /// using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+    /// ComplexityFunctionRegistry.Register&lt;MyFamily&gt;();
+    /// // ... exercise the estimator — only this async flow sees MyFamily ...
+    /// </code>
+    /// </para>
+    /// </summary>
+    public static IDisposable BeginIsolatedScope()
+    {
+        lock (SyncRoot)
+        {
+            var previous = ScopedEntries.Value;
+            ScopedEntries.Value = new List<Entry>(CurrentEntries);
+            return new IsolatedScope(previous);
+        }
     }
 
     private static void RegisterBuiltIns()
@@ -167,6 +218,24 @@ public static class ComplexityFunctionRegistry
         Register<LogLinear>(includeInFitting: false);
         Register<Exponential>();
         Register<Factorial>();
+    }
+
+    private sealed class IsolatedScope : IDisposable
+    {
+        private readonly List<Entry>? _previous;
+        private bool _disposed;
+
+        public IsolatedScope(List<Entry>? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            ScopedEntries.Value = _previous;
+        }
     }
 
     private sealed record Entry(

--- a/source/Tests.Library/Analysis/ScaleFish/ScaleFishRegistryTests.cs
+++ b/source/Tests.Library/Analysis/ScaleFish/ScaleFishRegistryTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Sailfish.Analysis.ScaleFish;
 using Sailfish.Analysis.ScaleFish.ComplexityFunctions;
 using Shouldly;
@@ -12,7 +14,11 @@ namespace Tests.Library.Analysis.ScaleFish;
 /// by default, user code can register custom families and they participate in the AICc ranking, and the
 /// JSON converter can deserialise custom families.
 ///
-/// Every test that mutates the registry must reset it on exit via <c>ResetToBuiltIns</c>.
+/// Every test that mutates the catalog does so inside <see cref="ComplexityFunctionRegistry.BeginIsolatedScope"/>,
+/// so the mutations are confined to this test's async flow. The test suite runs collections in parallel;
+/// mutating the process-global catalog here would race every concurrently-running test that fits
+/// measurements (observed as a one-off failure of ScaleFishParallelBootstrapTests.RepeatedParallelRuns_AreIdentical
+/// under load).
 /// </summary>
 public class ScaleFishRegistryTests
 {
@@ -50,112 +56,82 @@ public class ScaleFishRegistryTests
     [Fact]
     public void Register_LogLinear_OptsBackIntoFitting()
     {
-        try
-        {
-            // The escape hatch: explicit registration restores the family as a fit candidate.
-            ComplexityFunctionRegistry.Register<LogLinear>();
-            ComplexityFunctionRegistry.CreateFitInstances()
-                .Any(f => f.Name == nameof(LogLinear))
-                .ShouldBeTrue();
-        }
-        finally
-        {
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-        }
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+
+        // The escape hatch: explicit registration restores the family as a fit candidate.
+        ComplexityFunctionRegistry.Register<LogLinear>();
+        ComplexityFunctionRegistry.CreateFitInstances()
+            .Any(f => f.Name == nameof(LogLinear))
+            .ShouldBeTrue();
     }
 
     [Fact]
     public void Register_NewFamily_IncludedInFitCatalog()
     {
-        try
-        {
-            ComplexityFunctionRegistry.Register<TestQuintic>();
-            ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue();
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
 
-            var families = ComplexityFunctionRegistry.CreateFitInstances();
-            families.Any(f => f.Name == nameof(TestQuintic)).ShouldBeTrue();
-            // Each call returns fresh instances (independent FunctionParameters).
-            var first = ComplexityFunctionRegistry.CreateFitInstances().Single(f => f.Name == nameof(TestQuintic));
-            var second = ComplexityFunctionRegistry.CreateFitInstances().Single(f => f.Name == nameof(TestQuintic));
-            ReferenceEquals(first, second).ShouldBeFalse();
-        }
-        finally
-        {
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-        }
+        ComplexityFunctionRegistry.Register<TestQuintic>();
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue();
+
+        var families = ComplexityFunctionRegistry.CreateFitInstances();
+        families.Any(f => f.Name == nameof(TestQuintic)).ShouldBeTrue();
+        // Each call returns fresh instances (independent FunctionParameters).
+        var first = ComplexityFunctionRegistry.CreateFitInstances().Single(f => f.Name == nameof(TestQuintic));
+        var second = ComplexityFunctionRegistry.CreateFitInstances().Single(f => f.Name == nameof(TestQuintic));
+        ReferenceEquals(first, second).ShouldBeFalse();
     }
 
     [Fact]
     public void Register_NewFamily_WinsOnExactMatch()
     {
-        try
-        {
-            ComplexityFunctionRegistry.Register<TestQuintic>();
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
 
-            // Generate noise-free x^5 data — the custom Quintic family should win against all built-ins.
-            var measurements = Enumerable.Range(2, 6)
-                .Select(i => (double)(i * 2))
-                .Select(x => new ComplexityMeasurement(x, Math.Pow(x, 5)))
-                .ToArray();
+        ComplexityFunctionRegistry.Register<TestQuintic>();
 
-            var result = new ComplexityEstimator().EstimateComplexity(measurements);
-            result.ShouldNotBeNull();
-            result.ScaleFishModelFunction.Name.ShouldBe(nameof(TestQuintic));
-        }
-        finally
-        {
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-        }
+        // Generate noise-free x^5 data — the custom Quintic family should win against all built-ins.
+        var measurements = Enumerable.Range(2, 6)
+            .Select(i => (double)(i * 2))
+            .Select(x => new ComplexityMeasurement(x, Math.Pow(x, 5)))
+            .ToArray();
+
+        var result = new ComplexityEstimator().EstimateComplexity(measurements);
+        result.ShouldNotBeNull();
+        result.ScaleFishModelFunction.Name.ShouldBe(nameof(TestQuintic));
     }
 
     [Fact]
     public void Unregister_RemovesFamilyFromCatalog()
     {
-        try
-        {
-            ComplexityFunctionRegistry.Register<TestQuintic>();
-            ComplexityFunctionRegistry.Unregister(nameof(TestQuintic)).ShouldBeTrue();
-            ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse();
-            // Idempotent: subsequent removes are no-ops.
-            ComplexityFunctionRegistry.Unregister(nameof(TestQuintic)).ShouldBeFalse();
-        }
-        finally
-        {
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-        }
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+
+        ComplexityFunctionRegistry.Register<TestQuintic>();
+        ComplexityFunctionRegistry.Unregister(nameof(TestQuintic)).ShouldBeTrue();
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse();
+        // Idempotent: subsequent removes are no-ops.
+        ComplexityFunctionRegistry.Unregister(nameof(TestQuintic)).ShouldBeFalse();
     }
 
     [Fact]
     public void Register_SameName_ReplacesPreviousEntry()
     {
-        try
-        {
-            ComplexityFunctionRegistry.Register<TestQuintic>();
-            // Registering the same type twice is a no-op semantically (replaces) — should still be a single entry.
-            ComplexityFunctionRegistry.Register<TestQuintic>();
-            ComplexityFunctionRegistry.RegisteredNames().Count(n => n == nameof(TestQuintic)).ShouldBe(1);
-        }
-        finally
-        {
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-        }
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+
+        ComplexityFunctionRegistry.Register<TestQuintic>();
+        // Registering the same type twice is a no-op semantically (replaces) — should still be a single entry.
+        ComplexityFunctionRegistry.Register<TestQuintic>();
+        ComplexityFunctionRegistry.RegisteredNames().Count(n => n == nameof(TestQuintic)).ShouldBe(1);
     }
 
     [Fact]
     public void ResetToBuiltIns_RestoresExactSet()
     {
-        try
-        {
-            ComplexityFunctionRegistry.Register<TestQuintic>();
-            ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue();
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-            ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse();
-            ComplexityFunctionRegistry.IsRegistered(nameof(Linear)).ShouldBeTrue();
-        }
-        finally
-        {
-            ComplexityFunctionRegistry.ResetToBuiltIns();
-        }
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+
+        ComplexityFunctionRegistry.Register<TestQuintic>();
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue();
+        ComplexityFunctionRegistry.ResetToBuiltIns();
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse();
+        ComplexityFunctionRegistry.IsRegistered(nameof(Linear)).ShouldBeTrue();
     }
 
     [Fact]
@@ -163,24 +139,117 @@ public class ScaleFishRegistryTests
     {
         // A custom family whose `Name` deliberately diverges from its C# type name. The registry must
         // key by the runtime Name (what the JSON writer emits) so the converter can find it on load.
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+
+        ComplexityFunctionRegistry.Register<RenamedFamily>();
+
+        ComplexityFunctionRegistry.IsRegistered("CustomLogLog").ShouldBeTrue("key should be the runtime Name");
+        ComplexityFunctionRegistry.IsRegistered(nameof(RenamedFamily)).ShouldBeFalse("type-name key must not leak");
+
+        // Deserialize should succeed for the runtime Name…
+        var elem = System.Text.Json.JsonSerializer.SerializeToElement(new RenamedFamily());
+        ComplexityFunctionRegistry.Deserialize("CustomLogLog", elem).ShouldNotBeNull();
+
+        // …and return null when called with the type name (no false positives).
+        ComplexityFunctionRegistry.Deserialize(nameof(RenamedFamily), elem).ShouldBeNull();
+    }
+
+    // ─── Scope isolation ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsolatedScope_MutationsAreInvisibleToOtherFlows()
+    {
+        using var scope = ComplexityFunctionRegistry.BeginIsolatedScope();
+        ComplexityFunctionRegistry.IsScopeActive.ShouldBeTrue("scope must be active on the registering flow");
+        ComplexityFunctionRegistry.Register<TestQuintic>();
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue("the registering flow sees its own mutation");
+
+        // Observe the catalog from a flow that did NOT inherit this scope's ExecutionContext —
+        // exactly how a concurrently-running test sees it. A dedicated thread with flow suppressed
+        // is the only airtight probe: Task.Run + a blocking wait can INLINE the task onto this very
+        // thread, where an unflowed delegate executes under the thread's ambient (scoped) context.
+        var seenElsewhere = true;
+        using (ExecutionContext.SuppressFlow())
+        {
+            var probe = new Thread(() => seenElsewhere = ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)));
+            probe.Start();
+            probe.Join();
+        }
+
+        seenElsewhere.ShouldBeFalse("scoped registrations must not leak into other async flows");
+    }
+
+    [Fact]
+    public void IsolatedScope_DisposeRestoresThePreviousView()
+    {
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse();
+
+        using (ComplexityFunctionRegistry.BeginIsolatedScope())
+        {
+            ComplexityFunctionRegistry.Register<TestQuintic>();
+
+            // Nested scope snapshots the outer scope's view and discards its own changes on dispose.
+            using (ComplexityFunctionRegistry.BeginIsolatedScope())
+            {
+                ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue("nested scope inherits the outer view");
+                ComplexityFunctionRegistry.Unregister(nameof(TestQuintic)).ShouldBeTrue();
+                ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse();
+            }
+
+            ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeTrue("outer scope unaffected by the nested scope's mutations");
+        }
+
+        ComplexityFunctionRegistry.IsRegistered(nameof(TestQuintic)).ShouldBeFalse("flow returns to the global view after the last scope disposes");
+    }
+
+    [Fact]
+    public async Task ConcurrentScopedMutation_DoesNotPerturbEstimationDeterminism()
+    {
+        // Regression for the observed flake: a registry-mutating test running in parallel with a
+        // determinism test changed the candidate catalog between that test's two estimations. With
+        // scoped mutation, a hammering mutator must be invisible: two estimations on identical data
+        // must classify identically while the mutation loop runs.
+        var rng = new Random(99);
+        var measurements = ScaleFishTestHelpers.BuildNoisy(
+            x => 2.0 * x + 5.0,
+            new[] { 8, 16, 32, 64, 128, 256 },
+            sampleSize: 12,
+            relativeNoise: 0.05,
+            rng);
+
+        using var hammerStarted = new ManualResetEventSlim(false);
+        using var stopHammer = new CancellationTokenSource();
+        var hammer = Task.Run(() =>
+        {
+            using var hammerScope = ComplexityFunctionRegistry.BeginIsolatedScope();
+            hammerStarted.Set();
+            while (!stopHammer.Token.IsCancellationRequested)
+            {
+                ComplexityFunctionRegistry.Register<TestQuintic>();
+                ComplexityFunctionRegistry.Unregister(nameof(TestQuintic));
+                ComplexityFunctionRegistry.ResetToBuiltIns();
+            }
+        });
+
         try
         {
-            ComplexityFunctionRegistry.Register<RenamedFamily>();
+            hammerStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue("mutation hammer failed to start");
 
-            ComplexityFunctionRegistry.IsRegistered("CustomLogLog").ShouldBeTrue("key should be the runtime Name");
-            ComplexityFunctionRegistry.IsRegistered(nameof(RenamedFamily)).ShouldBeFalse("type-name key must not leak");
+            var estimator = new ComplexityEstimator();
+            var first = estimator.EstimateComplexity(measurements);
+            var second = estimator.EstimateComplexity(measurements);
 
-            // Deserialize should succeed for the runtime Name…
-            var elem = System.Text.Json.JsonSerializer.SerializeToElement(new RenamedFamily());
-            ComplexityFunctionRegistry.Deserialize("CustomLogLog", elem).ShouldNotBeNull();
-
-            // …and return null when called with the type name (no false positives).
-            ComplexityFunctionRegistry.Deserialize(nameof(RenamedFamily), elem).ShouldBeNull();
+            first.ShouldNotBeNull();
+            second.ShouldNotBeNull();
+            second.ScaleFishModelFunction.Name.ShouldBe(first.ScaleFishModelFunction.Name);
+            second.BestAicc.ShouldBe(first.BestAicc);
+            second.AkaikeWeight.ShouldBe(first.AkaikeWeight);
+            second.IsDistinguishable.ShouldBe(first.IsDistinguishable);
         }
         finally
         {
-            ComplexityFunctionRegistry.Unregister("CustomLogLog");
-            ComplexityFunctionRegistry.ResetToBuiltIns();
+            stopHammer.Cancel();
+            await hammer;
         }
     }
 


### PR DESCRIPTION
## Summary

Closes out the second flake found during [#326](https://github.com/paulegradie/Sailfish/pull/326)'s stress rounds: `ScaleFishRegistryTests` mutated the **process-global** `ComplexityFunctionRegistry` (Register/Unregister/ResetToBuiltIns) while xUnit runs test collections in parallel — so any concurrently-running test that fits measurements could watch the candidate catalog change mid-test. Observed once under load as `ScaleFishParallelBootstrapTests.RepeatedParallelRuns_AreIdentical` failing: its two back-to-back estimations saw different catalogs.

## Why not an xUnit `[Collection]`?

Serializing would require putting the mutating class **and every reading class** (essentially the whole ScaleFish test folder — anything that runs the estimator) into one collection, and it breaks silently the day a new test class forgets to join. Isolating the *mutations* fixes the race for all current and future readers with no serialization and no bookkeeping.

## Change

**`ComplexityFunctionRegistry.BeginIsolatedScope()`** — snapshots the catalog into an `AsyncLocal` overlay. While the scope is active on that async flow, every registry operation (registrations, unregistrations, resets, reads) targets the private copy; other threads and flows keep the unmodified catalog; dispose restores the prior view; scopes nest.

- **Production semantics unchanged:** no scope active → the global list, exactly as before. The estimator's read sites (`RankCandidates`, CV refit, `Parallel.For` bootstrap workers) all flow through the same locked accessor and inherit a scope only when their caller created one — which is the correct semantics for consumers testing custom families.
- `ResetToBuiltIns()` keeps its contract, now applying to whichever catalog the calling flow sees (its doc steers test cleanup toward scopes).
- Registry tests now run inside scopes instead of mutate-then-reset.

New isolation tests pin the contract:
- scoped mutations are invisible to non-inheriting flows — probed from a **dedicated thread with `ExecutionContext` flow suppressed**, because `Task.Run` + a blocking wait can inline the task onto the scoped thread and false-positive (found the hard way; the test comment documents it)
- dispose restores the previous view; nested scopes restore in order
- **the original flake shape, made deterministic:** a mutation loop hammering the registry inside its own scope while two estimations run on identical data — classifications must match exactly

## Verification

- 3 rounds of the full Tests.Library suite with net9.0 + net10.0 running **concurrently** (the reproduction condition): **1690/1690 on both TFMs, every round — zero flakes**, with #326's warmup deflake in the base
- Registry + parallel-bootstrap classes green in isolation
- Sailfish builds with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)