### PR TITLE
test: deflake OPI auto-tuner integration test via injectable pilot timer

### DIFF
--- a/source/Sailfish/Execution/TestCaseIterator.cs
+++ b/source/Sailfish/Execution/TestCaseIterator.cs
@@ -36,6 +36,13 @@ internal class TestCaseIterator : ITestCaseIterator
     /// </summary>
     internal ISteadyStateWarmupTimer WarmupTimer { get; set; } = new StopwatchWarmupTimer();
 
+    /// <summary>
+    ///     Pilot-measurement timer for OperationsPerInvoke auto-tuning. Wall-clock by default; tests inject
+    ///     a scripted source so the tuning decision (target duration → chosen OPI) is deterministic rather
+    ///     than dependent on host load. Same test-seam convention as <see cref="WarmupTimer"/>.
+    /// </summary>
+    internal Tuning.IOperationsPerInvokeTimer OpiTimer { get; set; } = new Tuning.StopwatchOperationsPerInvokeTimer();
+
     public TestCaseIterator(
         IRunSettings runSettings,
         ILogger logger,
@@ -117,7 +124,7 @@ internal class TestCaseIterator : ITestCaseIterator
             {
                 try
                 {
-                    var tuner = new OperationsPerInvokeTuner();
+                    var tuner = new OperationsPerInvokeTuner(OpiTimer);
                     var tuned = await tuner.TuneAsync(testInstanceContainer, executionSettings.TargetIterationDuration, _logger, cancellationToken).ConfigureAwait(false);
                     if (tuned > executionSettings.OperationsPerInvoke)
                     {

--- a/source/Sailfish/Execution/Tuning/OperationsPerInvokeTimer.cs
+++ b/source/Sailfish/Execution/Tuning/OperationsPerInvokeTimer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Sailfish.Execution.Tuning;
+
+/// <summary>
+///     Times a batch of operations for <see cref="OperationsPerInvokeTuner"/>'s pilot measurements.
+///     Production uses the wall-clock <see cref="StopwatchOperationsPerInvokeTimer"/>; tests substitute a
+///     scripted source so the tuner's <em>decision</em> logic (batch growth → per-op estimate → chosen
+///     OPI) can be exercised deterministically. Real pilot timing carries unbounded jitter under CI load,
+///     which made any assertion on "a fast method tunes up" inherently flaky — under load a single
+///     invocation can appear to already fill the target iteration, leaving OPI pinned at 1.
+/// </summary>
+internal interface IOperationsPerInvokeTimer
+{
+    /// <summary>Invokes <paramref name="invocation"/> <paramref name="operations"/> times and returns the aggregate duration in milliseconds.</summary>
+    Task<double> TimeBatchAsync(Func<Task> invocation, int operations);
+}
+
+/// <summary>Wall-clock implementation used in production runs.</summary>
+internal sealed class StopwatchOperationsPerInvokeTimer : IOperationsPerInvokeTimer
+{
+    public async Task<double> TimeBatchAsync(Func<Task> invocation, int operations)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        for (var i = 0; i < operations; i++)
+        {
+            await invocation().ConfigureAwait(false);
+        }
+        stopwatch.Stop();
+        return stopwatch.Elapsed.TotalMilliseconds;
+    }
+}

--- a/source/Sailfish/Execution/Tuning/OperationsPerInvokeTuner.cs
+++ b/source/Sailfish/Execution/Tuning/OperationsPerInvokeTuner.cs
@@ -1,6 +1,5 @@
 using Sailfish.Logging;
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +13,15 @@ internal class OperationsPerInvokeTuner
 
     // The aggregate estimate window must be large enough to time reliably above the Stopwatch floor.
     private const double MinMeasurableMs = 2.0;
+
+    private readonly IOperationsPerInvokeTimer _timer;
+
+    public OperationsPerInvokeTuner(IOperationsPerInvokeTimer? timer = null)
+    {
+        // Wall-clock by default — identical behaviour to the previous inline Stopwatch timing. Tests
+        // inject a scripted source so the tuning decision is deterministic under load.
+        _timer = timer ?? new StopwatchOperationsPerInvokeTimer();
+    }
 
     public async Task<int> TuneAsync(
         TestInstanceContainer container,
@@ -83,14 +91,8 @@ internal class OperationsPerInvokeTuner
         return ops;
     }
 
-    private static async Task<double> MeasureAggregateAsync(TestInstanceContainer container, int operations, CancellationToken ct)
+    private Task<double> MeasureAggregateAsync(TestInstanceContainer container, int operations, CancellationToken ct)
     {
-        var sw = Stopwatch.StartNew();
-        for (var i = 0; i < operations; i++)
-        {
-            await container.CoreInvoker.ExecutionMethod(ct, timed: false).ConfigureAwait(false);
-        }
-        sw.Stop();
-        return sw.Elapsed.TotalMilliseconds;
+        return _timer.TimeBatchAsync(() => container.CoreInvoker.ExecutionMethod(ct, timed: false), operations);
     }
 }

--- a/source/Tests.Library/Integration/OperationsPerInvokeTuningIntegrationTests.cs
+++ b/source/Tests.Library/Integration/OperationsPerInvokeTuningIntegrationTests.cs
@@ -5,69 +5,59 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Sailfish.Analysis;
 using Sailfish.Execution;
+using Sailfish.Execution.Tuning;
 using Sailfish.Logging;
 using Shouldly;
 using Xunit;
 
 namespace Tests.Library.Integration;
 
+/// <summary>
+/// Exercises OperationsPerInvoke auto-tuning end-to-end through TestCaseIterator, with the tuner's pilot
+/// measurements supplied by a scripted <see cref="IOperationsPerInvokeTimer"/> rather than the wall clock.
+/// The previous version timed a real ~15ms busy-wait and asserted the tuner chose OPI ≥ 2; under CI/parallel
+/// load the pilot stretched until a single invocation looked like it already filled the 45ms target, the
+/// tuner returned OPI 1, and the test flaked. The scripted timer still drives the real invocation path (the
+/// method under test is genuinely called for every pilot operation), but the durations the tuner reasons
+/// over are deterministic — so the tuning DECISION can be asserted exactly.
+/// </summary>
 public class OperationsPerInvokeTuningIntegrationTests
 {
     [Fact]
-    public async Task TestCaseIterator_AutoTunesOPI_RecordsPerOperationTime()
+    public async Task AutoTunesOPI_FastOperation_TunesUpToTargetMultiple()
     {
-        // Arrange: per-op ~15ms (busy-wait), target ~45ms should yield OPI >= 2
-        var logger = Substitute.For<ILogger>();
-        var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder().Build();
-        var fixedStrategy = new FixedIterationStrategy(logger);
-        var adaptiveStrategy = new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>());
-        var iterator = new TestCaseIterator(runSettings, logger, fixedStrategy, adaptiveStrategy);
+        // ~15ms/op against a 45ms target ⇒ exactly 3 operations per iteration.
+        var opi = await TuneOpiAsync(scriptedPerOpMs: 15.0, targetMs: 45.0);
+        opi.ShouldBe(3);
+    }
 
-        const double perOpMs = 15.0;
-        var instance = new DelayWork((int)perOpMs);
-        var method = typeof(DelayWork).GetMethod(nameof(DelayWork.Run))!;
-        var settings = new ExecutionSettings
-        {
-            NumWarmupIterations = 1,
-            SampleSize = 5,
-            OperationsPerInvoke = 1,
-            TargetIterationDuration = TimeSpan.FromMilliseconds(45),
-            UseAdaptiveSampling = false
-        };
-        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+    [Fact]
+    public async Task AutoTunesOPI_SubMeasurableOperation_GrowsBatchThenTunes()
+    {
+        // ~0.1ms/op is below the 2ms measurable floor, so the tuner must grow the pilot batch
+        // geometrically (1 → 4 → 16 → 64 ⇒ 6.4ms) before it can estimate per-op time, then scale to
+        // the 10ms target ⇒ 100 operations. This locks in the batch-growth path that batching exists
+        // for — the sub-microsecond case that previously made the tuner give up at OPI 1.
+        var opi = await TuneOpiAsync(scriptedPerOpMs: 0.1, targetMs: 10.0);
+        opi.ShouldBe(100);
+    }
 
-        // Act
-        var result = await iterator.Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        var opi = container.ExecutionSettings.OperationsPerInvoke;
-        opi.ShouldBeGreaterThanOrEqualTo(2);
-
-        var durations = container.CoreInvoker.GetPerformanceResults().ExecutionIterationPerformances
-            .Select(p => p.GetDurationFromTicks().MilliSeconds.Duration)
-            .OrderBy(x => x)
-            .ToArray();
-        durations.Length.ShouldBeGreaterThan(0);
-        var median = durations[durations.Length / 2];
-
-        var target = settings.TargetIterationDuration.TotalMilliseconds;
-
-        // The recorded sample is per-OPERATION (~15ms), NOT the per-ITERATION aggregate (~45ms target).
-        // Loose bounds to account for timer granularity on CI VMs.
-        median.ShouldBeGreaterThan(perOpMs * 0.5);
-        median.ShouldBeLessThan(perOpMs * 2.0); // < 30ms: also proves it is not the inflated ~45ms aggregate
-
-        // The tuned iteration (perOp * OPI) still lands near the target — tuning and normalization agree.
-        var iterationMs = median * opi;
-        iterationMs.ShouldBeGreaterThan(target * 0.5);
-        iterationMs.ShouldBeLessThan(target * 2.0);
+    [Fact]
+    public async Task AutoTunesOPI_SlowOperation_StaysAtOne()
+    {
+        // A single ~60ms op already overshoots the 45ms target, so batching can't help — OPI must
+        // stay 1. This is the counterpart guarantee that wall-clock timing could never assert
+        // (it was indistinguishable from the load-induced false negative the flake produced).
+        var opi = await TuneOpiAsync(scriptedPerOpMs: 60.0, targetMs: 45.0);
+        opi.ShouldBe(1);
     }
 
     [Fact]
     public async Task OperationsPerInvoke_RecordsPerOperationTime_NotAggregate()
     {
-        // Fixed OPI (no tuner): batching N ops must record per-op time, not the N× aggregate.
+        // Fixed OPI (no tuner): batching N ops must record per-op time, not the N× aggregate. This is
+        // the recording-normalization contract; it deliberately uses real timing with loose bounds and
+        // is independent of the tuning decision above.
         const double perOpMs = 10.0;
         const int opi = 4;
         var instance = new DelayWork((int)perOpMs);
@@ -89,10 +79,75 @@ public class OperationsPerInvokeTuningIntegrationTests
         median.ShouldBeLessThan(perOpMs * 2.5); // < 25ms, well below the ~40ms aggregate
     }
 
+    /// <summary>
+    /// Runs the full Iterate path with the OPI tuner fed a scripted per-op duration, and returns the OPI
+    /// the iterator settled on. The method under test is an instant counter (timing is supplied by the
+    /// scripted timer), so the decision is purely a function of scriptedPerOpMs and targetMs.
+    /// </summary>
+    private static async Task<int> TuneOpiAsync(double scriptedPerOpMs, double targetMs)
+    {
+        var logger = Substitute.For<ILogger>();
+        var runSettings = Sailfish.RunSettingsBuilder.CreateBuilder().Build();
+        var iterator = new TestCaseIterator(
+            runSettings, logger,
+            new FixedIterationStrategy(logger),
+            new AdaptiveIterationStrategy(logger, Substitute.For<IStatisticalConvergenceDetector>()))
+        {
+            OpiTimer = new ScriptedOperationsPerInvokeTimer(scriptedPerOpMs)
+        };
+
+        var instance = new CountingWork();
+        var method = typeof(CountingWork).GetMethod(nameof(CountingWork.Run))!;
+        var settings = new ExecutionSettings
+        {
+            NumWarmupIterations = 1,
+            SampleSize = 5,
+            OperationsPerInvoke = 1, // tuner only engages when starting from <= 1
+            TargetIterationDuration = TimeSpan.FromMilliseconds(targetMs),
+            UseAdaptiveSampling = false
+        };
+        var container = TestInstanceContainer.CreateTestInstance(instance, method, Array.Empty<string>(), Array.Empty<object>(), false, settings);
+
+        var result = await iterator.Iterate(container, disableOverheadEstimation: true, CancellationToken.None);
+        result.IsSuccess.ShouldBeTrue();
+
+        return container.ExecutionSettings.OperationsPerInvoke;
+    }
+
+    /// <summary>
+    /// Drives the real invocation (so the tuner's invocation path is genuinely exercised) but reports a
+    /// deterministic batch duration of operations × per-op, decoupling the tuning decision from host load.
+    /// </summary>
+    private sealed class ScriptedOperationsPerInvokeTimer : IOperationsPerInvokeTimer
+    {
+        private readonly double _perOpMs;
+
+        public ScriptedOperationsPerInvokeTimer(double perOpMs) => _perOpMs = perOpMs;
+
+        public async Task<double> TimeBatchAsync(Func<Task> invocation, int operations)
+        {
+            for (var i = 0; i < operations; i++)
+                await invocation().ConfigureAwait(false);
+            return operations * _perOpMs;
+        }
+    }
+
+    private sealed class CountingWork
+    {
+        public int Calls;
+
+        public Task Run(CancellationToken ct)
+        {
+            Calls++;
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class DelayWork
     {
         private readonly int _ms;
         public DelayWork(int ms) => _ms = ms;
+
         public Task Run(CancellationToken ct)
         {
             var sw = System.Diagnostics.Stopwatch.StartNew();


### PR DESCRIPTION
## Summary

Retires the last of the two load-flaky integration tests flagged in [#322](https://github.com/paulegradie/Sailfish/pull/322) (the first, SteadyStateWarmup, was fixed in [#326](https://github.com/paulegradie/Sailfish/pull/326); it bit [#327](https://github.com/paulegradie/Sailfish/pull/327)'s first CI run too). `TestCaseIterator_AutoTunesOPI_RecordsPerOperationTime` timed a real ~15ms busy-wait and asserted the tuner chose OPI ≥ 2 — but under CI/parallel load the pilot stretched until a single invocation looked like it already filled the 45ms target, so `OperationsPerInvokeTuner` returned OPI 1 and the assertion failed. Passes in isolation.

## Change — same playbook as #326

- **`IOperationsPerInvokeTimer`** (internal): the tuner sources its pilot batch measurements through this seam. Production is byte-identical — `StopwatchOperationsPerInvokeTimer` is exactly the old inline `MeasureAggregateAsync` (start stopwatch, invoke N times, return elapsed ms). Threaded through `TestCaseIterator.OpiTimer`, mirroring the existing `WarmupTimer` seam.
- **Tests inject a scripted timer** that still drives the real invocation path (the method is genuinely called for every pilot op — fidelity preserved) but reports deterministic batch durations. The tuning *decision* is now asserted exactly:
  - **fast** op (15ms, 45ms target) → **OPI 3**
  - **sub-measurable** op (0.1ms) → geometric batch growth `1→4→16→64` (6.4ms clears the 2ms floor), scale to 10ms target → **OPI 100**. Locks in the batch-growth path that batching exists for — the sub-microsecond case that used to make the tuner give up at 1.
  - **slow** op (60ms, 45ms target) → **stays at OPI 1**. The counterpart guarantee wall-clock timing could never assert: a real OPI-1 result was indistinguishable from the load-induced false negative the flake produced.
- The recording-normalization test (per-op time, not the N× aggregate) is **unchanged** — it uses fixed OPI, real timing, loose bounds, and was never the flaky assertion.

## Verification

- The scripted decision tests **fail against the old wall-clock tuner** (an instant method pilots at ~0ms → wrong OPI) and pass only through the injected seam — proving they test the tuning logic, not host timing.
- 3 rounds of the full Tests.Library suite with net9.0 + net10.0 running **concurrently** (the reproduction condition): **1692/1692 on both TFMs, every round**, plus isolation.
- Sailfish builds with zero warnings. The tuning test class drops from ~1s of real busy-waiting to ~230ms.

With this, all three timing-dependent integration flakes (warmup, registry race, OPI tuner) are resolved — CI should no longer need `rerun --failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Abstracted timing logic for `OperationsPerInvoke` auto-tuning, enabling dependency injection of custom timing implementations for more flexible testing and benchmarking scenarios.

* **Tests**
  * Replaced generalized auto-tuning test with three deterministic integration tests covering fast operations, sub-measurable operations, and slow operations for comprehensive auto-tuning validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->