### PR TITLE
feat: unify method-comparison verdict across IDE, console, markdown and CSV

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 ﻿## What's Changed in v0.0.118 (unreleased)
 
+### Method comparison: one verdict everywhere
+
+Method-vs-method comparison (every `[SailfishMethod]` on a `[Sailfish]` class) used to be judged *differently depending on where you looked*: the IDE ran the configured SailDiff test (Wilcoxon by default) on the raw samples with no multiplicity correction, while the console/markdown/CSV computed a parametric log-ratio approximation off summary statistics and gated the label on a BH-FDR q-value. The same two methods could get a different p-value and a different Improved/Slower/Similar label in the IDE vs the generated report.
+
+Both surfaces now share a single `IMethodComparisonAnalyzer`: significance comes from the **configured SailDiff test on the raw samples with one BH-FDR pass per comparison group**, so the p-value, q-value and verdict are **identical on every surface** (IDE, console, markdown, CSV). The ratio + confidence interval remains the separately-reported effect size. The IDE additionally gains the family-wise FDR correction it previously lacked. As part of this, a maximally-separated comparison (whose exact p-value is literally `0`) is correctly reported as significant rather than being mislabelled "Similar". No public API was removed; method-comparison numbers/labels may shift because the statistic and multiplicity control are now consistent.
+
 ### Breaking change: dependency injection container is now Microsoft.Extensions.DependencyInjection
 
 Sailfish's internal DI container moved from Autofac to `Microsoft.Extensions.DependencyInjection` (the standard .NET DI abstraction). The Autofac-typed public surface is gone — the `Autofac` package is no longer a dependency.

--- a/site/src/pages/docs/2/saildiff.md
+++ b/site/src/pages/docs/2/saildiff.md
@@ -27,6 +27,8 @@ Method comparisons generate:
 - **Improved / Slower / Similar labels** at α = 0.05
 - **Consolidated outputs**: both markdown and CSV formats with `[WriteToMarkdown]` and `[WriteToCsv]`
 
+The **verdict is computed identically on every surface** — the IDE test output, the console, the markdown report and the CSV all run the configured SailDiff test (Wilcoxon Rank-Sum by default) on the raw samples, with a single BH-FDR pass across each comparison group. The same two methods therefore always get the same p-value, q-value and Improved/Slower/Similar label wherever you read them. The ratio + confidence interval is reported separately as the effect size (it answers "by how much", independent of the significance call).
+
 ## Enabling / Configuring SailDiff
 
 If using Sailfish as a test project, you can create a `.sailfish.json` file in the root of your test project (next to your `.csproj` file). This file can hold various configuration settings. If any compatible setting is omitted, a sensible default will be used.

--- a/source/Sailfish.TestAdapter/Comparison/MethodComparisonBatchProcessor.cs
+++ b/source/Sailfish.TestAdapter/Comparison/MethodComparisonBatchProcessor.cs
@@ -2,6 +2,7 @@ using Sailfish.Mediation;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Formatting;
+using Sailfish.Contracts.Public;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Execution;
 using Sailfish.Logging;
@@ -38,17 +39,23 @@ internal class MethodComparisonBatchProcessor
     private readonly IPublisher _publisher;
     private readonly ILogger _logger;
     private readonly ISailDiffUnifiedFormatter _unifiedFormatter;
+    private readonly IMethodComparisonAnalyzer _analyzer;
+    private readonly IRunSettings _runSettings;
 
     public MethodComparisonBatchProcessor(
         IAdapterSailDiff sailDiff,
         IPublisher publisher,
         ILogger logger,
-        ISailDiffUnifiedFormatter unifiedFormatter)
+        ISailDiffUnifiedFormatter unifiedFormatter,
+        IMethodComparisonAnalyzer analyzer,
+        IRunSettings runSettings)
     {
         _sailDiff = sailDiff ?? throw new ArgumentNullException(nameof(sailDiff));
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _unifiedFormatter = unifiedFormatter ?? throw new ArgumentNullException(nameof(unifiedFormatter));
+        _analyzer = analyzer ?? throw new ArgumentNullException(nameof(analyzer));
+        _runSettings = runSettings ?? throw new ArgumentNullException(nameof(runSettings));
     }
 
     /// <summary>
@@ -155,6 +162,12 @@ internal class MethodComparisonBatchProcessor
                 continue;
             }
 
+            // Significance for the whole cohort comes from the shared analyzer — the configured SailDiff
+            // test on the raw samples with ONE BH-FDR pass across the cohort's pairs. The per-pair compare
+            // calls below still drive the displayed statistics, but their verdict is re-gated on this
+            // family q-value so the IDE agrees with the markdown/CSV (which use the same analyzer).
+            var cohortAnalysis = AnalyzeCohort(members);
+
             // A method flagged [SailfishMethod(IsBaseline = true)] is carried as ComparisonRole="Baseline"
             // (set during discovery in TestCaseItemCreator and forwarded through the message mappers).
             var baselines = members.Where(IsBaselineRole).ToList();
@@ -166,7 +179,7 @@ internal class MethodComparisonBatchProcessor
                 var baseline = baselines[0];
                 foreach (var contender in members.Where(m => !ReferenceEquals(m, baseline)))
                 {
-                    CompareBaselineToContender(baseline, contender, groupName);
+                    CompareBaselineToContender(baseline, contender, groupName, cohortAnalysis);
                 }
             }
             else
@@ -183,7 +196,7 @@ internal class MethodComparisonBatchProcessor
                 for (var i = 0; i < members.Count; i++)
                 for (var j = i + 1; j < members.Count; j++)
                 {
-                    CompareNxNPair(members[i], members[j], groupName);
+                    CompareNxNPair(members[i], members[j], groupName, cohortAnalysis);
                 }
             }
         }
