### PR TITLE
fix(adapter): run ScaleFish + AI (Skipper) on the VS Test Adapter path

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 ﻿## What's Changed in v0.0.118 (unreleased)
 
+### Fix: the VS Test Adapter now runs ScaleFish + AI (Skipper), like the programmatic runner
+
+Running benchmarks through the VS Test Adapter (`dotnet test` / Test Explorer / the gutter "play" button) **silently skipped ScaleFish and the Skipper AI layer**, even when fully configured — AI worked only via the programmatic `SailfishRunner.Run`. The adapter's run-completion path published its results notification but never invoked the SailDiff/ScaleFish analyzers (the call was dropped years ago), so the ScaleFish/SailDiff completion notifications that drive Skipper never fired. The adapter now mirrors `SailfishExecutor.Run`: after benchmarks are measured it runs SailDiff and ScaleFish, so BigO output, run-vs-run comparison, and the `skipper-report_*.md` / `skipper-review_*.json` artifacts are produced on the IDE path exactly as they are programmatically.
+
+Alongside the fix:
+
+- **No more silent no-ops.** When AI analysis is enabled but produces nothing, the adapter logs a single **warning** explaining why — no `.sailfish.json` was found, no Skipper transport is registered, or nothing triggered Skipper this run (and what would).
+- **Robust `.sailfish.json` discovery.** Discovery now also searches the **test assembly's own directory** (not just upward from the working directory), and logs which file was loaded (or that none was). A `<None CopyToOutputDirectory>` entry that keeps the file beside the test DLL now works.
+- **Opt-in run-vs-run baseline.** A new `SailDiffSettings.AutoCompareToPreviousRun` flag in `.sailfish.json` (default off) makes "run twice → SailDiff" work under the adapter by comparing against the most recent prior tracking file. Explicit `ProvidedBeforeTrackingFiles` still takes precedence; the explicit-only default introduced earlier in v0.0.118 is unchanged.
+- **Method-comparison groups now feed Skipper.** A completed in-run `ComparisonGroup` (the most common comparison) publishes a new `MethodComparisonAnalysisCompleteNotification` and triggers a Skipper "explain this comparison" review (artifact kind `comparison-<group>`).
+
 ### Method comparison: one verdict everywhere
 
 Method-vs-method comparison (every `[SailfishMethod]` on a `[Sailfish]` class) used to be judged *differently depending on where you looked*: the IDE ran the configured SailDiff test (Wilcoxon by default) on the raw samples with no multiplicity correction, while the console/markdown/CSV computed a parametric log-ratio approximation off summary statistics and gated the label on a BH-FDR q-value. The same two methods could get a different p-value and a different Improved/Slower/Similar label in the IDE vs the generated report.

--- a/site/src/pages/docs/2/skipper.md
+++ b/site/src/pages/docs/2/skipper.md
@@ -43,7 +43,13 @@ Sailfish benchmarks run as ordinary tests: install the **`Sailfish.TestAdapter`*
 
 There's no `RunSettingsBuilder` in this path — the adapter runs in its own process and never sees programmatic registration — so Skipper is configured by **file**, not code. Three things must be true before the play button will produce a Skipper verdict.
 
-**1. SailDiff and/or ScaleFish must be enabled.** Skipper explains *their* output, so at least one has to produce a comparison. In the **`.sailfish.json`** at (or above) your test directory:
+**1. Something must produce an analysis for Skipper to explain.** Skipper explains *other* analyses, so at least one has to fire. There are three triggers — and two of them work in a **single run**:
+
+- **ScaleFish** (BigO) — add a `[SailfishVariable(scaleFish: true, …)]` (or `[SailfishRangeVariable(scaleFish: true, …)]`) variable. Fires on a **single** run.
+- **A method-comparison group** — two or more `[SailfishMethod]`s sharing a `ComparisonGroup` (optionally one marked `IsBaseline`). Fires on a **single** run.
+- **Run-vs-run SailDiff** — compares this run against an earlier one. This one needs an explicit baseline (see "the run-twice loop" below); it does *not* auto-pick the previous run.
+
+In the **`.sailfish.json`** at (or above) your test directory, leave SailDiff/ScaleFish enabled (they are by default):
 
 ```jsonc
 {
@@ -73,13 +79,23 @@ public class RegistrationProvider : IRegisterSailfishServices
 }
 ```
 