@@ -238,13 +251,15 @@ internal class MethodComparisonBatchProcessor
     private void CompareBaselineToContender(
         TestCompletionMessage baseline,
         TestCompletionMessage contender,
-        string groupName)
+        string groupName,
+        MethodComparisonResult cohortAnalysis)
     {
         try
         {
             // before = baseline, after = contender ⇒ MeanBefore is the baseline's mean (no swap needed).
             var comparisonResult = ComputeDiff(baseline, contender, groupName);
             StorePairwisePValue(baseline, contender, comparisonResult);
+            RegateVerdictWithFamilyFdr(comparisonResult, cohortAnalysis, baseline, contender);
 
             var output = FormatOriented(comparisonResult, groupName, primary: baseline, compared: contender, swap: false);
 
@@ -269,13 +284,15 @@ internal class MethodComparisonBatchProcessor
     private void CompareNxNPair(
         TestCompletionMessage methodA,
         TestCompletionMessage methodB,
-        string groupName)
+        string groupName,
+        MethodComparisonResult cohortAnalysis)
     {
         try
         {
             // before = A, after = B ⇒ MeanBefore is A's mean.
             var comparisonResult = ComputeDiff(methodA, methodB, groupName);
             StorePairwisePValue(methodA, methodB, comparisonResult);
+            RegateVerdictWithFamilyFdr(comparisonResult, cohortAnalysis, methodA, methodB);
 
             // A's row: A is the reference (no swap). B's row: B is the reference (swap before/after).
             var outputA = FormatOriented(comparisonResult, groupName, primary: methodA, compared: methodB, swap: false);
@@ -291,6 +308,50 @@ internal class MethodComparisonBatchProcessor
         {
             _logger.Log(LogLevel.Error, ex,
                 "Failed to perform comparison for group '{0}': {1}", groupName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Builds the cohort members and runs the shared analyzer once — the configured SailDiff test on the
+    /// raw samples with a single BH-FDR pass across the cohort's pairs — so the IDE verdict is computed the
+    /// same way as the markdown/CSV.
+    /// </summary>
+    private MethodComparisonResult AnalyzeCohort(List<TestCompletionMessage> members)
+    {
+        var comparisonMembers = members
+            .Select(m => new MethodComparisonMember(
+                m.TestCaseId,
+                ExtractMethodName(m.TestCaseId),
+                IsBaselineRole(m),
+                CreatePerformanceRunResultFromMessage(m)))
+            .ToList();
+
+        return _analyzer.Analyze(comparisonMembers, _runSettings.SailDiffSettings);
+    }
+
+    /// <summary>
+    /// Re-gates a pair's headline verdict on the cohort's BH-FDR q-value. The per-pair test statistic and
+    /// p-value are already identical to the analyzer's (same test, same samples); the only thing the
+    /// per-pair path lacks is the family multiplicity correction. Since q ≥ p, FDR can only demote a verdict
+    /// to "No Change" — never flip its direction — so a not-significant family verdict simply resets the
+    /// headline. This is what makes the IDE agree with the markdown/CSV.
+    /// </summary>
+    private static void RegateVerdictWithFamilyFdr(
+        TestCaseSailDiffResult? comparisonResult,
+        MethodComparisonResult cohortAnalysis,
+        TestCompletionMessage primary,
+        TestCompletionMessage compared)
+    {
+        var stat = comparisonResult?.SailDiffResults?.FirstOrDefault()?.TestResultsWithOutlierAnalysis?.StatisticalTestResult;
+        if (stat is null || stat.Failed) return;
+
+        var pair = cohortAnalysis.Find(primary.TestCaseId, compared.TestCaseId);
+        if (pair is null) return;
+
+        stat.QValue = pair.QValue;
+        if (pair.Verdict == MethodComparisonVerdict.Similar && stat.ChangeDescription != SailfishChangeDirection.NoChange)
+        {
+            stat.ChangeDescription = SailfishChangeDirection.NoChange;
         }
     }
 

--- a/source/Sailfish/Analysis/SailDiff/MethodComparisonAnalyzer.cs
+++ b/source/Sailfish/Analysis/SailDiff/MethodComparisonAnalyzer.cs
@@ -58,8 +58,12 @@ public sealed record MethodComparisonResult(
     /// </summary>
     public MethodComparisonPairResult? Find(string idA, string idB)
     {
-        var key = MultipleComparisons.NormalizePair(idA, idB);
-        return Pairs.FirstOrDefault(p => MultipleComparisons.NormalizePair(p.Primary.Id, p.Compared.Id) == key);
+        // Canonicalize ids the same way ComputeTest re-keys its results (TestCaseId.DisplayName appends
+        // "()" to a bare name), so the lookup is robust to that round-trip — not just to argument ordering.
+        static string Canonicalize(string id) => new TestCaseId(id).DisplayName;
+        var key = MultipleComparisons.NormalizePair(Canonicalize(idA), Canonicalize(idB));
+        return Pairs.FirstOrDefault(p =>
+            MultipleComparisons.NormalizePair(Canonicalize(p.Primary.Id), Canonicalize(p.Compared.Id)) == key);
     }
 }
 
@@ -194,7 +198,8 @@ public sealed class MethodComparisonAnalyzer : IMethodComparisonAnalyzer
     private static int SampleCount(PerformanceRunResult r)
     {
         var cleaned = r.DataWithOutliersRemoved?.Length ?? 0;
-        return cleaned > 0 ? cleaned : Math.Max(0, r.SampleSize);
+        // Floor at 1 (never 0) to match the ratio/CI fallback the markdown/CSV surfaces used before this.
+        return cleaned > 0 ? cleaned : Math.Max(1, r.SampleSize);
     }
 
     private static double StandardError(PerformanceRunResult r, int n)

--- a/source/Sailfish/Analysis/SailDiff/MethodComparisonAnalyzer.cs
+++ b/source/Sailfish/Analysis/SailDiff/MethodComparisonAnalyzer.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Analysis.SailDiff.Statistics;
+using Sailfish.Contracts.Public;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Serialization.Tracking.V1;
+
+namespace Sailfish.Analysis.SailDiff;
+
+/// <summary>
+/// A method participating in one comparison cohort (a single variable set within a single comparison
+/// group). <see cref="Result"/> carries the raw samples the configured statistical test runs on.
+/// </summary>
+public sealed record MethodComparisonMember(string Id, string MethodName, bool IsBaseline, PerformanceRunResult Result);
+
+/// <summary>
+/// The significance verdict for a contender relative to its primary/baseline. <see cref="Similar"/> means
+/// "not significant after BH-FDR" — never silently "no change". Direction is taken from the means.
+/// </summary>
+public enum MethodComparisonVerdict
+{
+    Similar,
+    Improved,
+    Slower
+}
+
+/// <summary>
+/// One pair's comparison, oriented primary/baseline (before) vs compared/contender (after).
+/// Significance (<see cref="PValue"/>/<see cref="QValue"/>/<see cref="Verdict"/>) comes from the configured
+/// SailDiff test with one BH-FDR pass over the cohort; <see cref="Ratio"/> + CI is the effect size.
+/// </summary>
+public sealed record MethodComparisonPairResult(
+    MethodComparisonMember Primary,
+    MethodComparisonMember Compared,
+    double PrimaryMean,
+    double ComparedMean,
+    double PrimaryMedian,
+    double ComparedMedian,
+    int PrimarySampleSize,
+    int ComparedSampleSize,
+    double PValue,
+    double QValue,
+    double Ratio,
+    double? CiLower,
+    double? CiUpper,
+    MethodComparisonVerdict Verdict);
+
+/// <summary>The unified result for one comparison cohort.</summary>
+public sealed record MethodComparisonResult(
+    IReadOnlyList<MethodComparisonPairResult> Pairs,
+    bool BaselineMode,
+    string? BaselineId)
+{
+    /// <summary>
+    /// Looks up the computed pair for an unordered (a, b) method id pair, regardless of which id was the
+    /// primary. Returns <c>null</c> when no comparison was produced (e.g. insufficient samples).
+    /// </summary>
+    public MethodComparisonPairResult? Find(string idA, string idB)
+    {
+        var key = MultipleComparisons.NormalizePair(idA, idB);
+        return Pairs.FirstOrDefault(p => MultipleComparisons.NormalizePair(p.Primary.Id, p.Compared.Id) == key);
+    }
+}
+
+/// <summary>
+/// Computes the verdict for a method-vs-method comparison cohort so every surface (IDE, markdown, CSV,
+/// console) agrees. Significance is the configured SailDiff test (Wilcoxon Rank-Sum by default) run on the
+/// raw samples, with a single Benjamini-Hochberg FDR pass across the cohort's pairs — the exact same engine
+/// and multiplicity control historical SailDiff uses — rather than the old per-surface parametric log-ratio
+/// approximation. The ratio + confidence interval is reported separately as the effect size.
+/// </summary>
+public interface IMethodComparisonAnalyzer
+{
+    MethodComparisonResult Analyze(IReadOnlyList<MethodComparisonMember> members, SailDiffSettings settings);
+}
+
+/// <inheritdoc cref="IMethodComparisonAnalyzer" />
+public sealed class MethodComparisonAnalyzer : IMethodComparisonAnalyzer
+{
+    // Smallest positive significance value substituted for an exact-zero p/q from a successful test, so a
+    // maximally-separated comparison still reads as significant rather than as "no comparison computed".
+    private const double MinPositiveSignificance = 1e-300;
+
+    private readonly IStatisticalTestComputer _statisticalTestComputer;
+
+    public MethodComparisonAnalyzer(IStatisticalTestComputer statisticalTestComputer)
+    {
+        _statisticalTestComputer = statisticalTestComputer;
+    }
+
+    public MethodComparisonResult Analyze(IReadOnlyList<MethodComparisonMember> members, SailDiffSettings settings)
+    {
+        var usable = members.Where(m => m.Result is { Mean: > 0 }).ToList();
+        var baselines = usable.Where(m => m.IsBaseline).ToList();
+        var baselineMode = baselines.Count == 1;
+        var baselineId = baselines.Count == 1 ? baselines[0].Id : null;
+
+        // Ordered (primary, compared) pairs: baseline-vs-contender when exactly one baseline is marked,
+        // otherwise the full N×N (each unordered pair once; the matrix renderer mirrors a pair's cell).
+        var pairs = new List<(MethodComparisonMember Primary, MethodComparisonMember Compared)>();
+        if (baselineMode)
+        {
+            var baseline = baselines[0];
+            foreach (var contender in usable.Where(m => !ReferenceEquals(m, baseline)))
+                pairs.Add((baseline, contender));
+        }
+        else
+        {
+            for (var i = 0; i < usable.Count; i++)
+            for (var j = i + 1; j < usable.Count; j++)
+                pairs.Add((usable[i], usable[j]));
+        }
+
+        if (pairs.Count == 0)
+            return new MethodComparisonResult(Array.Empty<MethodComparisonPairResult>(), baselineMode, baselineId);
+
+        // Relabel each pair to a unique synthetic id, then run the whole cohort through ONE ComputeTest
+        // call. The engine tests each pair with the configured test and applies a single BH-FDR pass
+        // (q-values + verdict demotion) across them — identical to historical SailDiff. before = primary,
+        // after = compared, so MeanBefore/After line up with primary/compared.
+        var pairKeys = new string[pairs.Count];
+        var beforeData = new List<PerformanceRunResult>(pairs.Count);
+        var afterData = new List<PerformanceRunResult>(pairs.Count);
+        for (var i = 0; i < pairs.Count; i++)
+        {
+            var key = $"__methodcomparison::{i}";
+            pairKeys[i] = key;
+            beforeData.Add(WithDisplayName(pairs[i].Primary.Result, key));
+            afterData.Add(WithDisplayName(pairs[i].Compared.Result, key));
+        }
+
+        var statByKey = _statisticalTestComputer
+            .ComputeTest(new TestData(pairKeys, beforeData), new TestData(pairKeys, afterData), settings)
+            .Where(r => r.TestResultsWithOutlierAnalysis?.StatisticalTestResult is { Failed: false })
+            .GroupBy(r => r.TestCaseId.DisplayName)
+            .ToDictionary(g => g.Key, g => g.First().TestResultsWithOutlierAnalysis!.StatisticalTestResult);
+
+        var confidenceLevel = 1.0 - settings.Alpha;
+        var results = new List<MethodComparisonPairResult>(pairs.Count);
+        for (var i = 0; i < pairs.Count; i++)
+        {
+            var (primary, compared) = pairs[i];
+            // ComputeTest re-keys each result by `new TestCaseId(displayName).DisplayName`, which normalizes
+            // a bare name to "name()". Normalize the lookup the same way so the key round-trips.
+            statByKey.TryGetValue(new TestCaseId(pairKeys[i]).DisplayName, out var stat);
+
+            var primaryMean = primary.Result.Mean;
+            var comparedMean = compared.Result.Mean;
+            var primaryN = SampleCount(primary.Result);
+            var comparedN = SampleCount(compared.Result);
+
+            var (ratio, lower, upper) = MultipleComparisons.ComputeRatioCi(
+                primaryMean, StandardError(primary.Result, primaryN), primaryN,
+                comparedMean, StandardError(compared.Result, comparedN), comparedN,
+                confidenceLevel);
+
+            // Significance is the engine's q-value (BH-FDR adjusted). When a pair could not be tested
+            // (e.g. < 3 samples), p/q are NaN and the verdict falls through to Similar.
+            //
+            // A SUCCESSFUL test with maximal separation (e.g. a method that is comfortably faster than its
+            // peer) can return an exact p — and hence BH q — of exactly 0. Zero is otherwise the "no
+            // comparison computed" sentinel that SailDiffSignificance.IsSignificantPositive treats as not
+            // significant, so without this floor the most clear-cut difference would be mislabelled
+            // "Similar". Floor a real 0 to a tiny positive so the verdict stays significant (this mirrors the
+            // MinPositivePValue floor MultipleComparisons.LogRatioPValue already applies).
+            var rawP = stat?.PValue ?? double.NaN;
+            var rawQ = stat?.QValue ?? rawP;
+            var pValue = stat is { Failed: false } && rawP == 0.0 ? MinPositiveSignificance : rawP;
+            var qValue = stat is { Failed: false } && rawQ == 0.0 ? MinPositiveSignificance : rawQ;
+
+            results.Add(new MethodComparisonPairResult(
+                primary, compared,
+                primaryMean, comparedMean,
+                primary.Result.Median, compared.Result.Median,
+                primaryN, comparedN,
+                pValue, qValue,
+                ratio, lower, upper,
+                DetermineVerdict(qValue, settings.Alpha, ratio)));
+        }
+
+        return new MethodComparisonResult(results, baselineMode, baselineId);
+    }
+
+    // ratio = compared / primary, so ratio < 1 means the contender is faster than the primary ⇒ Improved.
+    private static MethodComparisonVerdict DetermineVerdict(double qValue, double alpha, double ratio)
+    {
+        if (!SailDiffSignificance.IsSignificantPositive(qValue, alpha)) return MethodComparisonVerdict.Similar;
+        return ratio < 1.0 ? MethodComparisonVerdict.Improved : MethodComparisonVerdict.Slower;
+    }
+
+    // Effective N: the post-outlier-removal sample count when available, else the raw sample size. Matches
+    // the N the surfaces already used for the ratio CI.
+    private static int SampleCount(PerformanceRunResult r)
+    {
+        var cleaned = r.DataWithOutliersRemoved?.Length ?? 0;
+        return cleaned > 0 ? cleaned : Math.Max(0, r.SampleSize);
+    }
+
+    private static double StandardError(PerformanceRunResult r, int n)
+    {
+        return n > 1 && r.StdDev > 0 ? r.StdDev / Math.Sqrt(n) : 0.0;
+    }
+
+    // PerformanceRunResult.DisplayName is constructor-set; clone with the synthetic pair id so a single
+    // ComputeTest call can pair the two methods (it groups before/after by DisplayName).
+    private static PerformanceRunResult WithDisplayName(PerformanceRunResult r, string displayName)
+    {
+        return new PerformanceRunResult(
+            displayName,
+            r.Mean, r.StdDev, r.Variance, r.Median,
+            r.RawExecutionResults, r.SampleSize, r.NumWarmupIterations,
+            r.DataWithOutliersRemoved, r.UpperOutliers, r.LowerOutliers, r.TotalNumOutliers,
+            r.StandardError, r.ConfidenceLevel, r.ConfidenceIntervalLower, r.ConfidenceIntervalUpper,
+            r.MarginOfError, r.ConfidenceIntervals);
+    }
+}
+
+/// <summary>
+/// Projection helpers between the persisted tracking format and the runtime model so file-based surfaces
+/// (console markdown / CSV) can feed the shared <see cref="IMethodComparisonAnalyzer" />.
+/// </summary>
+public static class PerformanceRunResultTrackingFormatExtensions
+{
+    /// <summary>
+    /// Projects a tracking-format result back to a runtime <see cref="PerformanceRunResult" /> so the shared
+    /// statistical engine can run on it. Confidence-interval fields the tracking format does not persist are
+    /// left at their defaults — SailDiff recomputes everything it needs from the raw samples.
+    /// </summary>
+    public static PerformanceRunResult ToPerformanceRunResult(this PerformanceRunResultTrackingFormat t)
+    {
+        return new PerformanceRunResult(
+            t.DisplayName, t.Mean, t.StdDev, t.Variance, t.Median,
+            t.RawExecutionResults, t.SampleSize, t.NumWarmupIterations,
+            t.DataWithOutliersRemoved, t.UpperOutliers, t.LowerOutliers, t.TotalNumOutliers);
+    }
+}

--- a/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/CsvTestRunCompletedHandler.cs
@@ -12,6 +12,7 @@ using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Contracts.Public.Serialization.Tracking.V1;
 using Sailfish.Logging;
 using Sailfish.Presentation;
+using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Statistics;
 using Sailfish.Contracts.Public.Models;
 
@@ -26,6 +27,7 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
 {
     private readonly ILogger _logger;
     private readonly IPublisher _publisher;
+    private readonly IMethodComparisonAnalyzer _analyzer;
     private readonly IRunSettings? _runSettings;
 
     /// <summary>
@@ -33,10 +35,12 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
     /// </summary>
     /// <param name="logger">The logger for diagnostic output.</param>
     /// <param name="publisher">The publisher for publishing notifications.</param>
-    public CsvTestRunCompletedHandler(ILogger logger, IPublisher publisher)
+    /// <param name="analyzer">The shared method-comparison analyzer (single source of truth for the verdict).</param>
+    public CsvTestRunCompletedHandler(ILogger logger, IPublisher publisher, IMethodComparisonAnalyzer analyzer)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _analyzer = analyzer ?? throw new ArgumentNullException(nameof(analyzer));
         _runSettings = null;
     }
 
@@ -46,8 +50,8 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
     /// instead of defaulting to 0.05. The DI container selects this overload when all
     /// dependencies are available (multiple ctors → the container picks the longest constructor it can satisfy).
     /// </summary>
-    public CsvTestRunCompletedHandler(ILogger logger, IPublisher publisher, IRunSettings runSettings)
-        : this(logger, publisher)
+    public CsvTestRunCompletedHandler(ILogger logger, IPublisher publisher, IMethodComparisonAnalyzer analyzer, IRunSettings runSettings)
+        : this(logger, publisher, analyzer)
     {
         _runSettings = runSettings;
     }
@@ -253,7 +257,7 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
                         var name = GetMethodName(tr.TestCaseId?.DisplayName ?? "Unknown");
                         var id = tr.TestCaseId?.DisplayName ?? name;
                         var isBaseline = GetComparisonInfoForResult(tr, m.TestClass).IsBaseline;
-                        return new { Name = name, Id = id, Mean = mean, SE = se, N = n, IsBaseline = isBaseline };
+                        return new { Name = name, Id = id, Result = pr, Mean = mean, SE = se, N = n, IsBaseline = isBaseline };
                     })
                     .Where(s => s.Mean > 0)
                     .ToList();
@@ -292,23 +296,17 @@ internal class CsvTestRunCompletedHandler : INotificationHandler<TestRunComplete
                     }
                 }
 
-                // Compute p-values over the selected pairs and apply BH-FDR
-                var pMap = new Dictionary<(string A, string B), double>();
-                foreach (var (i, j) in pairs)
-                {
-                    var a = stats[i];
-                    var b = stats[j];
-                    var p = MultipleComparisons.LogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
-                    if (!double.IsNaN(p) && p > 0)
-                    {
-                        pMap[MultipleComparisons.NormalizePair(a.Id, b.Id)] = p;
-                    }
-                }
-                var qMap = pMap.Count > 0
-                    ? MultipleComparisons.BenjaminiHochbergAdjust(pMap)
-                    : new Dictionary<(string A, string B), double>();
+                // Significance comes from the shared analyzer (configured SailDiff test on the raw samples +
+                // one BH-FDR pass over the selected pairs) so the CSV agrees with the IDE and markdown.
+                var settings = _runSettings?.SailDiffSettings ?? new SailDiffSettings();
+                var comparisonMembers = stats
+                    .Select(s => new MethodComparisonMember(s.Id, s.Name, s.IsBaseline, s.Result!.ToPerformanceRunResult()))
+                    .ToList();
+                var qMap = new Dictionary<(string A, string B), double>();
+                foreach (var pair in _analyzer.Analyze(comparisonMembers, settings).Pairs)
+                    qMap[MultipleComparisons.NormalizePair(pair.Primary.Id, pair.Compared.Id)] = pair.QValue;
 
-                var alpha = _runSettings?.SailDiffSettings?.Alpha ?? SailDiffSignificance.FallbackAlpha;
+                var alpha = settings.Alpha;
                 var confidenceLevel = 1.0 - alpha;
 
                 // Emit one row per selected pair

--- a/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler.cs
@@ -15,6 +15,7 @@ using Sailfish.Diagnostics.Environment;
 using Sailfish.Logging;
 using Sailfish.Presentation;
 using Sailfish.Results;
+using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Statistics;
 
 using Sailfish.Execution;
@@ -30,6 +31,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
 {
     private readonly ILogger _logger;
     private readonly IPublisher _publisher;
+    private readonly IMethodComparisonAnalyzer _analyzer;
     private readonly IEnvironmentHealthReportProvider? _healthProvider;
     private readonly IRunSettings? _runSettings;
     private readonly IReproducibilityManifestProvider? _manifestProvider;
@@ -42,10 +44,12 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
     /// </summary>
     /// <param name="logger">The logger for diagnostic output.</param>
     /// <param name="publisher">The publisher for publishing notifications.</param>
-    public MethodComparisonTestRunCompletedHandler(ILogger logger, IPublisher publisher)
+    /// <param name="analyzer">The shared method-comparison analyzer (single source of truth for the verdict).</param>
+    public MethodComparisonTestRunCompletedHandler(ILogger logger, IPublisher publisher, IMethodComparisonAnalyzer analyzer)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _analyzer = analyzer ?? throw new ArgumentNullException(nameof(analyzer));
         _healthProvider = null; // backward compatible path
         _runSettings = null;
         _manifestProvider = null;
@@ -55,8 +59,8 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
     /// <summary>
     /// Preferred constructor that can optionally receive environment health report provider via DI.
     /// </summary>
-    public MethodComparisonTestRunCompletedHandler(ILogger logger, IPublisher publisher, IEnvironmentHealthReportProvider healthProvider)
-        : this(logger, publisher)
+    public MethodComparisonTestRunCompletedHandler(ILogger logger, IPublisher publisher, IMethodComparisonAnalyzer analyzer, IEnvironmentHealthReportProvider healthProvider)
+        : this(logger, publisher, analyzer)
     {
         _healthProvider = healthProvider;
     }
@@ -64,11 +68,12 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
     public MethodComparisonTestRunCompletedHandler(
         ILogger logger,
         IPublisher publisher,
+        IMethodComparisonAnalyzer analyzer,
         IEnvironmentHealthReportProvider healthProvider,
         IRunSettings runSettings,
         IReproducibilityManifestProvider manifestProvider,
         ITimerCalibrationResultProvider timerProvider)
-        : this(logger, publisher, healthProvider)
+        : this(logger, publisher, analyzer, healthProvider)
     {
         _runSettings = runSettings;
         _manifestProvider = manifestProvider;
@@ -78,16 +83,17 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
     /// <summary>
     /// Fallback constructor used when the health/reporting services are available but
     /// <see cref="ITimerCalibrationResultProvider"/> is not registered. If all
-    /// six constructor dependencies are available, the 6-parameter overload above is
+    /// dependencies are available, the longest overload above is
     /// preferred by the DI activator (longest satisfiable constructor wins).
     /// </summary>
     public MethodComparisonTestRunCompletedHandler(
         ILogger logger,
         IPublisher publisher,
+        IMethodComparisonAnalyzer analyzer,
         IEnvironmentHealthReportProvider healthProvider,
         IRunSettings runSettings,
         IReproducibilityManifestProvider manifestProvider)
-        : this(logger, publisher, healthProvider)
+        : this(logger, publisher, analyzer, healthProvider)
     {
         _runSettings = runSettings;
         _manifestProvider = manifestProvider;
@@ -542,13 +548,15 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
         if (methods.Count < 2) return string.Empty;
         try
         {
-            // Build stats from tracking format (use cleaned data length for N when available)
+            // Build display stats (cleaned-data length for N when available). Result carries the raw
+            // samples the analyzer's statistical test runs on.
             var stats = methods
                 .Where(m => m.PerformanceRunResult != null)
                 .Select(m => new
                 {
                     Id = m.TestCaseId?.DisplayName ?? m.PerformanceRunResult!.DisplayName,
                     Name = GetMethodName(m.TestCaseId?.DisplayName ?? m.PerformanceRunResult!.DisplayName),
+                    Result = m.PerformanceRunResult!,
                     Mean = m.PerformanceRunResult!.Mean,
                     StdDev = m.PerformanceRunResult!.StdDev,
                     N = Math.Max(1, (m.PerformanceRunResult!.DataWithOutliersRemoved?.Length ?? -1) > 0
@@ -559,6 +567,7 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
                 {
                     x.Id,
                     x.Name,
+                    x.Result,
                     x.Mean,
                     x.N,
                     SE = (x.N > 1 && x.StdDev > 0) ? x.StdDev / Math.Sqrt(x.N) : 0.0
@@ -568,26 +577,17 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
 
             if (stats.Count < 2) return string.Empty;
 
-            // Compute pairwise p-values on log-ratio and apply BH-FDR
-            var pMap = new Dictionary<(string A, string B), double>();
-            for (var i = 0; i < stats.Count; i++)
-            {
-                for (var j = i + 1; j < stats.Count; j++)
-                {
-                    var a = stats[i];
-                    var b = stats[j];
-                    var p = MultipleComparisons.LogRatioPValue(a.Mean, a.SE, a.N, b.Mean, b.SE, b.N);
-                    if (!double.IsNaN(p) && p > 0)
-                    {
-                        pMap[MultipleComparisons.NormalizePair(a.Id, b.Id)] = p;
-                    }
-                }
-            }
-            var qMap = pMap.Count > 0
-                ? MultipleComparisons.BenjaminiHochbergAdjust(pMap)
-                : new Dictionary<(string, string), double>();
+            // Significance comes from the shared analyzer — the configured SailDiff test (Wilcoxon by
+            // default) on the raw samples, with one BH-FDR pass over this cohort — so the IDE, markdown and
+            // CSV report the same p/q/verdict. The ratio + CI rendered below remains the (display) effect size.
+            var settings = _runSettings?.SailDiffSettings ?? new SailDiffSettings();
+            var members = stats.Select(s => new MethodComparisonMember(s.Id, s.Name, false, s.Result.ToPerformanceRunResult())).ToList();
+            var analysis = _analyzer.Analyze(members, settings);
+            var qMap = new Dictionary<(string A, string B), double>();
+            foreach (var pair in analysis.Pairs)
+                qMap[MultipleComparisons.NormalizePair(pair.Primary.Id, pair.Compared.Id)] = pair.QValue;
 
-            var alpha = _runSettings?.SailDiffSettings?.Alpha ?? SailDiffSignificance.FallbackAlpha;
+            var alpha = settings.Alpha;
             var confidenceLevel = 1.0 - alpha;
             var sb = new StringBuilder();
             sb.AppendLine($"### 🔢 NxN Comparison Matrix (q-values via BH-FDR, α={alpha:0.###})");
@@ -688,21 +688,18 @@ internal class MethodComparisonTestRunCompletedHandler : INotificationHandler<Te
             var contenders = stats.Where(s => !ReferenceEquals(s.Result, baseline)).ToList();
             if (contenders.Count == 0) return string.Empty;
 
-            // BH-FDR over the N−1 baseline-vs-contender p-values
-            var pMap = new Dictionary<(string A, string B), double>();
-            foreach (var c in contenders)
-            {
-                var p = MultipleComparisons.LogRatioPValue(baselineStat.Mean, baselineStat.SE, baselineStat.N, c.Mean, c.SE, c.N);
-                if (!double.IsNaN(p) && p > 0)
-                {
-                    pMap[MultipleComparisons.NormalizePair(baselineStat.Id, c.Id)] = p;
-                }
-            }
-            var qMap = pMap.Count > 0
-                ? MultipleComparisons.BenjaminiHochbergAdjust(pMap)
-                : new Dictionary<(string, string), double>();
+            // Significance comes from the shared analyzer — configured SailDiff test on the raw samples
+            // with one BH-FDR pass over the N−1 baseline-vs-contender pairs — so every surface agrees.
+            var settings = _runSettings?.SailDiffSettings ?? new SailDiffSettings();
+            var members = stats
+                .Select(s => new MethodComparisonMember(s.Id, s.Name, ReferenceEquals(s.Result, baseline), s.Result.PerformanceRunResult!.ToPerformanceRunResult()))
+                .ToList();
+            var analysis = _analyzer.Analyze(members, settings);
+            var qMap = new Dictionary<(string A, string B), double>();
+            foreach (var pair in analysis.Pairs)
+                qMap[MultipleComparisons.NormalizePair(pair.Primary.Id, pair.Compared.Id)] = pair.QValue;
 
-            var alpha = _runSettings?.SailDiffSettings?.Alpha ?? SailDiffSignificance.FallbackAlpha;
+            var alpha = settings.Alpha;
             var confidenceLevel = 1.0 - alpha;
             var sb = new StringBuilder();
             sb.AppendLine($"### 📐 Baseline-vs-Contender (baseline = `{baselineStat.Name}`, q-values via BH-FDR, α={alpha:0.###})");

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -119,6 +119,7 @@ internal static class SailfishModuleRegistrations
         services.AddTransient<ITrackingFileSerialization, TrackingFileSerialization>();
         services.AddTransient<ITypeActivator, TypeActivator>();
         services.AddTransient<IStatisticalTestComputer, StatisticalTestComputer>();
+        services.AddTransient<IMethodComparisonAnalyzer, MethodComparisonAnalyzer>();
         services.AddTransient<ITestPreprocessor, TestPreprocessor>();
         services.AddTransient<IStatisticalTestExecutor, StatisticalTestExecutor>();
         services.AddTransient<IPerformanceRunResultAggregator, PerformanceRunResultAggregator>();

--- a/source/Tests.Common/MethodComparisonAnalyzerTestFactory.cs
+++ b/source/Tests.Common/MethodComparisonAnalyzerTestFactory.cs
@@ -1,0 +1,38 @@
+using Sailfish;
+using Sailfish.Analysis;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.SailDiff.Statistics.Tests;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.KolmogorovSmirnovTestSailfish;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.MWWilcoxonTestSailfish;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.PermutationTest;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.TTest;
+using Sailfish.Analysis.SailDiff.Statistics.Tests.TwoSampleWilcoxonSignedRankTestSailfish;
+
+namespace Tests.Common;
+
+/// <summary>
+/// Builds a real <see cref="MethodComparisonAnalyzer" /> wired to the production statistical engine, for
+/// tests that exercise method-comparison output end-to-end (so the verdict matches what ships).
+/// </summary>
+public static class MethodComparisonAnalyzerTestFactory
+{
+    public static IMethodComparisonAnalyzer Create()
+    {
+        var preprocessor = new TestPreprocessor(new SailfishOutlierDetector());
+        var executor = new StatisticalTestExecutor(
+            new MannWhitneyWilcoxonTest(preprocessor),
+            new Test(preprocessor),
+            new TwoSampleWilcoxonSignedRankTest(preprocessor),
+            new KolmogorovSmirnovTest(preprocessor),
+            new PermutationTest(preprocessor));
+        var computer = new StatisticalTestComputer(executor, new PerformanceRunResultAggregator());
+        return new MethodComparisonAnalyzer(computer);
+    }
+
+    /// <summary>A minimal real <see cref="IRunSettings" /> with SailDiff enabled, for wiring the IDE batch processor.</summary>
+    public static IRunSettings CreateRunSettings()
+    {
+        return RunSettingsBuilder.CreateBuilder().WithSailDiff().Build();
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/MethodComparisonAnalyzerTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/MethodComparisonAnalyzerTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Contracts.Public.Models;
+using Shouldly;
+using Xunit;
+
+namespace Tests.Library.Analysis.SailDiff;
+
+/// <summary>
+/// Locks the unified method-comparison verdict: significance comes from the configured SailDiff test on the
+/// raw samples (with one BH-FDR pass per cohort), the ratio + CI is a separate effect size, and a
+/// maximally-separated comparison (exact p == 0) still reads as significant rather than "Similar".
+/// </summary>
+public class MethodComparisonAnalyzerTests
+{
+    private static readonly IMethodComparisonAnalyzer Analyzer = Tests.Common.MethodComparisonAnalyzerTestFactory.Create();
+    private static readonly SailDiffSettings Settings = new(alpha: 0.05);
+
+    // Deterministic samples: n values linearly spanning center ± spread (so there is real within-group
+    // variance for the ratio CI, and no reliance on randomness).
+    private static double[] Samples(double center, double spread, int n)
+    {
+        if (n == 1) return new[] { center };
+        return Enumerable.Range(0, n).Select(i => center - spread + 2 * spread * i / (n - 1)).ToArray();
+    }
+
+    private static MethodComparisonMember Member(string name, bool isBaseline, double[] samples)
+    {
+        var mean = samples.Average();
+        var variance = samples.Length > 1 ? samples.Select(x => (x - mean) * (x - mean)).Sum() / (samples.Length - 1) : 0.0;
+        var stdDev = Math.Sqrt(variance);
+        var median = samples.OrderBy(x => x).ElementAt(samples.Length / 2);
+        var result = new PerformanceRunResult(
+            name, mean, stdDev, variance, median,
+            samples, samples.Length, 0,
+            samples, Array.Empty<double>(), Array.Empty<double>(), 0);
+        return new MethodComparisonMember(name, name, isBaseline, result);
+    }
+
+    [Fact]
+    public void NxN_ProducesOnePairPerUnorderedCombination()
+    {
+        var members = new[]
+        {
+            Member("A", false, Samples(10, 1, 20)),
+            Member("B", false, Samples(20, 1, 20)),
+            Member("C", false, Samples(30, 1, 20))
+        };
+
+        var result = Analyzer.Analyze(members, Settings);
+
+        result.BaselineMode.ShouldBeFalse();
+        result.Pairs.Count.ShouldBe(3); // C(3,2)
+    }
+
+    [Fact]
+    public void BaselineMode_EveryPairIsBaselineVsContender()
+    {
+        var members = new[]
+        {
+            Member("Baseline", true, Samples(10, 1, 20)),
+            Member("C1", false, Samples(20, 1, 20)),
+            Member("C2", false, Samples(30, 1, 20))
+        };
+
+        var result = Analyzer.Analyze(members, Settings);
+
+        result.BaselineMode.ShouldBeTrue();
+        result.BaselineId.ShouldBe("Baseline");
+        result.Pairs.Count.ShouldBe(2); // N-1
+        result.Pairs.ShouldAllBe(p => p.Primary.Id == "Baseline");
+    }
+
+    [Fact]
+    public void ClearlySlowerContender_IsLabelledSlower_WithSignificantQ()
+    {
+        // Baseline is fast (~10), contender is far slower (~100) and fully separated.
+        var members = new[]
+        {
+            Member("Baseline", true, Samples(10, 0.5, 15)),
+            Member("Slow", false, Samples(100, 5, 15))
+        };
+
+        var pair = Analyzer.Analyze(members, Settings).Pairs.Single();
+
+        pair.Verdict.ShouldBe(MethodComparisonVerdict.Slower); // ratio = compared/baseline > 1
+        pair.QValue.ShouldBeGreaterThan(0);
+        pair.QValue.ShouldBeLessThanOrEqualTo(Settings.Alpha);
+        pair.Ratio.ShouldBeGreaterThan(1.0);
+    }
+
+    [Fact]
+    public void ClearlyFasterContender_IsLabelledImproved()
+    {
+        var members = new[]
+        {
+            Member("Baseline", true, Samples(100, 5, 15)),
+            Member("Fast", false, Samples(10, 0.5, 15))
+        };
+
+        var pair = Analyzer.Analyze(members, Settings).Pairs.Single();
+
+        pair.Verdict.ShouldBe(MethodComparisonVerdict.Improved); // contender faster than baseline
+        pair.Ratio.ShouldBeLessThan(1.0);
+    }
+
+    [Fact]
+    public void HeavilyOverlappingSamples_AreLabelledSimilar()
+    {
+        // Tiny shift relative to spread → the rank-sum cannot reject; honest "Similar".
+        var members = new[]
+        {
+            Member("A", true, Samples(10.0, 3, 12)),
+            Member("B", false, Samples(10.3, 3, 12))
+        };
+
+        var pair = Analyzer.Analyze(members, Settings).Pairs.Single();
+
+        pair.Verdict.ShouldBe(MethodComparisonVerdict.Similar);
+    }
+
+    [Fact]
+    public void MaximalSeparationAtLargeN_StaysSignificant_NotMislabelledSimilar()
+    {
+        // N > 30 uses the large-sample normal approximation, whose p underflows to exactly 0 for a huge,
+        // perfectly-separated gap. Without the analyzer's zero-floor this would read as "Similar" (the
+        // canonical "this method is 100× faster" mislabelled). Lock it as significant.
+        var members = new[]
+        {
+            Member("Baseline", true, Samples(1000, 5, 40)),
+            Member("Fast", false, Samples(1, 0.05, 40))
+        };
+
+        var pair = Analyzer.Analyze(members, Settings).Pairs.Single();
+
+        pair.Verdict.ShouldBe(MethodComparisonVerdict.Improved);
+        pair.QValue.ShouldBeGreaterThan(0);
+        pair.QValue.ShouldBeLessThanOrEqualTo(Settings.Alpha);
+    }
+
+    [Fact]
+    public void InsufficientSamples_FallThroughToSimilar()
+    {
+        // Fewer than 3 samples per side → the test can't run → no significance → Similar (never a crash).
+        var members = new[]
+        {
+            Member("A", true, new[] { 10.0, 10.0 }),
+            Member("B", false, new[] { 20.0, 20.0 })
+        };
+
+        var pair = Analyzer.Analyze(members, Settings).Pairs.Single();
+
+        pair.Verdict.ShouldBe(MethodComparisonVerdict.Similar);
+        double.IsNaN(pair.QValue).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Find_LocatesPairRegardlessOfArgumentOrder()
+    {
+        var members = new[]
+        {
+            Member("A", false, Samples(10, 1, 20)),
+            Member("B", false, Samples(20, 1, 20))
+        };
+
+        var result = Analyzer.Analyze(members, Settings);
+
+        result.Find("A", "B").ShouldNotBeNull();
+        result.Find("B", "A").ShouldNotBeNull();
+        result.Find("A", "B").ShouldBeSameAs(result.Find("B", "A"));
+    }
+
+    [Fact]
+    public void FewerThanTwoUsableMethods_ProducesNoPairs()
+    {
+        var members = new[] { Member("Solo", false, Samples(10, 1, 20)) };
+
+        Analyzer.Analyze(members, Settings).Pairs.ShouldBeEmpty();
+    }
+}

--- a/source/Tests.Library/Analysis/SailDiff/MethodComparisonAnalyzerTests.cs
+++ b/source/Tests.Library/Analysis/SailDiff/MethodComparisonAnalyzerTests.cs
@@ -31,7 +31,9 @@ public class MethodComparisonAnalyzerTests
         var mean = samples.Average();
         var variance = samples.Length > 1 ? samples.Select(x => (x - mean) * (x - mean)).Sum() / (samples.Length - 1) : 0.0;
         var stdDev = Math.Sqrt(variance);
-        var median = samples.OrderBy(x => x).ElementAt(samples.Length / 2);
+        var ordered = samples.OrderBy(x => x).ToArray();
+        var mid = ordered.Length / 2;
+        var median = ordered.Length % 2 == 0 ? (ordered[mid - 1] + ordered[mid]) / 2.0 : ordered[mid];
         var result = new PerformanceRunResult(
             name, mean, stdDev, variance, median,
             samples, samples.Length, 0,

--- a/source/Tests.Library/DefaultHandlers/Sailfish/CsvTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/CsvTestRunCompletedHandlerTests.cs
@@ -25,21 +25,21 @@ public class CsvTestRunCompletedHandlerTests
     {
         _mockLogger = Substitute.For<ILogger>();
         _mockMediator = Substitute.For<IPublisher>();
-        _handler = new CsvTestRunCompletedHandler(_mockLogger, _mockMediator);
+        _handler = new CsvTestRunCompletedHandler(_mockLogger, _mockMediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create());
     }
 
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenLoggerIsNull()
     {
         // Act & Assert
-        Should.Throw<ArgumentNullException>(() => new CsvTestRunCompletedHandler(null!, _mockMediator));
+        Should.Throw<ArgumentNullException>(() => new CsvTestRunCompletedHandler(null!, _mockMediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create()));
     }
 
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenMediatorIsNull()
     {
         // Act & Assert
-        Should.Throw<ArgumentNullException>(() => new CsvTestRunCompletedHandler(_mockLogger, null!));
+        Should.Throw<ArgumentNullException>(() => new CsvTestRunCompletedHandler(_mockLogger, null!, Tests.Common.MethodComparisonAnalyzerTestFactory.Create()));
     }
 
     [Fact]

--- a/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Sailfish.Contracts.Public.Serialization.Tracking.V1;
 
@@ -38,7 +39,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
     {
         _mockLogger = Substitute.For<ILogger>();
         _mockMediator = Substitute.For<IPublisher>();
-        _handler = new MethodComparisonTestRunCompletedHandler(_mockLogger, _mockMediator);
+        _handler = new MethodComparisonTestRunCompletedHandler(_mockLogger, _mockMediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create());
     }
 
     #region Constructor Tests
@@ -48,7 +49,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
     {
         // Act & Assert
         Should.Throw<ArgumentNullException>(() =>
-            new MethodComparisonTestRunCompletedHandler(null!, _mockMediator));
+            new MethodComparisonTestRunCompletedHandler(null!, _mockMediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create()));
     }
 
     [Fact]
@@ -56,7 +57,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
     {
         // Act & Assert
         Should.Throw<ArgumentNullException>(() =>
-            new MethodComparisonTestRunCompletedHandler(_mockLogger, null!));
+            new MethodComparisonTestRunCompletedHandler(_mockLogger, null!, Tests.Common.MethodComparisonAnalyzerTestFactory.Create()));
     }
 
     #endregion
@@ -720,6 +721,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
         var richHandler = new MethodComparisonTestRunCompletedHandler(
             _mockLogger,
             _mockMediator,
+            Tests.Common.MethodComparisonAnalyzerTestFactory.Create(),
             healthProvider,
             runSettings,
             manifestProvider);
@@ -767,6 +769,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
 	        var richHandler = new MethodComparisonTestRunCompletedHandler(
 	            _mockLogger,
 	            _mockMediator,
+	            Tests.Common.MethodComparisonAnalyzerTestFactory.Create(),
 	            healthProvider,
 	            runSettings,
 	            manifestProvider);
@@ -799,7 +802,15 @@ public class MethodComparisonTestRunCompletedHandlerTests
         [Fact]
         public void CreateNxNComparisonMatrix_WithSignificantDifference_IncludesHeaderDiagonalCIQAndLabels()
         {
-            // Arrange: two methods with strong difference and non-zero SE to produce CI and tiny q
+            // Arrange: two methods with realistic, well-separated samples so the configured SailDiff test
+            // (Wilcoxon on the raw samples) finds a significant difference. Both carry within-group spread
+            // (non-zero SE → a ratio CI) and never overlap (every Beta sample > every Alpha sample → the
+            // rank-sum is maximally significant). This mirrors what a real run produces.
+            // N=30 (the rank-sum's exact-distribution path, ≤30) with cleanly separated samples: every Beta
+            // value exceeds every Alpha value, so the exact p is tiny-but-positive (the exact path doesn't
+            // underflow to 0 the way the large-sample normal approximation can), giving a real q-value.
+            var alphaSamples = Enumerable.Range(0, 30).Select(i => 9.0 + i * 0.05).ToArray();
+            var betaSamples = Enumerable.Range(0, 30).Select(i => 10.5 + i * 0.05).ToArray();
             var methods = new List<CompiledTestCaseResultTrackingFormat>
             {
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
@@ -807,19 +818,21 @@ public class MethodComparisonTestRunCompletedHandlerTests
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
                             .WithMean(10.0)
-                            .WithStdDev(1.0)
-                            .WithSampleSize(100)
-                            .WithDataWithOutliersRemoved(new double[100])
+                            .WithStdDev(0.58)
+                            .WithSampleSize(30)
+                            .WithRawExecutionResults(alphaSamples)
+                            .WithDataWithOutliersRemoved(alphaSamples)
                             .Build())
                     .Build(),
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
                     .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Beta").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
-                            .WithMean(10.5)
-                            .WithStdDev(1.0)
-                            .WithSampleSize(100)
-                            .WithDataWithOutliersRemoved(new double[100])
+                            .WithMean(11.0)
+                            .WithStdDev(0.58)
+                            .WithSampleSize(30)
+                            .WithRawExecutionResults(betaSamples)
+                            .WithDataWithOutliersRemoved(betaSamples)
                             .Build())
                     .Build(),
             };
@@ -851,6 +864,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
                             .WithMean(10.0)
                             .WithStdDev(0.0)
                             .WithSampleSize(1)
+                            .WithRawExecutionResults(new[] { 1.0 }) // <3 raw samples => the configured test can't run
                             .WithDataWithOutliersRemoved(new []{ 1.0 }) // N=1 => SE=0
                             .Build())
                     .Build(),
@@ -861,6 +875,7 @@ public class MethodComparisonTestRunCompletedHandlerTests
                             .WithMean(20.0)
                             .WithStdDev(0.0)
                             .WithSampleSize(1)
+                            .WithRawExecutionResults(new[] { 1.0 }) // <3 raw samples => the configured test can't run
                             .WithDataWithOutliersRemoved(new []{ 1.0 })
                             .Build())
                     .Build(),

--- a/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandlerTests.cs
@@ -42,6 +42,13 @@ public class MethodComparisonTestRunCompletedHandlerTests
         _handler = new MethodComparisonTestRunCompletedHandler(_mockLogger, _mockMediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create());
     }
 
+    // Sample standard deviation, so fixtures can derive the declared StdDev from their own samples.
+    private static double SampleStdDev(double[] xs)
+    {
+        var mean = xs.Average();
+        return Math.Sqrt(xs.Sum(x => (x - mean) * (x - mean)) / (xs.Length - 1));
+    }
+
     #region Constructor Tests
 
     [Fact]
@@ -806,20 +813,22 @@ public class MethodComparisonTestRunCompletedHandlerTests
             // (Wilcoxon on the raw samples) finds a significant difference. Both carry within-group spread
             // (non-zero SE → a ratio CI) and never overlap (every Beta sample > every Alpha sample → the
             // rank-sum is maximally significant). This mirrors what a real run produces.
-            // N=30 (the rank-sum's exact-distribution path, ≤30) with cleanly separated samples: every Beta
-            // value exceeds every Alpha value, so the exact p is tiny-but-positive (the exact path doesn't
-            // underflow to 0 the way the large-sample normal approximation can), giving a real q-value.
-            var alphaSamples = Enumerable.Range(0, 30).Select(i => 9.0 + i * 0.05).ToArray();
-            var betaSamples = Enumerable.Range(0, 30).Select(i => 10.5 + i * 0.05).ToArray();
+            // N=30 (the rank-sum's exact-distribution path). The two methods overlap but are clearly shifted
+            // (Alpha ramps over [9,11] ⇒ mean 10ms; Beta over [10,12] ⇒ mean 11ms): a ~1.6σ shift at N=30 is
+            // comfortably significant with a small-but-positive p. Mean/StdDev are DERIVED from the samples so
+            // the displayed effect size (which the analyzer reads from those fields) is consistent with the
+            // raw samples the significance test actually runs on.
+            var alphaSamples = Enumerable.Range(0, 30).Select(i => 9.0 + i * (2.0 / 29)).ToArray();
+            var betaSamples = Enumerable.Range(0, 30).Select(i => 10.0 + i * (2.0 / 29)).ToArray();
             var methods = new List<CompiledTestCaseResultTrackingFormat>
             {
                 CompiledTestCaseResultTrackingFormatBuilder.Create()
                     .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Alpha").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
-                            .WithMean(10.0)
-                            .WithStdDev(0.58)
-                            .WithSampleSize(30)
+                            .WithMean(alphaSamples.Average())
+                            .WithStdDev(SampleStdDev(alphaSamples))
+                            .WithSampleSize(alphaSamples.Length)
                             .WithRawExecutionResults(alphaSamples)
                             .WithDataWithOutliersRemoved(alphaSamples)
                             .Build())
@@ -828,9 +837,9 @@ public class MethodComparisonTestRunCompletedHandlerTests
                     .WithTestCaseId(TestCaseIdBuilder.Create().WithTestCaseVariables(SharedComparisonVariables).WithTestCaseName("Beta").Build())
                     .WithPerformanceRunResult(
                         PerformanceRunResultTrackingFormatBuilder.Create()
-                            .WithMean(11.0)
-                            .WithStdDev(0.58)
-                            .WithSampleSize(30)
+                            .WithMean(betaSamples.Average())
+                            .WithStdDev(SampleStdDev(betaSamples))
+                            .WithSampleSize(betaSamples.Length)
                             .WithRawExecutionResults(betaSamples)
                             .WithDataWithOutliersRemoved(betaSamples)
                             .Build())

--- a/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler_HealthSection_Tests.cs
+++ b/source/Tests.Library/DefaultHandlers/Sailfish/MethodComparisonTestRunCompletedHandler_HealthSection_Tests.cs
@@ -50,7 +50,7 @@ public class MethodComparisonTestRunCompletedHandlerHealthSectionTests
             })
         };
 
-        var handler = new MethodComparisonTestRunCompletedHandler(logger, mediator, provider);
+        var handler = new MethodComparisonTestRunCompletedHandler(logger, mediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create(), provider);
         var notification = CreateNotificationWithWriteToMarkdown();
 
         await handler.Handle(notification, CancellationToken.None);
@@ -71,7 +71,7 @@ public class MethodComparisonTestRunCompletedHandlerHealthSectionTests
         var mediator = Substitute.For<IPublisher>();
         var provider = new StubProvider { Current = null };
 
-        var handler = new MethodComparisonTestRunCompletedHandler(logger, mediator, provider);
+        var handler = new MethodComparisonTestRunCompletedHandler(logger, mediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create(), provider);
         var notification = CreateNotificationWithWriteToMarkdown();
 
         await handler.Handle(notification, CancellationToken.None);

--- a/source/Tests.Library/Presentation/CsvOutputGoldenTests.cs
+++ b/source/Tests.Library/Presentation/CsvOutputGoldenTests.cs
@@ -86,7 +86,7 @@ public class CsvOutputGoldenTests
                 .Do(ci => actualCsv = ci.ArgAt<WriteMethodComparisonCsvNotification>(0).CsvContent);
 
             var logger = new TestLogger();
-            var handler = new CsvTestRunCompletedHandler(logger, mediator);
+            var handler = new CsvTestRunCompletedHandler(logger, mediator, Tests.Common.MethodComparisonAnalyzerTestFactory.Create());
 
             var notification = CreateNotification();
             await handler.Handle(notification, CancellationToken.None);

--- a/source/Tests.Library/Presentation/MarkdownOutputGoldenTests.cs
+++ b/source/Tests.Library/Presentation/MarkdownOutputGoldenTests.cs
@@ -141,6 +141,7 @@ public class MarkdownOutputGoldenTests
             var handler = new MethodComparisonTestRunCompletedHandler(
                 logger,
                 mediator,
+                Tests.Common.MethodComparisonAnalyzerTestFactory.Create(),
                 healthProvider,
                 runSettings,
                 manifestProvider,

--- a/source/Tests.TestAdapter/Aggregation/TestCompletionAggregatorTests.cs
+++ b/source/Tests.TestAdapter/Aggregation/TestCompletionAggregatorTests.cs
@@ -42,7 +42,7 @@ public class TestCompletionAggregatorTests
 
         // The REAL comparison processor — the behaviour-bearing code we are preserving. It and the aggregator
         // share one mediator so every framework publish (immediate or enhanced) is counted in one place.
-        _batchProcessor = new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _unifiedFormatter);
+        _batchProcessor = new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _unifiedFormatter, Tests.Common.MethodComparisonAnalyzerTestFactory.Create(), Tests.Common.MethodComparisonAnalyzerTestFactory.CreateRunSettings());
     }
 
     private TestCompletionAggregator NewAggregator(params ITestCompletionSink[] sinks)

--- a/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_AccumulateAndPublishTests.cs
+++ b/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_AccumulateAndPublishTests.cs
@@ -29,7 +29,7 @@ public class MethodComparisonBatchProcessorAccumulateAndPublishTests
 
     private MethodComparisonBatchProcessor CreateSut()
     {
-        return new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _formatter);
+        return new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _formatter, Tests.Common.MethodComparisonAnalyzerTestFactory.Create(), Tests.Common.MethodComparisonAnalyzerTestFactory.CreateRunSettings());
     }
 
     private static TestCompletionMessage CreateMessage(string className, string methodName, string group, double meanMs)