-For the reference `ClaudeCliSkipperTransport`, the `claude` CLI must be installed and on your `PATH`. Without *any* registered transport, `Enabled: true` is a harmless no-op.
+For the reference `ClaudeCliSkipperTransport`, the `claude` CLI must be installed and on your `PATH`. Without *any* registered transport, `Enabled: true` is a harmless no-op — but the adapter now **warns** you about it instead of staying silent (see [When Skipper produces nothing](#when-skipper-produces-nothing)).
 
-**The loop is run-twice.** SailDiff compares your latest run against the previous one, so a single run has nothing to diff:
+**The run-twice loop (run-vs-run SailDiff).** Sailfish does **not** auto-compare a run against the previous one — a historical comparison happens only when you name a baseline. For the classic "run, change, run again, explain the diff" loop under the adapter, opt in once in `.sailfish.json`:
+
+```jsonc
+{
+  "SailDiffSettings": { "AutoCompareToPreviousRun": true }
+}
+```
+
+With that set:
 
 1. Click the play button once — this records the **baseline** (no comparison yet).
 2. Change your code.
-3. Click play again — SailDiff produces the before/after, and Skipper explains it.
+3. Click play again — SailDiff compares against the most recent prior run, and Skipper explains it.
+
+To pin a *fixed* baseline instead, name the tracking file(s) explicitly with `SailDiffSettings.ProvidedBeforeTrackingFiles` (which always takes precedence over `AutoCompareToPreviousRun`). If you only want a **single-run** explanation, reach for a ScaleFish variable or a method-comparison group instead — neither needs a baseline.
 
 {% callout title="Run one test, not the whole suite" type="note" %}
 The agent is invoked **once per analyzed comparison** — running the entire suite fans out into one call per test (and, for the reference agent, one `claude` invocation each). While you iterate, click the play button on a **single** benchmark. The Skipper verdict prints to the **test output window**, right beneath the SailDiff table; the `skipper-review_*.json` and `skipper-report_*.md` artifacts land in your results directory (`GlobalSettings.ResultsDirectory`).
@@ -173,7 +189,7 @@ Chips: 🔴 regressed · 🟢 improved · ⚪ not significant · 🟡 inconclusi
 | `skipper-review_<timestamp>_<kind>.json` | The structured review — machine-readable, for a CI bot or orchestrator to consume. |
 | `skipper-report_<timestamp>_<kind>.md` | The deep human-readable write-up: call path, cited code, suggested fix. |
 
-`<kind>` is `saildiff` or `scalefish`, so a run that does both never overwrites itself.
+`<kind>` is `saildiff`, `scalefish`, or `comparison-<group>` (one per method-comparison group), so several analyses in one run never overwrite each other.
 
 ## Reliability-aware verdicts
 
@@ -183,20 +199,19 @@ Skipper's context packet includes an **environment snapshot** drawn from Sailfis
 
 Each comparison also carries its effect size and the **minimum detectable effect** — so Skipper can tell you when a run was simply underpowered to catch the change you care about.
 
-## Two questions Skipper answers
+## Three questions Skipper answers
 
-- **"Why did this change?"** — from SailDiff. Skipper reads the implicated method, follows it into the system under test, and explains the cause (an allocation in a loop, an N+1 query, a lost fast-path) with citations.
+- **"Why did this change?"** — from run-vs-run SailDiff. Skipper reads the implicated method, follows it into the system under test, and explains the cause (an allocation in a loop, an N+1 query, a lost fast-path) with citations.
+- **"Which of these implementations is faster, and why?"** — from a method-comparison group (one baseline, N candidates). Skipper explains the winner and the gap on the most common comparison you run — in a single run, no baseline file required.
 - **"Why does this scale like that, and what happens at 10× the data?"** — from ScaleFish. Skipper takes the best-fit complexity class (and whether it's statistically distinguishable from the runner-up) and projects the fitted curve to larger N: *"O(n²), R²=0.98 — at 10,000 items expect ~500ms."*
 
-## Workflow: rerun in place
+## When Skipper produces nothing
 
-The most natural local loop is the simplest one. Sailfish's tracking files capture each run, and SailDiff automatically compares your **latest run against the previous one** — so you just:
+Skipper used to fail *silently* — you'd enable it and simply see nothing, with no clue why. It no longer does: when AI analysis is enabled but produces no output, the adapter logs a single **warning** (visible in the test output / `dotnet test` log) telling you exactly what's missing:
 
-1. Run your benchmarks.
-2. Change your code.
-3. Run again.
-
-SailDiff produces the before/after, and Skipper explains it — no file paths to type, nothing to wire up. (You can still point SailDiff at specific prior tracking files when you want a fixed baseline; rerun-in-place is simply the zero-friction default.)
+- **No `.sailfish.json` was found** — discovery searches upward from the working directory *and* from the test assembly's own output directory; if neither has one, defaults are used and AI stays off. (Tip: a `<None Update=".sailfish.json" CopyToOutputDirectory="PreserveNewest" />` entry keeps the file beside the test DLL so it's always found.)
+- **AI is enabled but no transport is registered** — register one with `services.AddSkipperTransport<T>()`.
+- **AI is enabled with a transport, but nothing triggered it this run** — add a ScaleFish variable, a method-comparison group, or a run-vs-run baseline (see the trigger list above).
 
 ## Settings
 

--- a/source/Sailfish.TestAdapter/Comparison/MethodComparisonBatchProcessor.cs
+++ b/source/Sailfish.TestAdapter/Comparison/MethodComparisonBatchProcessor.cs
@@ -4,6 +4,7 @@ using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Formatting;
 using Sailfish.Contracts.Public;
 using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Execution;
 using Sailfish.Logging;
 using Sailfish.TestAdapter.Execution;
@@ -151,6 +152,10 @@ internal class MethodComparisonBatchProcessor
             .GroupBy(tc => ExtractVariableSection(tc.TestCaseId), StringComparer.Ordinal)
             .ToList();
 
+        // Accumulate every cohort's pairwise results so the whole group can be handed to the Skipper AI
+        // layer once (one review per comparison group, not per cohort).
+        var groupPairs = new List<MethodComparisonPairResult>();
+
         foreach (var cohort in cohorts)
         {
             var members = cohort.ToList();
@@ -167,6 +172,7 @@ internal class MethodComparisonBatchProcessor
             // calls below still drive the displayed statistics, but their verdict is re-gated on this
             // family q-value so the IDE agrees with the markdown/CSV (which use the same analyzer).
             var cohortAnalysis = AnalyzeCohort(members);
+            groupPairs.AddRange(cohortAnalysis.Pairs);
 
             // A method flagged [SailfishMethod(IsBaseline = true)] is carried as ComparisonRole="Baseline"
             // (set during discovery in TestCaseItemCreator and forwarded through the message mappers).
@@ -209,6 +215,58 @@ internal class MethodComparisonBatchProcessor
 
         // Republish all enhanced FrameworkTestCaseEndNotification messages
         await PublishEnhancedFrameworkNotificationsForGroup(testCases, cancellationToken);
+
+        // Hand the completed group to the Skipper AI layer (opt-in; the handler no-ops when AI is off or no
+        // transport is registered). This is what lets "explain this comparison" work on the most common
+        // comparison users run — the in-run baseline/N-candidates ComparisonGroup.
+        await PublishComparisonAnalysisForSkipper(groupName, groupPairs, cancellationToken);
+    }
+
+    /// <summary>
+    ///     Publishes the completed comparison group's pairwise results as a
+    ///     <see cref="MethodComparisonAnalysisCompleteNotification" /> so the Skipper AI layer can reason over
+    ///     it. Published unconditionally (cheap, additive); the Skipper handler gates on
+    ///     <c>RunAiAnalysis</c> + a registered transport, mirroring how SailDiff/ScaleFish feed Skipper.
+    /// </summary>
+    private async Task PublishComparisonAnalysisForSkipper(
+        string groupName,
+        List<MethodComparisonPairResult> pairs,
+        CancellationToken cancellationToken)
+    {
+        if (pairs.Count == 0) return;
+
+        try
+        {
+            var markdown = BuildComparisonMarkdown(groupName, pairs);
+            await _publisher.Publish(
+                new MethodComparisonAnalysisCompleteNotification(groupName, pairs, markdown),
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Strictly additive: a failure feeding the AI layer must never affect the comparison output.
+            _logger.Log(LogLevel.Warning, ex,
+                "Failed to publish method-comparison analysis for AI on group '{0}': {1}", groupName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    ///     Renders a concise grounding table for the AI narrative — one row per pair, baseline vs contender
+    ///     with mean, ratio, q-value and verdict. The agent reasons over these authoritative figures.
+    /// </summary>
+    private static string BuildComparisonMarkdown(string groupName, List<MethodComparisonPairResult> pairs)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"### Method comparison: {groupName}");
+        sb.AppendLine("| Compared | Baseline | Mean (compared) | Mean (baseline) | Ratio (compared/baseline) | q-value | Verdict |");
+        sb.AppendLine("|----------|----------|-----------------|-----------------|---------------------------|---------|---------|");
+        foreach (var p in pairs)
+        {
+            sb.AppendLine(
+                $"| {ExtractMethodName(p.Compared.Id)} | {ExtractMethodName(p.Primary.Id)} | {p.ComparedMean:0.###}ms | {p.PrimaryMean:0.###}ms | {p.Ratio:0.###}x | {p.QValue:0.###e-0} | {p.Verdict} |");
+        }
+
+        return sb.ToString();
     }
 
     private static bool HasComparisonMetadata(TestCompletionMessage message)

--- a/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
+++ b/source/Sailfish.TestAdapter/Execution/AdapterRunSettingsLoader.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Exceptions;
 using Sailfish.TestAdapter.Discovery;
@@ -7,14 +8,40 @@ using SailDiffSettings = Sailfish.Analysis.SailDiff.SailDiffSettings;
 using RuntimeScaleFishSettings = Sailfish.Analysis.ScaleFish.ScaleFishSettings;
 using RuntimeTrawlSettings = Sailfish.Trawl.TrawlSettings;
 using CoreAiAnalysisSettings = Sailfish.Analysis.Ai.AiAnalysisSettings;
+using TrackingFiles = Sailfish.Analysis.SailDiff.TrackingFiles;
+using DefaultFileSettings = Sailfish.Presentation.DefaultFileSettings;
 
 namespace Sailfish.TestAdapter.Execution;
 
 public static class AdapterRunSettingsLoader
 {
+    /// <summary>
+    ///     Loads the adapter run settings from <c>.sailfish.json</c>, falling back to defaults when none is found.
+    ///     Prefer the overload that takes the test assembly location and a message logger so discovery can also
+    ///     search the assembly's output directory and so the loaded-file / not-found outcome is observable.
+    /// </summary>
     public static IRunSettings RetrieveAndLoadAdapterRunSettings()
     {
-        var parsedSettings = ParseSettings();
+        return RetrieveAndLoadAdapterRunSettings(null, null);
+    }
+
+    /// <summary>
+    ///     Loads the adapter run settings from <c>.sailfish.json</c>.
+    /// </summary>
+    /// <param name="testAssemblyLocation">
+    ///     Path to the test assembly (e.g. the test DLL). When provided, discovery also searches the assembly's
+    ///     own directory upward — not only upward from the working directory — so the file is found regardless of
+    ///     the test host's working directory (and the <c>&lt;None CopyToOutputDirectory&gt;</c> convention, where
+    ///     <c>.sailfish.json</c> sits beside the test DLL, works).
+    /// </param>
+    /// <param name="messageLogger">
+    ///     Optional VSTest message logger. When provided, the loader logs which <c>.sailfish.json</c> was loaded
+    ///     (info) or warns (once) that none was found and defaults are in effect — so AI analysis being off is
+    ///     never a silent surprise.
+    /// </param>
+    public static IRunSettings RetrieveAndLoadAdapterRunSettings(string? testAssemblyLocation, IMessageLogger? messageLogger)
+    {
+        var parsedSettings = ParseSettings(testAssemblyLocation, messageLogger);
 
         if (parsedSettings.GlobalSettings.DisableEverything) throw new SailfishException("Everything is disabled!");
 
@@ -51,18 +78,18 @@ public static class AdapterRunSettingsLoader
             runSettingsBuilder = runSettingsBuilder.WithDistributionHtmlReport(parsedSettings.GlobalSettings.EmitDistributionHtmlReport.Value);
 
         // Skipper AI analysis is opt-in via .sailfish.json. A Skipper transport must also be registered through
-        // IRegisterSailfishServices (services.AddSkipperTransport<T>()); without one, enabling this is a harmless no-op.
+        // IRegisterSailfishServices (services.AddSkipperTransport<T>()); without one, enabling this is a no-op
+        // (the adapter warns about it after the run — see TestExecutor — rather than failing silently).
         if (parsedSettings.AiAnalysisSettings is { Enabled: true } ai)
             runSettingsBuilder = runSettingsBuilder.WithAiAnalysis(new CoreAiAnalysisSettings(
                 writeReviewArtifact: ai.WriteReviewArtifact ?? true,
                 emitConsoleSummary: ai.EmitConsoleSummary ?? true,
                 useResponseCache: ai.UseResponseCache ?? true));
 
-        // Explicit historical comparison: SailDiff only compares against an earlier run when the user names the
-        // 'before' tracking file(s). There is no auto-pick of the previous run.
-        var providedBeforeTrackingFiles = parsedSettings.SailDiffSettings.ProvidedBeforeTrackingFiles;
-        if (providedBeforeTrackingFiles is { Length: > 0 })
-            runSettingsBuilder = runSettingsBuilder.WithProvidedBeforeTrackingFiles(providedBeforeTrackingFiles);
+        // Historical (run-vs-run) comparison is explicit by default: SailDiff compares against an earlier run
+        // only when the user names the 'before' file(s). The opt-in AutoCompareToPreviousRun flag is the
+        // deliberate way to get the "run twice → SailDiff" workflow without naming a file by hand.
+        ConfigureHistoricalComparison(ref runSettingsBuilder, parsedSettings, messageLogger);
 
         var testSettings = MapToTestSettings(parsedSettings);
         var scaleFishSettings = MapToScaleFishSettings(parsedSettings);
@@ -74,6 +101,45 @@ public static class AdapterRunSettingsLoader
             .WithTrawl(trawlSettings)
             .Build();
         return runSettings;
+    }
+
+    /// <summary>
+    ///     Wires up the 'before' tracking file(s) for a historical comparison. An explicit
+    ///     <c>ProvidedBeforeTrackingFiles</c> always wins. Otherwise, when <c>AutoCompareToPreviousRun</c> is
+    ///     enabled, the most recent prior tracking file is resolved here — <em>before</em> this run writes its
+    ///     own file, so "most recent" is genuinely the previous run.
+    /// </summary>
+    private static void ConfigureHistoricalComparison(
+        ref RunSettingsBuilder runSettingsBuilder,
+        SettingsConfiguration parsedSettings,
+        IMessageLogger? messageLogger)
+    {
+        var providedBeforeTrackingFiles = parsedSettings.SailDiffSettings.ProvidedBeforeTrackingFiles;
+        if (providedBeforeTrackingFiles is { Length: > 0 })
+        {
+            runSettingsBuilder = runSettingsBuilder.WithProvidedBeforeTrackingFiles(providedBeforeTrackingFiles);
+            return;
+        }
+
+        if (parsedSettings.SailDiffSettings.AutoCompareToPreviousRun != true) return;
+
+        var outputDir = string.IsNullOrEmpty(parsedSettings.GlobalSettings.ResultsDirectory)
+            ? DefaultFileSettings.DefaultOutputDirectory
+            : parsedSettings.GlobalSettings.ResultsDirectory;
+        var trackingDir = Path.Combine(outputDir, TrackingFiles.DefaultTrackingDirectoryName);
+        var previousRun = TrackingFiles.MostRecentIn(trackingDir);
+
+        if (previousRun is not null)
+        {
+            runSettingsBuilder = runSettingsBuilder.WithProvidedBeforeTrackingFile(previousRun);
+            Log(messageLogger, TestMessageLevel.Informational,
+                $"Sailfish: AutoCompareToPreviousRun is on — comparing this run against the most recent prior tracking file: {previousRun}");
+        }
+        else
+        {
+            Log(messageLogger, TestMessageLevel.Informational,
+                "Sailfish: AutoCompareToPreviousRun is on but no prior tracking file was found, so there is no run-vs-run comparison this run (expected on the first run).");
+        }
     }
 
     private static RuntimeScaleFishSettings MapToScaleFishSettings(SettingsConfiguration settingsConfiguration)
@@ -129,29 +195,61 @@ public static class AdapterRunSettingsLoader
         return mappedSettings;
     }
 
-    private static SettingsConfiguration ParseSettings()
+    private static SettingsConfiguration ParseSettings(string? testAssemblyLocation, IMessageLogger? messageLogger)
     {
-        FileInfo settingsFile;
-        try
+        var settingsFile = LocateSettingsFile(testAssemblyLocation);
+        if (settingsFile is null)
         {
-            settingsFile = DirectoryRecursion.RecurseUpwardsUntilFileIsFound(
-                ".sailfish.json",
-#pragma warning disable RS1035
-                Directory.GetCurrentDirectory(),
-#pragma warning restore RS1035
-                6);
-        }
-        catch (TestAdapterException)
-        {
-            // No .sailfish.json is present anywhere up the tree — that is an expected,
-            // supported configuration. Fall back to defaults silently.
+            // No .sailfish.json anywhere up the tree from the working directory or the test assembly — that is
+            // an expected, supported configuration, but it is the silent path that makes AI analysis appear to
+            // do nothing. Warn once (not debug) so it is observable, then fall back to defaults.
+            Log(messageLogger, TestMessageLevel.Warning,
+                "Sailfish: no .sailfish.json was found (searched upward from the working directory" +
+                (string.IsNullOrEmpty(testAssemblyLocation) ? "" : " and the test assembly directory") +
+                "); using built-in defaults. Skipper AI analysis stays OFF unless a .sailfish.json sets " +
+                "AiAnalysisSettings.Enabled = true.");
             return new SettingsConfiguration();
         }
 
-        // If the file exists but cannot be parsed (malformed JSON, IO error, etc.) we
-        // intentionally let the exception propagate. TestExecutor.HandleStartupException
-        // surfaces it to the test framework so the user can see and fix their config —
-        // silently falling back to defaults previously hid these problems entirely.
+        Log(messageLogger, TestMessageLevel.Informational, $"Sailfish: loaded settings from {settingsFile.FullName}");
+
+        // If the file exists but cannot be parsed (malformed JSON, IO error, etc.) we intentionally let the
+        // exception propagate. TestExecutor.HandleStartupException surfaces it to the test framework so the user
+        // can see and fix their config — silently falling back to defaults previously hid these problems.
         return SailfishSettingsParser.Parse(settingsFile.FullName);
+    }
+
+    /// <summary>
+    ///     Locates <c>.sailfish.json</c>, searching upward from the working directory first (historical
+    ///     behaviour) and then, as a fallback, upward from the test assembly's own directory (the output dir).
+    ///     Returns null when neither search finds it.
+    /// </summary>
+    private static FileInfo? LocateSettingsFile(string? testAssemblyLocation)
+    {
+#pragma warning disable RS1035
+        var fromWorkingDirectory = TryRecurseUpwards(Directory.GetCurrentDirectory());
+#pragma warning restore RS1035
+        if (fromWorkingDirectory is not null) return fromWorkingDirectory;
+
+        return string.IsNullOrEmpty(testAssemblyLocation)
+            ? null
+            : TryRecurseUpwards(testAssemblyLocation!);
+    }
+
+    private static FileInfo? TryRecurseUpwards(string startPath)
+    {
+        try
+        {
+            return DirectoryRecursion.RecurseUpwardsUntilFileIsFound(".sailfish.json", startPath, 6);
+        }
+        catch (TestAdapterException)
+        {
+            return null;
+        }
+    }
+
+    private static void Log(IMessageLogger? messageLogger, TestMessageLevel level, string message)
+    {
+        messageLogger?.SendMessage(level, message);
     }
 }

--- a/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
+++ b/source/Sailfish.TestAdapter/Execution/TestAdapterExecutionProgram.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Sailfish.Mediation;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Analysis.ScaleFish;
 using Sailfish.Contracts.Public.Models;
 using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Logging;
@@ -20,7 +23,9 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
 {
     private readonly ILogger _logger;
     private readonly IPublisher _publisher;
-    private readonly ISailfishConsoleWindowFormatter _sailfishConsoleWindowFormatter;
+    private readonly IRunSettings _runSettings;
+    private readonly ISailDiffInternal _sailDiff;
+    private readonly IScaleFishInternal _scaleFish;
     private readonly ITestAdapterExecutionEngine _testAdapterExecutionEngine;
     private readonly ITestCaseCountPrinter _testCaseCountPrinter;
 
@@ -28,14 +33,17 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
         IRunSettings runSettings,
         ITestAdapterExecutionEngine testAdapterExecutionEngine,
         IPublisher publisher,
+        ISailDiffInternal sailDiff,
+        IScaleFishInternal scaleFish,
         ILogger logger,
-        ISailfishConsoleWindowFormatter sailfishConsoleWindowFormatter,
         ITestCaseCountPrinter testCaseCountPrinter)
     {
+        _runSettings = runSettings;
         _testAdapterExecutionEngine = testAdapterExecutionEngine;
         _publisher = publisher;
+        _sailDiff = sailDiff;
+        _scaleFish = scaleFish;
         _logger = logger;
-        _sailfishConsoleWindowFormatter = sailfishConsoleWindowFormatter;
         _testCaseCountPrinter = testCaseCountPrinter;
     }
 
@@ -51,8 +59,47 @@ internal class TestAdapterExecutionProgram : ITestAdapterExecutionProgram
         _testCaseCountPrinter.PrintDiscoveredTotal();
 
         var executionSummaries = await _testAdapterExecutionEngine.Execute(testCases, cancellationToken);
-        await _publisher
-            .Publish(new TestRunCompletedNotification(executionSummaries.ToTrackingFormat()), cancellationToken)
-            .ConfigureAwait(false);
+
+        // Benchmarks are measured at this point. From here the adapter mirrors the programmatic
+        // SailfishExecutor.Run: publish the run-completed notification, then run SailDiff and ScaleFish.
+        // Those analyzers publish the SailDiff/ScaleFish completion notifications the Skipper AI handlers
+        // listen for, so AI analysis fires on the IDE / `dotnet test` path exactly as it does programmatically.
+        // Each post-measurement stage runs inside an error boundary so a failure in analysis never loses the
+        // collected timings or crashes the test host.
+        await RunPostMeasurementStage(
+            "publish test-run-completed notification",
+            () => _publisher.Publish(new TestRunCompletedNotification(executionSummaries.ToTrackingFormat()), cancellationToken));
+
+        if (_runSettings.RunSailDiff)
+            await RunPostMeasurementStage("SailDiff analysis", () => _sailDiff.Analyze(cancellationToken));
+
+        if (_runSettings.RunScaleFish)
+            await RunPostMeasurementStage("ScaleFish analysis", () => _scaleFish.Analyze(executionSummaries, cancellationToken));
+    }
+
+    /// <summary>
+    ///     Runs a single post-measurement stage (notification publish or an analyzer) inside an error boundary.
+    ///     A throw is logged as a structured error so the stage fails soft — the collected timings survive and
+    ///     the remaining stages still run. Cancellation is a control-flow signal rather than an analysis failure,
+    ///     so it is allowed to propagate. Mirrors <c>SailfishExecutor.RunPostMeasurementStage</c>.
+    /// </summary>
+    private async Task RunPostMeasurementStage(string stageName, Func<Task> stage)
+    {
+        try
+        {
+            await stage().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.Log(
+                LogLevel.Error,
+                ex,
+                "Post-measurement stage '{Stage}' failed after benchmarks were measured. The collected timings are preserved and the remaining stages continue; this step's artifacts/analysis were skipped.",
+                stageName);
+        }
     }
 }

--- a/source/Sailfish.TestAdapter/TestExecutor.cs
+++ b/source/Sailfish.TestAdapter/TestExecutor.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Sailfish.Analysis.Ai;
 using Sailfish.Diagnostics.Environment;
 using Sailfish.Exceptions;
 using Sailfish.Logging;
@@ -86,7 +87,11 @@ public class TestExecutor : ITestExecutor
         var services = new ServiceCollection();
         try
         {
-            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
+            // Pass the test assembly path so discovery can also search the assembly's output directory (not only
+            // upward from the working directory), and the frameworkHandle so the loaded-file / not-found outcome
+            // is observable (warns when no .sailfish.json is found). See AdapterRunSettingsLoader.
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings(
+                testCases.FirstOrDefault()?.Source, frameworkHandle);
             services.AddSailfish(runSettings);
             services.AddSailfishTestAdapter(frameworkHandle);
 
@@ -106,6 +111,7 @@ public class TestExecutor : ITestExecutor
 
         var provider = services.BuildServiceProvider();
 
+        var ranToCompletion = false;
         try
         {
             // Environment health check (informational).
@@ -198,6 +204,7 @@ public class TestExecutor : ITestExecutor
 
             // Execute tests.
             _testExecution.ExecuteTests(testCases, provider, frameworkHandle, _cancellationTokenSource.Token);
+            ranToCompletion = true;
         }
         catch (Exception ex)
         {
@@ -206,10 +213,55 @@ public class TestExecutor : ITestExecutor
         finally
         {
             // Flush the aggregator: publish any comparison group that never completed (deterministic, end-of-run).
+            // This can fire the last comparison-group Skipper triggers, so warn about AI inactivity afterwards.
             FlushComparisonAggregator(provider);
+
+            // Surface why AI analysis produced nothing, instead of leaving the user staring at silence.
+            if (ranToCompletion) WarnIfAiConfiguredButInactive(provider, frameworkHandle);
 
             // Dispose provider — releases all singletons and any other IDisposable services it owns.
             provider.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///     Emits a single, actionable warning when Skipper AI analysis was enabled but produced nothing — the
+    ///     core UX failure this addresses. Two cases: (1) enabled but no <see cref="ISkipperTransport" /> is
+    ///     registered, and (2) enabled with a transport but no trigger (ScaleFish / method comparison / run-vs-run
+    ///     SailDiff) was produced this run, so Skipper had nothing to explain. Best-effort: diagnostics must never
+    ///     affect the run.
+    /// </summary>
+    internal static void WarnIfAiConfiguredButInactive(IServiceProvider provider, IFrameworkHandle frameworkHandle)
+    {
+        try
+        {
+            var runSettings = provider.GetService<Sailfish.Contracts.Public.Models.IRunSettings>();
+            if (runSettings?.RunAiAnalysis != true) return; // AI not enabled — nothing to warn about.
+
+            string? message = null;
+            if (provider.GetService<ISailfishAgent>() is NoOpSailfishAgent)
+            {
+                message =
+                    "Sailfish AI analysis (Skipper) is enabled in .sailfish.json, but no Skipper transport is registered, so it was skipped. " +
+                    "Register one from your test project via IRegisterSailfishServices: services.AddSkipperTransport<YourTransport>().";
+            }
+            else if (provider.GetService<ISkipperActivitySink>() is { Triggered: false })
+            {
+                message =
+                    "Sailfish AI analysis (Skipper) is enabled and a transport is registered, but it did not fire this run because no analysis produced a result to explain. " +
+                    "Skipper runs on a ScaleFish complexity result (add a [SailfishVariable(scaleFish: true, ...)] variable), a completed method-comparison group, " +
+                    "or a run-vs-run SailDiff (set SailDiffSettings.ProvidedBeforeTrackingFiles or AutoCompareToPreviousRun in .sailfish.json).";
+            }
+
+            if (message is null) return;
+
+            frameworkHandle.SendMessage(TestMessageLevel.Warning, message);
+            provider.GetService<ILogger>()?.Log(LogLevel.Warning, message);
+        }
+        catch (Exception ex)
+        {
+            provider.GetService<ILogger>()?.Log(LogLevel.Warning, ex,
+                "Failed to evaluate Skipper AI diagnostics: {0}", ex.Message);
         }
     }
 

--- a/source/Sailfish.TestAdapter/TestSettingsParser/SailDiffSettings.cs
+++ b/source/Sailfish.TestAdapter/TestSettingsParser/SailDiffSettings.cs
@@ -29,4 +29,11 @@ public class SailDiffSettings
     // relative to the working directory). Leave null/empty for no historical comparison.
     [JsonPropertyName("ProvidedBeforeTrackingFiles")]
     public string[]? ProvidedBeforeTrackingFiles { get; set; }
+
+    // Opt-in convenience for the "run twice → SailDiff" workflow under the adapter. When true and no
+    // ProvidedBeforeTrackingFiles is set, this run is compared against the most recent prior tracking file
+    // (resolved before this run writes its own). Default (null/false) preserves the explicit-only behaviour;
+    // ProvidedBeforeTrackingFiles always takes precedence when both are set.
+    [JsonPropertyName("AutoCompareToPreviousRun")]
+    public bool? AutoCompareToPreviousRun { get; set; }
 }

--- a/source/Sailfish/Analysis/Ai/ISkipperActivitySink.cs
+++ b/source/Sailfish/Analysis/Ai/ISkipperActivitySink.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+
+namespace Sailfish.Analysis.Ai;
+
+/// <summary>
+///     Records whether the Skipper AI layer actually engaged this run — i.e. a SailDiff, ScaleFish, or
+///     method-comparison trigger reached a real agent with analyzable content. The adapter reads this after the
+///     run to distinguish "AI ran" from "AI was enabled but never had anything to act on", so it can emit one
+///     actionable warning instead of leaving the user staring at silence (the core UX failure this addresses).
+///     Registered as a singleton; the DI container is built once per run, so the flag is naturally run-scoped
+///     and needs no reset.
+/// </summary>
+internal interface ISkipperActivitySink
+{
+    /// <summary>Marks that Skipper engaged at least once this run.</summary>
+    void RecordTriggered();
+
+    /// <summary>True once any Skipper analysis (SailDiff / ScaleFish / method comparison) has engaged.</summary>
+    bool Triggered { get; }
+}
+
+/// <inheritdoc cref="ISkipperActivitySink" />
+internal sealed class SkipperActivitySink : ISkipperActivitySink
+{
+    private int _triggered;
+
+    public void RecordTriggered() => Interlocked.Exchange(ref _triggered, 1);
+
+    public bool Triggered => Volatile.Read(ref _triggered) == 1;
+}

--- a/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
+++ b/source/Sailfish/Analysis/Ai/PerformanceNarrativeContextBuilder.cs
@@ -5,6 +5,7 @@ using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Diagnostics.Environment;
 using Sailfish.Results;
 using Sailfish.Analysis.ScaleFish;
+using Sailfish.Analysis.SailDiff;
 using Sailfish.Analysis.SailDiff.Formatting;
 
 namespace Sailfish.Analysis.Ai;
@@ -14,6 +15,8 @@ internal interface IPerformanceNarrativeContextBuilder
     PerformanceNarrativeContext Build(SailDiffAnalysisCompleteNotification notification, double alpha);
 
     PerformanceNarrativeContext BuildScaling(ScaleFishAnalysisCompleteNotification notification);
+
+    PerformanceNarrativeContext BuildComparison(MethodComparisonAnalysisCompleteNotification notification);
 }
 
 /// <summary>
@@ -68,6 +71,59 @@ internal sealed class PerformanceNarrativeContextBuilder : IPerformanceNarrative
             notification.ScaleFishResultMarkdown ?? string.Empty,
             BuildEnvironment(),
             verdicts);
+    }
+
+    public PerformanceNarrativeContext BuildComparison(MethodComparisonAnalysisCompleteNotification notification)
+    {
+        var comparisons = notification.Pairs
+            .Select(ToCaseContext)
+            .ToList();
+
+        return new PerformanceNarrativeContext(comparisons, notification.ResultsAsMarkdown ?? string.Empty, BuildEnvironment());
+    }
+
+    /// <summary>
+    ///     Lifts one method-comparison pair into the grounded packet. Orientation matches the analyzer:
+    ///     primary/baseline is "before", compared/contender is "after". The verdict reuses the unified
+    ///     method-comparison verdict (a Slower contender is a regression relative to its baseline), and the
+    ///     ratio (compared/primary) is carried as the effect size.
+    /// </summary>
+    private static SailDiffCaseContext ToCaseContext(MethodComparisonPairResult pair)
+    {
+        var verdict = pair.Verdict switch
+        {
+            MethodComparisonVerdict.Improved => SkipperVerdict.Improved,
+            MethodComparisonVerdict.Slower => SkipperVerdict.Regressed,
+            _ => SkipperVerdict.NotSignificant
+        };
+
+        var changeDescription = pair.Verdict switch
+        {
+            MethodComparisonVerdict.Improved => "Faster than baseline",
+            MethodComparisonVerdict.Slower => "Slower than baseline",
+            _ => "No significant difference from baseline"
+        };
+
+        var percentChangeMean = pair.PrimaryMean != 0
+            ? (pair.ComparedMean - pair.PrimaryMean) / pair.PrimaryMean * 100.0
+            : 0.0;
+
+        return new SailDiffCaseContext(
+            $"{pair.Compared.MethodName} vs {pair.Primary.MethodName}",
+            verdict,
+            pair.PrimaryMean,
+            pair.ComparedMean,
+            pair.PrimaryMedian,
+            pair.ComparedMedian,
+            percentChangeMean,
+            pair.PValue,
+            pair.QValue,
+            changeDescription,
+            pair.PrimarySampleSize,
+            pair.ComparedSampleSize,
+            Failed: false,
+            EffectSizeName: "Ratio (compared/baseline)",
+            EffectSizeValue: pair.Ratio);
     }
 
     private static IReadOnlyList<ComplexityProjection> Project(ScaleFishModelFunction function)

--- a/source/Sailfish/Analysis/Ai/SkipperAnalysisRunner.cs
+++ b/source/Sailfish/Analysis/Ai/SkipperAnalysisRunner.cs
@@ -21,6 +21,7 @@ internal interface ISkipperAnalysisRunner
 internal sealed class SkipperAnalysisRunner : ISkipperAnalysisRunner
 {
     private readonly ISailfishAgent agent;
+    private readonly ISkipperActivitySink activitySink;
     private readonly IConsoleWriter consoleWriter;
     private readonly ISkipperConsoleFormatter consoleFormatter;
     private readonly ILogger logger;
@@ -37,6 +38,7 @@ internal sealed class SkipperAnalysisRunner : ISkipperAnalysisRunner
         ISkipperResponseCache responseCache,
         IConsoleWriter consoleWriter,
         ISkipperConsoleFormatter consoleFormatter,
+        ISkipperActivitySink activitySink,
         ILogger logger)
     {
         this.runSettings = runSettings;
@@ -46,6 +48,7 @@ internal sealed class SkipperAnalysisRunner : ISkipperAnalysisRunner
         this.responseCache = responseCache;
         this.consoleWriter = consoleWriter;
         this.consoleFormatter = consoleFormatter;
+        this.activitySink = activitySink;
         this.logger = logger;
     }
 