--- a/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_BaselineInversionTests.cs
+++ b/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_BaselineInversionTests.cs
@@ -311,7 +311,7 @@ public class MethodComparisonBatchProcessorBaselineInversionTests
             {
                 MeanMs = meanMs,
                 MedianMs = meanMs,
-                SampleSize = 5,
+                SampleSize = 10,
                 StandardDeviation = meanMs * 0.01,
                 Variance = 1.0,
                 // 10 samples with a small (±~5%) deterministic spread. The methods are far apart (e.g. 8ms

--- a/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_BaselineInversionTests.cs
+++ b/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_BaselineInversionTests.cs
@@ -119,7 +119,7 @@ public class MethodComparisonBatchProcessorBaselineInversionTests
             CompletedAt = DateTime.UtcNow,
         };
 
-        var sut = new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _formatter);
+        var sut = new MethodComparisonBatchProcessor(_sailDiff, _mediator, _logger, _formatter, Tests.Common.MethodComparisonAnalyzerTestFactory.Create(), Tests.Common.MethodComparisonAnalyzerTestFactory.CreateRunSettings());
 
         // Act
         await sut.ProcessBatch(batch, CancellationToken.None);
@@ -314,8 +314,11 @@ public class MethodComparisonBatchProcessorBaselineInversionTests
                 SampleSize = 5,
                 StandardDeviation = meanMs * 0.01,
                 Variance = 1.0,
-                RawExecutionResults = new[] { meanMs, meanMs, meanMs },
-                DataWithOutliersRemoved = new[] { meanMs, meanMs, meanMs },
+                // 10 samples with a small (±~5%) deterministic spread. The methods are far apart (e.g. 8ms
+                // vs 1ms), so the configured rank-sum test cleanly finds significance — whereas 3 identical
+                // samples never could (the smallest achievable rank-sum p at N=3 is 0.1).
+                RawExecutionResults = Enumerable.Range(0, 10).Select(k => meanMs * (0.95 + k * 0.01)).ToArray(),
+                DataWithOutliersRemoved = Enumerable.Range(0, 10).Select(k => meanMs * (0.95 + k * 0.01)).ToArray(),
                 UpperOutliers = Array.Empty<double>(),
                 LowerOutliers = Array.Empty<double>(),
                 TotalNumOutliers = 0,

--- a/source/Tests.TestAdapter/TestCaseCompletedNotificationHandlerTests.cs
+++ b/source/Tests.TestAdapter/TestCaseCompletedNotificationHandlerTests.cs
@@ -36,7 +36,9 @@ public class TestCaseCompletedNotificationHandlerTests
             Substitute.For<IAdapterSailDiff>(),
             publisher,
             Substitute.For<ILogger>(),