@@ -55,6 +58,10 @@ internal sealed class SkipperAnalysisRunner : ISkipperAnalysisRunner
 
         var hasContent = context.Comparisons.Count > 0 || context.Scaling is { Count: > 0 };
         if (!hasContent) return;
+
+        // A real trigger with analyzable content reached a real agent. Record it so the adapter can tell
+        // "AI engaged" from "AI was enabled but had nothing to act on" and warn accordingly (see #2).
+        activitySink.RecordTriggered();
 
         try
         {

--- a/source/Sailfish/Contracts.Public/Notifications/MethodComparisonAnalysisCompleteNotification.cs
+++ b/source/Sailfish/Contracts.Public/Notifications/MethodComparisonAnalysisCompleteNotification.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Sailfish.Mediation;
+using Sailfish.Analysis.SailDiff;
+
+namespace Sailfish.Contracts.Public.Notifications;
+
+/// <summary>
+///     Published when an in-run method-vs-method comparison group (the one-baseline / N-candidates
+///     <c>ComparisonGroup</c> feature) has been analyzed. Carries the authoritative pairwise results so
+///     downstream listeners — notably the Skipper AI layer — can reason over the most common comparison users
+///     run without recomputing anything. Emitted once per completed comparison group.
+/// </summary>
+public record MethodComparisonAnalysisCompleteNotification : INotification
+{
+    public MethodComparisonAnalysisCompleteNotification(
+        string GroupName,
+        IReadOnlyList<MethodComparisonPairResult> Pairs,
+        string ResultsAsMarkdown)
+    {
+        this.GroupName = GroupName;
+        this.Pairs = Pairs;
+        this.ResultsAsMarkdown = ResultsAsMarkdown;
+    }
+
+    /// <summary>The comparison group's name (the <c>ComparisonGroup</c> label shared by its member methods).</summary>
+    public string GroupName { get; init; }
+
+    /// <summary>The pairwise comparison results for the group, primary/baseline (before) vs compared (after).</summary>
+    public IReadOnlyList<MethodComparisonPairResult> Pairs { get; init; }
+
+    /// <summary>A concise markdown rendering of the comparison, used to ground the AI narrative.</summary>
+    public string ResultsAsMarkdown { get; init; }
+
+    public void Deconstruct(
+        out string GroupName,
+        out IReadOnlyList<MethodComparisonPairResult> Pairs,
+        out string ResultsAsMarkdown)
+    {
+        GroupName = this.GroupName;
+        Pairs = this.Pairs;
+        ResultsAsMarkdown = this.ResultsAsMarkdown;
+    }
+}

--- a/source/Sailfish/DefaultHandlers/Ai/SkipperMethodComparisonAnalysisHandler.cs
+++ b/source/Sailfish/DefaultHandlers/Ai/SkipperMethodComparisonAnalysisHandler.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Sailfish.Mediation;
+using Sailfish.Analysis.Ai;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+
+namespace Sailfish.DefaultHandlers.Ai;
+
+/// <summary>
+///     Bridges a completed in-run method-vs-method comparison (the <c>ComparisonGroup</c> feature — one
+///     baseline, N candidates — which is the most common comparison users run) to the Skipper AI layer. Builds
+///     a grounded comparison context and hands it to the shared <see cref="ISkipperAnalysisRunner" />. Opt-in
+///     (<see cref="IRunSettings.RunAiAnalysis" />) and strictly additive — if no real agent is registered the
+///     run is entirely unaffected. Artifacts are keyed by group name so several comparison groups in one run do
+///     not overwrite each other.
+/// </summary>
+internal sealed class SkipperMethodComparisonAnalysisHandler : INotificationHandler<MethodComparisonAnalysisCompleteNotification>
+{
+    private readonly IPerformanceNarrativeContextBuilder contextBuilder;
+    private readonly ISkipperAnalysisRunner runner;
+    private readonly IRunSettings runSettings;
+
+    public SkipperMethodComparisonAnalysisHandler(
+        IRunSettings runSettings,
+        IPerformanceNarrativeContextBuilder contextBuilder,
+        ISkipperAnalysisRunner runner)
+    {
+        this.runSettings = runSettings;
+        this.contextBuilder = contextBuilder;
+        this.runner = runner;
+    }
+
+    public async Task Handle(MethodComparisonAnalysisCompleteNotification notification, CancellationToken cancellationToken)
+    {
+        if (!runSettings.RunAiAnalysis) return;
+        if (notification.Pairs.Count == 0) return;
+
+        var context = contextBuilder.BuildComparison(notification);
+        await runner.RunAsync(context, AnalysisKindFor(notification.GroupName), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Builds a filesystem-safe artifact key from the comparison group name (e.g. "comparison-MyGroup"),
+    ///     so each group's Skipper artifacts are distinct from one another and from the SailDiff/ScaleFish ones.
+    /// </summary>
+    private static string AnalysisKindFor(string groupName)
+    {
+        if (string.IsNullOrWhiteSpace(groupName)) return "comparison";
+
+        var safe = new StringBuilder("comparison-");
+        foreach (var c in groupName)
+            safe.Append(char.IsLetterOrDigit(c) ? c : '-');
+        return safe.ToString();
+    }
+}

--- a/source/Sailfish/Registration/SailfishModuleRegistrations.cs
+++ b/source/Sailfish/Registration/SailfishModuleRegistrations.cs
@@ -161,6 +161,11 @@ internal static class SailfishModuleRegistrations
         services.AddTransient<ISkipperConsoleFormatter, SkipperConsoleFormatter>();
         services.AddTransient<ISkipperAnalysisRunner, SkipperAnalysisRunner>();
 
+        // Per-run flag recording whether Skipper actually engaged (a trigger reached a real agent with
+        // content). Singleton so it survives across the run's notifications; read by the adapter to warn when
+        // AI was enabled but never fired. See ISkipperActivitySink.
+        services.AddSingleton<ISkipperActivitySink, SkipperActivitySink>();
+
         return services;
     }
 }

--- a/source/Tests.Library/Analysis/Ai/SkipperMethodComparisonTests.cs
+++ b/source/Tests.Library/Analysis/Ai/SkipperMethodComparisonTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Sailfish.Analysis.Ai;
+using Sailfish.Analysis.SailDiff;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
+using Sailfish.DefaultHandlers.Ai;
+using Sailfish.Diagnostics.Environment;
+using Sailfish.Results;
+using Shouldly;
+using Tests.Common.Builders;
+using Xunit;
+
+namespace Tests.Library.Analysis.Ai;
+
+/// <summary>
+///     Deliverable #5: a completed in-run method-vs-method ComparisonGroup must feed Skipper. Covers the handler
+///     (gating + context build + runner invocation) and the verdict/orientation mapping the context builder uses.
+/// </summary>
+public class SkipperMethodComparisonTests
+{
+    [Fact]
+    public async Task Handler_WhenAiEnabled_BuildsComparisonContextAndRunsSkipperKeyedByGroup()
+    {
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.RunAiAnalysis.Returns(true);
+
+        var context = new PerformanceNarrativeContext(Array.Empty<SailDiffCaseContext>(), "md", null);
+        var builder = Substitute.For<IPerformanceNarrativeContextBuilder>();
+        builder.BuildComparison(Arg.Any<MethodComparisonAnalysisCompleteNotification>()).Returns(context);
+        var runner = Substitute.For<ISkipperAnalysisRunner>();
+
+        var handler = new SkipperMethodComparisonAnalysisHandler(runSettings, builder, runner);
+        var notification = new MethodComparisonAnalysisCompleteNotification("My Group", new[] { Pair(MethodComparisonVerdict.Slower) }, "md");
+
+        await handler.Handle(notification, CancellationToken.None);
+
+        builder.Received(1).BuildComparison(notification);
+        await runner.Received(1).RunAsync(
+            context,
+            Arg.Is<string>(kind => kind.StartsWith("comparison")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handler_WhenAiDisabled_DoesNothing()
+    {
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.RunAiAnalysis.Returns(false);
+        var builder = Substitute.For<IPerformanceNarrativeContextBuilder>();
+        var runner = Substitute.For<ISkipperAnalysisRunner>();
+
+        var handler = new SkipperMethodComparisonAnalysisHandler(runSettings, builder, runner);
+
+        await handler.Handle(new MethodComparisonAnalysisCompleteNotification("G", new[] { Pair(MethodComparisonVerdict.Improved) }, "md"), CancellationToken.None);
+
+        builder.DidNotReceiveWithAnyArgs().BuildComparison(default!);
+        await runner.DidNotReceiveWithAnyArgs().RunAsync(default!, default!, default!);
+    }
+
+    [Fact]
+    public async Task Handler_WhenNoPairs_DoesNothing()
+    {
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.RunAiAnalysis.Returns(true);
+        var builder = Substitute.For<IPerformanceNarrativeContextBuilder>();
+        var runner = Substitute.For<ISkipperAnalysisRunner>();
+
+        var handler = new SkipperMethodComparisonAnalysisHandler(runSettings, builder, runner);
+
+        await handler.Handle(new MethodComparisonAnalysisCompleteNotification("G", Array.Empty<MethodComparisonPairResult>(), "md"), CancellationToken.None);
+
+        await runner.DidNotReceiveWithAnyArgs().RunAsync(default!, default!, default!);
+    }
+
+    [Fact]
+    public void BuildComparison_MapsVerdictAndOrientsBaselineAsBefore()
+    {
+        var builder = new PerformanceNarrativeContextBuilder(
+            Substitute.For<IReproducibilityManifestProvider>(),
+            Substitute.For<IEnvironmentHealthReportProvider>());
+
+        // Contender (compared) is faster than the baseline (primary): 5ms vs 10ms ⇒ Improved, -50%.
+        var pair = new MethodComparisonPairResult(
+            new MethodComparisonMember("Sut.Baseline", "Baseline", true, AResult()),
+            new MethodComparisonMember("Sut.Candidate", "Candidate", false, AResult()),
+            PrimaryMean: 10.0, ComparedMean: 5.0,
+            PrimaryMedian: 10.0, ComparedMedian: 5.0,
+            PrimarySampleSize: 8, ComparedSampleSize: 8,
+            PValue: 0.001, QValue: 0.002,
+            Ratio: 0.5, CiLower: 0.4, CiUpper: 0.6,
+            Verdict: MethodComparisonVerdict.Improved);
+
+        var context = builder.BuildComparison(
+            new MethodComparisonAnalysisCompleteNotification("Group", new[] { pair }, "## md"));
+
+        var c = context.Comparisons.ShouldHaveSingleItem();
+        c.Verdict.ShouldBe(SkipperVerdict.Improved);
+        c.MeanBefore.ShouldBe(10.0);  // baseline is "before"
+        c.MeanAfter.ShouldBe(5.0);    // contender is "after"
+        c.PercentChangeMean.ShouldBe(-50.0, 1e-9);
+        c.AdjustedPValue.ShouldBe(0.002);
+        c.EffectSizeValue.ShouldBe(0.5);
+        context.SailDiffMarkdown.ShouldBe("## md");
+    }
+
+    private static MethodComparisonPairResult Pair(MethodComparisonVerdict verdict)
+    {
+        return new MethodComparisonPairResult(
+            new MethodComparisonMember("Sut.A", "A", true, AResult()),
+            new MethodComparisonMember("Sut.B", "B", false, AResult()),
+            PrimaryMean: 10.0, ComparedMean: 12.0,
+            PrimaryMedian: 10.0, ComparedMedian: 12.0,
+            PrimarySampleSize: 5, ComparedSampleSize: 5,
+            PValue: 0.04, QValue: 0.04,
+            Ratio: 1.2, CiLower: 1.0, CiUpper: 1.4,
+            Verdict: verdict);
+    }
+
+    private static PerformanceRunResult AResult()
+    {
+        return PerformanceRunResultBuilder.Create().Build();
+    }
+}

--- a/source/Tests.TestAdapter/AdapterRunSettingsLoader_AiAndDiscovery_Tests.cs
+++ b/source/Tests.TestAdapter/AdapterRunSettingsLoader_AiAndDiscovery_Tests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using NSubstitute;
+using Sailfish.TestAdapter.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Tests.TestAdapter;
+
+// Serialize with the sibling AdapterRunSettingsLoader tests — all mutate the process-wide current working
+// directory via Directory.SetCurrentDirectory, which races under xUnit's default class-parallel execution.
+[Collection("CwdMutatingAdapterRunSettingsLoader")]
+public class AdapterRunSettingsLoaderAiAndDiscoveryTests
+{
+    private const string TrackingFileName = "PerformanceTracking_20200101_000000.json.tracking";
+
+    // ---- #3 Robust discovery + observability -------------------------------------------------------------
+
+    [Fact]
+    public void Discovery_FindsSettingsBesideTheTestAssembly_WhenWorkingDirectoryHasNone()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var cwdRoot = NewTempDir("sf_disc_cwd");          // isolated, no .sailfish.json up-tree
+        var asmDir = NewTempDir("sf_disc_asm");           // a .sailfish.json sits here, beside the "assembly"
+        var nestedCwd = Path.Combine(cwdRoot, "a", "b");
+        Directory.CreateDirectory(nestedCwd);
+
+        // Distinctive setting so we can prove THIS file was loaded (default would be true).
+        File.WriteAllText(Path.Combine(asmDir, ".sailfish.json"),
+            """{ "SailfishSettings": { "EnableEnvironmentHealthCheck": false } }""");
+
+        var logger = Substitute.For<IMessageLogger>();
+        try
+        {
+            Directory.SetCurrentDirectory(nestedCwd);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings(
+                Path.Combine(asmDir, "SomeTests.dll"), logger);
+
+            runSettings.EnableEnvironmentHealthCheck.ShouldBeFalse(); // proves the assembly-dir file was loaded
+            logger.Received().SendMessage(
+                TestMessageLevel.Informational,
+                Arg.Is<string>(s => s.Contains("loaded settings from")));
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            TryDelete(cwdRoot);
+            TryDelete(asmDir);
+        }
+    }
+
+    [Fact]
+    public void Discovery_WarnsAndFallsBackToDefaults_WhenNoSettingsAnywhere()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var cwdRoot = NewTempDir("sf_none_cwd");
+        var asmDir = NewTempDir("sf_none_asm");
+        var nestedCwd = Path.Combine(cwdRoot, "a", "b");
+        Directory.CreateDirectory(nestedCwd);
+
+        var logger = Substitute.For<IMessageLogger>();
+        try
+        {
+            Directory.SetCurrentDirectory(nestedCwd);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings(
+                Path.Combine(asmDir, "SomeTests.dll"), logger);
+
+            // A warning (not debug) is the whole point — AI being off must never be silent.
+            logger.Received().SendMessage(
+                TestMessageLevel.Warning,
+                Arg.Is<string>(s => s.Contains("no .sailfish.json") && s.Contains("AiAnalysisSettings.Enabled")));
+            runSettings.EnableEnvironmentHealthCheck.ShouldBeTrue(); // defaults are in effect
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            TryDelete(cwdRoot);
+            TryDelete(asmDir);
+        }
+    }
+
+    // ---- #4 Opt-in auto-baseline for run-vs-run SailDiff --------------------------------------------------
+
+    [Fact]
+    public void AutoCompareToPreviousRun_ResolvesMostRecentPriorTrackingFile()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var cwdRoot = NewTempDir("sf_auto_cwd");
+        var outputDir = NewTempDir("sf_auto_out");
+        var nestedCwd = Path.Combine(cwdRoot, "a", "b");
+        Directory.CreateDirectory(nestedCwd);
+
+        var trackingDir = Path.Combine(outputDir, "sailfish_tracking_output");
+        Directory.CreateDirectory(trackingDir);
+        var priorRun = Path.Combine(trackingDir, TrackingFileName);
+        File.WriteAllText(priorRun, "{}");
+
+        // .sailfish.json found via cwd-search, points its output dir at our absolute temp dir, opts in.
+        File.WriteAllText(Path.Combine(cwdRoot, ".sailfish.json"),
+            $$"""
+            {
+              "GlobalSettings": { "ResultsDirectory": {{ Json(outputDir) }} },
+              "SailDiffSettings": { "AutoCompareToPreviousRun": true }
+            }
+            """);
+
+        try
+        {
+            Directory.SetCurrentDirectory(nestedCwd);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
+
+            runSettings.ProvidedBeforeTrackingFiles.ShouldHaveSingleItem().ShouldEndWith(TrackingFileName);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            TryDelete(cwdRoot);
+            TryDelete(outputDir);
+        }
+    }
+
+    [Fact]
+    public void AutoCompareToPreviousRun_OnFirstRunWithNoPriorFile_LeavesComparisonUnset()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var cwdRoot = NewTempDir("sf_auto_first_cwd");
+        var outputDir = NewTempDir("sf_auto_first_out"); // exists but contains no tracking files
+        var nestedCwd = Path.Combine(cwdRoot, "a", "b");
+        Directory.CreateDirectory(nestedCwd);
+
+        File.WriteAllText(Path.Combine(cwdRoot, ".sailfish.json"),
+            $$"""
+            {
+              "GlobalSettings": { "ResultsDirectory": {{ Json(outputDir) }} },
+              "SailDiffSettings": { "AutoCompareToPreviousRun": true }
+            }
+            """);
+
+        try
+        {
+            Directory.SetCurrentDirectory(nestedCwd);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
+
+            runSettings.ProvidedBeforeTrackingFiles.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            TryDelete(cwdRoot);
+            TryDelete(outputDir);
+        }
+    }
+
+    [Fact]
+    public void ExplicitProvidedBeforeTrackingFiles_TakePrecedenceOverAutoCompare()
+    {
+        var originalCwd = Directory.GetCurrentDirectory();
+        var cwdRoot = NewTempDir("sf_auto_explicit_cwd");
+        var outputDir = NewTempDir("sf_auto_explicit_out");
+        var nestedCwd = Path.Combine(cwdRoot, "a", "b");
+        Directory.CreateDirectory(nestedCwd);
+
+        // A prior file exists AND auto-compare is on, but an explicit file is named — the explicit one wins.
+        var trackingDir = Path.Combine(outputDir, "sailfish_tracking_output");
+        Directory.CreateDirectory(trackingDir);
+        File.WriteAllText(Path.Combine(trackingDir, TrackingFileName), "{}");
+
+        File.WriteAllText(Path.Combine(cwdRoot, ".sailfish.json"),
+            $$"""
+            {
+              "GlobalSettings": { "ResultsDirectory": {{ Json(outputDir) }} },
+              "SailDiffSettings": {
+                "AutoCompareToPreviousRun": true,
+                "ProvidedBeforeTrackingFiles": [ "explicit/run-1.json.tracking" ]
+              }
+            }
+            """);
+
+        try
+        {
+            Directory.SetCurrentDirectory(nestedCwd);
+
+            var runSettings = AdapterRunSettingsLoader.RetrieveAndLoadAdapterRunSettings();
+
+            runSettings.ProvidedBeforeTrackingFiles.ShouldBe(new[] { "explicit/run-1.json.tracking" });
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            TryDelete(cwdRoot);
+            TryDelete(outputDir);
+        }
+    }
+
+    private static string Json(string value) => System.Text.Json.JsonSerializer.Serialize(value);
+
+    private static string NewTempDir(string prefix)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), prefix + "_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+        catch
+        {
+            /* best-effort cleanup */
+        }
+    }
+}

--- a/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_AccumulateAndPublishTests.cs
+++ b/source/Tests.TestAdapter/Comparison/MethodComparisonBatchProcessor_AccumulateAndPublishTests.cs
@@ -10,6 +10,7 @@ using Sailfish.Analysis;
 using Sailfish.Analysis.SailDiff.Formatting;
 using Sailfish.Analysis.SailDiff.Statistics.Tests;
 using Sailfish.Contracts.Public.Models;
+using Sailfish.Contracts.Public.Notifications;
 using Sailfish.Execution;
 using Sailfish.Logging;
 using Sailfish.TestAdapter.Execution;
@@ -245,5 +246,35 @@ public class MethodComparisonBatchProcessorAccumulateAndPublishTests
         ((List<string>)a.Metadata["AccumulatedComparisons"]).Count.ShouldBe(2);
         ((List<string>)b.Metadata["AccumulatedComparisons"]).Count.ShouldBe(2);
         ((List<string>)c.Metadata["AccumulatedComparisons"]).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_WithComparisonGroup_PublishesMethodComparisonAnalysisForSkipper()
+    {
+        // Arrange — deliverable #5: a completed ComparisonGroup must feed the Skipper AI layer.
+        var sut = CreateSut();
+        _sailDiff.ComputeTestCaseDiff(default!, default!, default!, default!, default!).ReturnsForAnyArgs(CreateFakeDiff());
+        _formatter.Format(default!, default!).ReturnsForAnyArgs(new SailDiffFormattedOutput { FullOutput = "x" });
+
+        var m1 = CreateMessage("TestClass1", "BeforeMethod", "GroupX", 10.0);
+        var m2 = CreateMessage("TestClass1", "AfterMethod", "GroupX", 12.0);
+        AttachClassExecutionSummary(m1, m2);
+
+        var batch = new TestCaseBatch
+        {
+            BatchId = "Comparison_TestClass1_GroupX",
+            TestCases = new List<TestCompletionMessage> { m1, m2 },
+            Status = BatchStatus.Complete,
+            CreatedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow,
+        };
+
+        // Act
+        await sut.ProcessBatch(batch, CancellationToken.None);
+
+        // Assert — exactly one comparison notification, naming the group and carrying its pair(s).
+        await _mediator.Received(1).Publish(
+            Arg.Is<MethodComparisonAnalysisCompleteNotification>(n => n.GroupName == "GroupX" && n.Pairs.Count > 0),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/source/Tests.TestAdapter/Execution/AdapterAiAnalysisExecutionTests.cs
+++ b/source/Tests.TestAdapter/Execution/AdapterAiAnalysisExecutionTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using NSubstitute;
+using Sailfish;
+using Sailfish.Analysis.Ai;
+using Sailfish.Analysis.ScaleFish;
+using Sailfish.Contracts.Public.Models;
+using Sailfish.Execution;
+using Sailfish.Presentation;
+using Sailfish.Registration;
+using Sailfish.TestAdapter.Execution;
+using Sailfish.TestAdapter.Registrations;
+using Shouldly;
+using Tests.Common.Builders;
+using Tests.Common.Builders.ScaleFish;
+using Tests.Common.Utils;
+using Xunit;
+using IRunSettings = Sailfish.Contracts.Public.Models.IRunSettings;
+
+namespace Tests.TestAdapter.Execution;
+
+/// <summary>
+///     End-to-end coverage of the regression these changes fix: the VS Test Adapter's execution program must run
+///     ScaleFish and fire Skipper exactly like the programmatic <c>SailfishExecutor.Run</c>. Drives
+///     <see cref="ITestAdapterExecutionProgram" /> (the adapter's run-completion path) with a stubbed engine /
+///     complexity computer and a fake Skipper agent, then asserts the agent was invoked and the artifacts written.
+/// </summary>
+public class AdapterAiAnalysisExecutionTests
+{
+    [Fact]
+    public async Task AdapterRun_WithScaleFishAndAiEnabledAndTransport_FiresSkipperAndWritesArtifacts()
+    {
+        var outputDir = NewTempDir();
+        try
+        {
+            var runSettings = RunSettingsBuilder.CreateBuilder()
+                .WithScaleFish()
+                .WithAiAnalysis(new AiAnalysisSettings(useResponseCache: false))
+                .WithLocalOutputDirectory(outputDir)
+                .CreateTrackingFiles(false)
+                .DisableOverheadEstimation()
+                .Build();
+
+            var agent = FakeAgentReturning(NonEmptyReview());
+            await using var provider = BuildProvider(runSettings, agent);
+
+            await provider.GetRequiredService<ITestAdapterExecutionProgram>()
+                .Run(new List<TestCase> { ATestCase() }, CancellationToken.None);
+
+            // Skipper fired: the registered transport/agent was actually called.
+            await agent.Received().RunAsync(Arg.Any<SkipperSession>(), Arg.Any<CancellationToken>());
+
+            // Artifacts were written beside the run output (keyed by the 'scalefish' analysis kind).
+            Directory.GetFiles(outputDir, "skipper-review_*_scalefish.json").ShouldNotBeEmpty();
+            Directory.GetFiles(outputDir, "skipper-report_*_scalefish.md").ShouldNotBeEmpty();
+        }
+        finally
+        {
+            TryDelete(outputDir);
+        }
+    }
+
+    [Fact]
+    public async Task AdapterRun_WithScaleFishButNoTransport_DoesNotFireAndWritesNoArtifacts()
+    {
+        var outputDir = NewTempDir();
+        try
+        {
+            var runSettings = RunSettingsBuilder.CreateBuilder()
+                .WithScaleFish()
+                .WithAiAnalysis(new AiAnalysisSettings(useResponseCache: false))
+                .WithLocalOutputDirectory(outputDir)
+                .CreateTrackingFiles(false)
+                .DisableOverheadEstimation()
+                .Build();
+
+            // No agent registered → the core NoOpSailfishAgent default stays in place.
+            await using var provider = BuildProvider(runSettings, agent: null);
+
+            await provider.GetRequiredService<ITestAdapterExecutionProgram>()
+                .Run(new List<TestCase> { ATestCase() }, CancellationToken.None);
+
+            provider.GetRequiredService<ISailfishAgent>().ShouldBeOfType<NoOpSailfishAgent>();
+            (Directory.Exists(outputDir) ? Directory.GetFiles(outputDir, "skipper-*") : Array.Empty<string>())
+                .ShouldBeEmpty();
+        }
+        finally
+        {
+            TryDelete(outputDir);
+        }
+    }
+
+    [Fact]
+    public async Task AdapterRun_WithAiDisabled_DoesNotFireSkipperEvenWithTransport()
+    {
+        var outputDir = NewTempDir();
+        try
+        {
+            var runSettings = RunSettingsBuilder.CreateBuilder()
+                .WithScaleFish() // ScaleFish on, but AI analysis NOT enabled
+                .WithLocalOutputDirectory(outputDir)
+                .CreateTrackingFiles(false)
+                .DisableOverheadEstimation()
+                .Build();
+
+            var agent = FakeAgentReturning(NonEmptyReview());
+            await using var provider = BuildProvider(runSettings, agent);
+
+            await provider.GetRequiredService<ITestAdapterExecutionProgram>()
+                .Run(new List<TestCase> { ATestCase() }, CancellationToken.None);
+
+            await agent.DidNotReceive().RunAsync(Arg.Any<SkipperSession>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            TryDelete(outputDir);
+        }
+    }
+
+    // Builds a real AddSailfish + AddSailfishTestAdapter provider, then overrides the engine (so no real
+    // benchmarks run) and the complexity computer (so ScaleFish deterministically yields a model), plus an
+    // optional fake Skipper agent. Last registration wins, so these override the defaults.
+    private static ServiceProvider BuildProvider(IRunSettings runSettings, ISailfishAgent? agent)
+    {
+        var services = new ServiceCollection();
+        services.AddSailfish(runSettings);
+        services.AddSailfishTestAdapter(Substitute.For<IFrameworkHandle>());
+
+        var engine = Substitute.For<ITestAdapterExecutionEngine>();
+        engine.Execute(Arg.Any<List<TestCase>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<IClassExecutionSummary> { ACannedSummary() }));
+        services.AddSingleton(engine);
+
+        var computer = Substitute.For<IComplexityComputer>();
+        computer.AnalyzeComplexity(Arg.Any<List<IClassExecutionSummary>>())
+            .ReturnsForAnyArgs(new List<ScalefishClassModel> { ACannedComplexityModel() });
+        services.AddSingleton(computer);
+
+        var converter = Substitute.For<IMarkdownTableConverter>();
+        converter.ConvertScaleFishResultToMarkdown(Arg.Any<List<ScalefishClassModel>>())
+            .ReturnsForAnyArgs("## ScaleFish\nO(n)");
+        services.AddSingleton(converter);
+
+        if (agent is not null) services.AddSingleton(agent);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ISailfishAgent FakeAgentReturning(SkipperReview review)
+    {
+        var agent = Substitute.For<ISailfishAgent>();
+        agent.RunAsync(Arg.Any<SkipperSession>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(review));
+        return agent;
+    }
+
+    private static SkipperReview NonEmptyReview()
+    {
+        return new SkipperReview(
+            SkipperVerdict.Improved,
+            new[] { new Finding("Sut.Method", SkipperVerdict.Improved, "Scales linearly.", Array.Empty<string>(), 0.9) },
+            Array.Empty<ProposedAction>(),
+            "Linear scaling confirmed.",
+            "# Skipper\nLinear scaling confirmed.");
+    }
+
+    private static IClassExecutionSummary ACannedSummary()
+    {
+        var testCaseId = Some.SimpleTestCaseId();
+        var result = PerformanceRunResultBuilder.Create().WithDisplayName(testCaseId.DisplayName).Build();
+        var compiled = new CompiledTestCaseResult(testCaseId, Some.RandomString(), result);
+        return new ClassExecutionSummary(typeof(AdapterAiAnalysisExecutionTests), new ExecutionSettings(), new[] { compiled });
+    }
+
+    private static ScalefishClassModel ACannedComplexityModel()
+    {
+        var propertyModel = ScaleFishPropertyModelBuilder.Create().Build();
+        var methodModel = new ScaleFishMethodModel(Some.RandomString(), new[] { propertyModel });
+        return new ScalefishClassModel(Some.RandomString(), Some.RandomString(), new[] { methodModel });
+    }
+
+    private static TestCase ATestCase()
+    {
+        return new TestCase("Sut.Method", new Uri("executor://sailfishexecutor/v1"), "source.dll");
+    }
+
+    private static string NewTempDir()
+    {
+        return Path.Combine(Path.GetTempPath(), "sf_adapter_ai_" + Guid.NewGuid().ToString("N"));
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+        catch
+        {
+            /* best-effort cleanup */
+        }
+    }
+}

--- a/source/Tests.TestAdapter/Execution/TestExecutorAiWarningsTests.cs
+++ b/source/Tests.TestAdapter/Execution/TestExecutorAiWarningsTests.cs
@@ -1,0 +1,88 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using NSubstitute;
+using Sailfish.Analysis.Ai;
+using Sailfish.Logging;
+using Sailfish.TestAdapter;
+using Xunit;
+using IRunSettings = Sailfish.Contracts.Public.Models.IRunSettings;
+
+namespace Tests.TestAdapter.Execution;
+
+/// <summary>
+///     Covers deliverable #2: AI analysis being a silent no-op is the core UX failure. The adapter must surface
+///     a single, actionable warning when Skipper was enabled but produced nothing — either because no transport
+///     is registered or because nothing triggered it this run.
+/// </summary>
+public class TestExecutorAiWarningsTests
+{
+    [Fact]
+    public void Warns_WhenAiEnabledButNoTransportRegistered()
+    {
+        var frameworkHandle = Substitute.For<IFrameworkHandle>();
+
+        TestExecutor.WarnIfAiConfiguredButInactive(
+            BuildProvider(aiEnabled: true, new NoOpSailfishAgent(), new SkipperActivitySink()),
+            frameworkHandle);
+
+        frameworkHandle.Received().SendMessage(
+            TestMessageLevel.Warning,
+            Arg.Is<string>(s => s.Contains("AddSkipperTransport") && s.Contains("no Skipper transport is registered")));
+    }
+
+    [Fact]
+    public void Warns_WhenAiEnabledWithTransportButNothingTriggeredSkipper()
+    {
+        var frameworkHandle = Substitute.For<IFrameworkHandle>();
+        var realAgent = Substitute.For<ISailfishAgent>(); // a registered transport (not the NoOp default)
+
+        TestExecutor.WarnIfAiConfiguredButInactive(
+            BuildProvider(aiEnabled: true, realAgent, new SkipperActivitySink() /* never triggered */),
+            frameworkHandle);
+
+        frameworkHandle.Received().SendMessage(
+            TestMessageLevel.Warning,
+            Arg.Is<string>(s => s.Contains("did not fire this run") && s.Contains("scaleFish")));
+    }
+
+    [Fact]
+    public void DoesNotWarn_WhenSkipperActuallyFired()
+    {
+        var frameworkHandle = Substitute.For<IFrameworkHandle>();
+        var triggeredSink = new SkipperActivitySink();
+        triggeredSink.RecordTriggered();
+
+        TestExecutor.WarnIfAiConfiguredButInactive(
+            BuildProvider(aiEnabled: true, Substitute.For<ISailfishAgent>(), triggeredSink),
+            frameworkHandle);
+
+        frameworkHandle.DidNotReceive().SendMessage(TestMessageLevel.Warning, Arg.Any<string>());
+    }
+
+    [Fact]
+    public void DoesNotWarn_WhenAiIsDisabled()
+    {
+        var frameworkHandle = Substitute.For<IFrameworkHandle>();
+
+        TestExecutor.WarnIfAiConfiguredButInactive(
+            BuildProvider(aiEnabled: false, new NoOpSailfishAgent(), new SkipperActivitySink()),
+            frameworkHandle);
+
+        frameworkHandle.DidNotReceive().SendMessage(TestMessageLevel.Warning, Arg.Any<string>());
+    }
+
+    private static IServiceProvider BuildProvider(bool aiEnabled, ISailfishAgent agent, ISkipperActivitySink sink)
+    {
+        var runSettings = Substitute.For<IRunSettings>();
+        runSettings.RunAiAnalysis.Returns(aiEnabled);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(runSettings);
+        services.AddSingleton(agent);
+        services.AddSingleton(sink);
+        services.AddSingleton(Substitute.For<ILogger>());
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## Problem

Running benchmarks through the **VS Test Adapter** (`dotnet test` / Test Explorer / the gutter "play" button) **silently skipped ScaleFish and the Skipper AI layer**, even when fully configured (`scaleFish:true` variable, `AiAnalysisSettings.Enabled=true` in `.sailfish.json`, a registered `ISkipperTransport`). AI worked only via the programmatic `SailfishRunner.Run`. Enabling it for the adapter produced **no artifacts, no error, no log line** — the user just saw nothing.

## Root cause

`TestAdapterExecutionProgram.Run` published `TestRunCompletedNotification` and **stopped** — it never invoked the SailDiff/ScaleFish analyzers, unlike the programmatic `SailfishExecutor.Run`. `git log -S` shows those calls were commented out and dropped in `2dad5b0` (Feb 2024) and never restored. Since `AdapterScaleFish`/`AdapterSailDiff` are what publish the `ScaleFish/SailDiffAnalysisCompleteNotification`s the Skipper handlers listen for, the entire AI chain was dead on the adapter path. (Not a PR #318 regression — the analyzers were already uninvoked in its parent.)

## What changed

1. **Adapter runs ScaleFish + AI like the programmatic runner.** `TestAdapterExecutionProgram` injects `ISailDiffInternal`/`IScaleFishInternal` and, after publishing, runs both inside an error boundary mirroring `SailfishExecutor.Run`.
2. **No silent no-ops.** New per-run `ISkipperActivitySink` (marked in `SkipperAnalysisRunner`) lets `TestExecutor` emit a single actionable **warning** when AI is enabled but produced nothing: no `.sailfish.json` found, no transport registered, or no trigger fired this run (and what would).
3. **Robust `.sailfish.json` discovery.** Also searches the **test assembly's own output directory** (not just upward from cwd) and logs which file loaded (or none). Supports the `<None CopyToOutputDirectory>` convention.
4. **Opt-in run-vs-run baseline.** New `SailDiffSettings.AutoCompareToPreviousRun` (default off) resolves the most recent prior tracking file *before* the run, so "run twice → SailDiff" works under the adapter. Explicit `ProvidedBeforeTrackingFiles` still wins; the explicit-only default from #329 is unchanged.
5. **ComparisonGroup → Skipper.** A completed in-run method-comparison group publishes a new `MethodComparisonAnalysisCompleteNotification`; a new `SkipperMethodComparisonAnalysisHandler` builds a comparison context (`BuildComparison`) and runs Skipper (artifact kind `comparison-<group>`).

## Decisions

- **#4** was implemented as an **opt-in flag** rather than a silent auto-pick, to honor PR #329's deliberate "historical comparison is explicit-only" decision.
- **#5** ComparisonGroup→Skipper is **adapter-only** (it's an adapter feature); the programmatic `[WriteToMarkdown]` comparison path still doesn't feed Skipper — documented in the Skipper page.

## Testing

- **Tests.TestAdapter 183/183**, **Tests.Library 1684/1684** — green on **net9.0 + net10.0**; full solution builds with no new warnings.
- **+13 adapter tests, +4 core tests.** The headline test (`AdapterAiAnalysisExecutionTests`) drives `TestAdapterExecutionProgram.Run` with a ScaleFish setup + a fake transport and asserts Skipper fires and the `skipper-review_*_scalefish.json` / `skipper-report_*_scalefish.md` artifacts are written.
- A live `dotnet test` against `PerformanceTests` was deliberately not run: its `ScaleFishExample` is minutes of real `Task.Delay`s plus a non-deterministic live `claude` CLI call — exactly what the deterministic adapter tests replace.

Docs: corrected `skipper.md` (its "run-twice auto-compares" claim was stale post-#329) and added a RELEASE_NOTES entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `AutoCompareToPreviousRun` setting to automatically compare current run against the most recent prior baseline
  * Enabled AI analysis for method comparison results with generated markdown summaries
  * Improved settings discovery to search from test assembly location

* **Improvements**
  * Enhanced configuration warnings when settings file not found or AI analysis configured but inactive
  * Better fallback handling for missing configuration files with informative messaging

* **Tests**
  * Added comprehensive test coverage for AI analysis features and settings discovery scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->