-            Substitute.For<ISailDiffUnifiedFormatter>());
+            Substitute.For<ISailDiffUnifiedFormatter>(),
+            Tests.Common.MethodComparisonAnalyzerTestFactory.Create(),
+            Tests.Common.MethodComparisonAnalyzerTestFactory.CreateRunSettings());
         return new TestCompletionAggregator(publisher, batchProcessor, Substitute.For<ILogger>());
     }
 


### PR DESCRIPTION
## Why

Method-vs-method comparison (every `[SailfishMethod]` on a `[Sailfish]` class) was judged **differently depending on where you looked**, which quietly breaks trust in the feature:

- **IDE** ran the configured SailDiff test (Wilcoxon Rank-Sum by default) on the raw samples, with **no** BH-FDR multiplicity correction.
- **Console / markdown / CSV** never ran that test — they computed a parametric **log-ratio Student-t on summary statistics** and gated the Improved/Slower/Similar label on a BH-FDR q-value.

So the same two methods could get a different p-value, a different significance call, and a different label in the IDE vs the generated `.md`/`.csv`.

## What

A new shared **`IMethodComparisonAnalyzer`** (`source/Sailfish/Analysis/SailDiff/MethodComparisonAnalyzer.cs`) is the single source of truth. It relabels each pair to a unique synthetic key and runs the whole comparison group through **one `IStatisticalTestComputer.ComputeTest` call**, reusing the engine's configured test (Wilcoxon by default) on the raw samples + its single BH-FDR pass + verdict gating — exactly as historical SailDiff does. The ratio + confidence interval is kept as a **separate effect-size** readout (it answers "by how much", independent of the significance call).

All three surfaces now consume it:
- **markdown** (`MethodComparisonTestRunCompletedHandler`) and **CSV** (`CsvTestRunCompletedHandler`) drop their inline log-ratio computation for the analyzer's q-value;
- the **IDE** (`MethodComparisonBatchProcessor`) re-gates each pair's verdict on the family q-value, **gaining the FDR correction it previously lacked**.

Same two methods ⇒ same p-value, q-value and label, on every surface — by construction.

### Two bugs surfaced and fixed
- **Maximal separation was mislabelled "Similar."** The rank-sum's exact p for a huge, perfectly-separated gap comes out as literally `0`, and the q-gate requires `> 0` — so the canonical "this method is 100× faster" would read *not significant*. The analyzer floors a successful zero to `1e-300` (mirroring the existing `LogRatioPValue` floor). Locked by a dedicated test.
- A `TestCaseId` round-trip quirk (`"k"` → `"k()"`) that would otherwise drop every verdict to NaN — handled by normalizing the lookup key.

## Scope
Verdict/statistics **only**. Unifying the two renderers onto one table, and printing method comparison to the **console window** (today it only writes md/CSV files), are intentional follow-ups. Method-comparison numbers/labels may shift because the statistic and multiplicity control are now consistent. **No public API was removed.**

## Tests / verification
- Full solution builds **net9 + net10**, 0 errors.
- **Tests.Library 1680/1680** and **Tests.TestAdapter 170/170** (net9); changed slices green on net10.
- New `MethodComparisonAnalyzerTests` (9) lock N×N vs baseline-mode, the q-gated verdict, the exact-zero floor, degenerate-data → Similar, and `Find()`. New `MethodComparisonAnalyzerTestFactory` (Tests.Common) builds a real analyzer for tests; several unit tests moved from summary-only/degenerate data to realistic separated samples (the new path tests the actual samples, as real runs do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified method comparison analyzer for consistent statistical analysis across all comparison outputs.

* **Improvements**
  * Centralized Benjamini-Hochberg FDR correction ensures reliable multiple-comparison adjustment for method comparisons, eliminating inconsistencies between different output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->